### PR TITLE
fix the text for other performance measures

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
@@ -344,11 +344,16 @@ const useAgeGroupsCheckboxes: CheckBoxBuilder = (name) => {
         value: cleanedLabel,
         displayValue: labelText[value] ?? value,
         children: [
-          <CUI.Heading key={`${name}.rates.${cleanedLabel}Header`} size={"sm"}>
-            {customPrompt ??
-              `Enter a number for the numerator and the denominator. Rate will
-            auto-calculate:`}
-          </CUI.Heading>,
+          <CUI.Heading
+            key={`${name}.rates.${cleanedLabel}Header`}
+            size={"sm"}
+            dangerouslySetInnerHTML={{
+              __html:
+                customPrompt ??
+                `Enter a number for the numerator and the denominator. Rate will
+            auto-calculate:`,
+            }}
+          />,
           <CUI.Heading
             pt="1"
             key={`${name}.rates.${cleanedLabel}HeaderHelper`}
@@ -525,11 +530,13 @@ const useRenderOPMCheckboxOptions = (name: string) => {
           <CUI.Heading
             key={`${name}.rates.${cleanedFieldName}Header`}
             size={"sm"}
-          >
-            {customPrompt ??
-              `Enter a number for the numerator and the denominator. Rate will
-            auto-calculate:`}
-          </CUI.Heading>,
+            dangerouslySetInnerHTML={{
+              __html:
+                customPrompt ??
+                `Enter a number for the numerator and the denominator. Rate will
+              auto-calculate:`,
+            }}
+          />,
           <CUI.Heading
             pt="1"
             size={"sm"}

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
@@ -89,12 +89,14 @@ export const OtherPerformanceMeasure = ({
               <CUI.Text
                 fontWeight="bold"
                 mt={5}
+                dangerouslySetInnerHTML={{
+                  __html:
+                    data.customPrompt ??
+                    `Enter a number for the numerator and the denominator. Rate will
+                  auto-calculate:`,
+                }}
                 data-cy="Enter a number for the numerator and the denominator"
-              >
-                {data.customPrompt ??
-                  `Enter a number for the numerator and the denominator. Rate will
-        auto-calculate:`}
-              </CUI.Text>
+              ></CUI.Text>
               {(dataSourceWatch?.[0] !== "AdministrativeData" ||
                 dataSourceWatch?.length !== 1) && (
                 <CUI.Heading pt="5" size={"sm"}>


### PR DESCRIPTION
## Summary
This is the same fix as before, to get a line break for the formula. This was overlooked in my last PR.
### Description


### How to test
Go to AAB-AD and get the other performance measures to show up. You'll see that the string has a line break and not a literal `<br>` tag in the browser.

> 
>  "Enter a number for the numerator and the denominator. The measure is reported as an inverted rate. 
> <br/> The formula for the Rate = (1 - (Numerator/Denominator)) x 100"

Test the same thing inside the Optional Measure Strat section as well 


### Important updates
<!-- Any changed dependencies, .env files, local configs, etc. and
instructions for other engineers, e.g. requires new installs in directories -->

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
