### PR TITLE
add inline validation for YYYY

### DIFF
--- a/services/ui-src/src/components/DateRange/index.test.tsx
+++ b/services/ui-src/src/components/DateRange/index.test.tsx
@@ -1,5 +1,6 @@
 import { DateRange } from ".";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
+import userEvent from "@testing-library/user-event";
 
 describe("Test DateRange", () => {
   test("Check DateRange Renders", () => {
@@ -13,5 +14,18 @@ describe("Test DateRange", () => {
 
     expect(screen.getAllByLabelText(/month/i)[0]).toBeInTheDocument();
     expect(screen.getAllByLabelText(/year/i)[0]).toBeInTheDocument();
+  });
+
+  test("Check that a year with incorrect format will throw an error", () => {
+    const screen = renderWithHookForm(<DateRange name="testComponent" />);
+
+    const monthLabel = screen.getAllByLabelText(/month/i)[0];
+    const yearLabel = screen.getAllByLabelText(/year/i)[0];
+    userEvent.type(monthLabel, "01");
+    userEvent.type(yearLabel, "202");
+    const errorMessage = screen.getByText(
+      "Please enter start date year in YYYY-format"
+    );
+    expect(errorMessage).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/DateRange/index.test.tsx
+++ b/services/ui-src/src/components/DateRange/index.test.tsx
@@ -28,4 +28,16 @@ describe("Test DateRange", () => {
     );
     expect(errorMessage).toBeInTheDocument();
   });
+
+  test("Check that error disapears when user inputs correct date", () => {
+    const screen = renderWithHookForm(<DateRange name="testComponent" />);
+
+    const monthLabel = screen.getAllByLabelText(/month/i)[0];
+    const yearLabel = screen.getAllByLabelText(/year/i)[0];
+    userEvent.type(monthLabel, "01");
+    userEvent.type(yearLabel, "2022");
+    expect(
+      screen.queryByText("Please enter start date year in YYYY-format")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/services/ui-src/src/components/DateRange/index.test.tsx
+++ b/services/ui-src/src/components/DateRange/index.test.tsx
@@ -40,4 +40,43 @@ describe("Test DateRange", () => {
       screen.queryByText("Please enter start date year in YYYY-format")
     ).not.toBeInTheDocument();
   });
+
+  test("Check that error appears when user inputs a start date after the end date", () => {
+    const screen = renderWithHookForm(<DateRange name="testComponent" />);
+
+    const startMonthLabel = screen.getAllByLabelText(/month/i)[0];
+    const yearLabel = screen.getAllByLabelText(/year/i)[0];
+    const endMonthLabel = screen.getAllByLabelText(/month/i)[1];
+    const endYearLabel = screen.getAllByLabelText(/year/i)[1];
+    userEvent.type(startMonthLabel, "01");
+    userEvent.type(yearLabel, "2023");
+    userEvent.type(endMonthLabel, "02");
+    userEvent.type(endYearLabel, "2022");
+    expect(
+      screen.queryByText("Start Date must be before the End Date")
+    ).toBeInTheDocument();
+  });
+
+  test("Check that error appears when start date is a date in the future", () => {
+    const screen = renderWithHookForm(<DateRange name="testComponent" />);
+    const startMonthLabel = screen.getAllByLabelText(/month/i)[0];
+    const yearLabel = screen.getAllByLabelText(/year/i)[0];
+    userEvent.type(startMonthLabel, "01");
+    userEvent.type(yearLabel, "2080");
+    expect(
+      screen.queryByText("Start date cannot be a future date")
+    ).toBeInTheDocument();
+  });
+
+  test("Check that error appears when end date is a date in the future", () => {
+    const screen = renderWithHookForm(<DateRange name="testComponent" />);
+
+    const endMonthLabel = screen.getAllByLabelText(/month/i)[1];
+    const endYearLabel = screen.getAllByLabelText(/year/i)[1];
+    userEvent.type(endMonthLabel, "02");
+    userEvent.type(endYearLabel, "2080");
+    expect(
+      screen.queryByText("End date cannot be a future date")
+    ).toBeInTheDocument();
+  });
 });

--- a/services/ui-src/src/components/DateRange/index.tsx
+++ b/services/ui-src/src/components/DateRange/index.tsx
@@ -4,7 +4,6 @@ import { MonthPicker } from "components/MonthPicker";
 import { useFormContext } from "react-hook-form";
 import { format } from "date-fns";
 import { useEffect } from "react";
-
 interface Props {
   name: string;
   initStartMonth?: string;
@@ -66,6 +65,20 @@ export const DateRangeError = ({ name }: { name: string }) => {
     (endMonth > currentMonth && endYear === currentYear)
   ) {
     return <RangeNotification text="End date cannot be a future date" />;
+  }
+
+  /* If start date is not in correct YYYY format */
+  if (!!startYear && startYear.toString().length !== 4) {
+    return (
+      <RangeNotification text="Please enter start date year in YYYY-format" />
+    );
+  }
+
+  /* If end date is not in correct YYYY format */
+  if (!!endYear && endYear.toString().length !== 4) {
+    return (
+      <RangeNotification text="Please enter end date year in YYYY-format" />
+    );
   }
 
   return null;


### PR DESCRIPTION
## Summary
adds inline validation for `YYYY` format in start and end date

### Description
When a user clicks the `validate` button at the bottom, they are informed of any errors. This PR adds inline validation so they are notified of the `YYYY` format error before getting all the way to the end of the page.

### Related ticket
[jira](https://qmacbis.atlassian.net/jira/software/c/projects/MDCT/boards/232?modal=detail&selectedIssue=MDCT-2245)

### How to test
<!-- Step-by-step instructions on how to test -->
Go to 2023, choose any of the measures, see that there is now inline validation after you start typing the year or start and end date.

### Important updates
<!-- Any changed dependencies, .env files, local configs, etc. and
instructions for other engineers, e.g. requires new installs in directories -->

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
