### PR TITLE
covid related description box hidden behind flag

### DIFF
--- a/services/ui-src/src/measures/2021/CommonQuestions/PerformanceMeasure/index.test.tsx
+++ b/services/ui-src/src/measures/2021/CommonQuestions/PerformanceMeasure/index.test.tsx
@@ -50,7 +50,7 @@ describe("Test the PerformanceMeasure RateComponent prop", () => {
         exampleData.categories!.length
       );
     for (const label of exampleData.categories!)
-      expect(screen.getByText(label)).toBeVisible;
+      expect(screen.getByText(label)).toBeVisible();
 
     const numeratorTextBox = screen.queryAllByLabelText("Numerator")[0];
     const denominatorTextBox = screen.queryAllByLabelText("Denominator")[0];

--- a/services/ui-src/src/measures/2022/SSHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2022/SSHH/questions/PerformanceMeasure.tsx
@@ -5,6 +5,7 @@ import * as DC from "dataConstants";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "measures/2022/shared/CommonQuestions/types";
 import { useEffect } from "react";
+import { useFlags } from "launchdarkly-react-client-sdk";
 
 interface Props {
   hybridMeasure?: boolean;
@@ -29,6 +30,7 @@ export const PerformanceMeasure = ({
   rateAlwaysEditable,
 }: Props) => {
   const { control, reset } = useFormContext();
+  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2023"];
 
   const { fields, remove, append } = useFieldArray({
     name: DC.OPM_RATES,
@@ -83,11 +85,13 @@ export const PerformanceMeasure = ({
             voluntary, CMS encourages states that can collect information safely
             to continue reporting the measures they have reported in the past.
           </CUI.Text>
-          <QMR.TextArea
-            formLabelProps={{ mt: 5 }}
-            {...register(DC.OPM_HYBRID_EXPLANATION)}
-            label="Describe any COVID-related difficulties encountered while collecting this data:"
-          />
+          {pheIsCurrent && (
+            <QMR.TextArea
+              formLabelProps={{ mt: 5 }}
+              {...register(DC.OPM_HYBRID_EXPLANATION)}
+              label="Describe any COVID-related difficulties encountered while collecting this data:"
+            />
+          )}
         </CUI.Box>
       )}
 

--- a/services/ui-src/src/measures/2022/SSHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2022/SSHH/questions/PerformanceMeasure.tsx
@@ -5,7 +5,6 @@ import * as DC from "dataConstants";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "measures/2022/shared/CommonQuestions/types";
 import { useEffect } from "react";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 interface Props {
   hybridMeasure?: boolean;
@@ -30,7 +29,6 @@ export const PerformanceMeasure = ({
   rateAlwaysEditable,
 }: Props) => {
   const { control, reset } = useFormContext();
-  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2023"];
 
   const { fields, remove, append } = useFieldArray({
     name: DC.OPM_RATES,
@@ -85,13 +83,11 @@ export const PerformanceMeasure = ({
             voluntary, CMS encourages states that can collect information safely
             to continue reporting the measures they have reported in the past.
           </CUI.Text>
-          {pheIsCurrent && (
-            <QMR.TextArea
-              formLabelProps={{ mt: 5 }}
-              {...register(DC.OPM_HYBRID_EXPLANATION)}
-              label="Describe any COVID-related difficulties encountered while collecting this data:"
-            />
-          )}
+          <QMR.TextArea
+            formLabelProps={{ mt: 5 }}
+            {...register(DC.OPM_HYBRID_EXPLANATION)}
+            label="Describe any COVID-related difficulties encountered while collecting this data:"
+          />
         </CUI.Box>
       )}
 

--- a/services/ui-src/src/measures/2023/SSHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/SSHH/index.test.tsx
@@ -1,0 +1,168 @@
+import { screen, waitFor, act } from "@testing-library/react";
+import { createElement } from "react";
+import { RouterWrappedComp } from "utils/testing";
+import { MeasureWrapper } from "components/MeasureWrapper";
+import { useApiMock } from "utils/testUtils/useApiMock";
+import { useUser } from "hooks/authHooks";
+import Measures from "measures";
+import { Suspense } from "react";
+import { MeasuresLoading } from "views";
+import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { mockLDFlags } from "../../../../setupJest";
+import { clearMocks } from "../shared/util/validationsMock";
+
+expect.extend(toHaveNoViolations);
+
+mockLDFlags.setDefault({ periodOfHealthEmergency2023: false });
+
+// Test Setup
+const measureAbbr = "SS-1-HH";
+const coreSet = "HHCS";
+const state = "CT";
+const year = 2023;
+const description = "test";
+const apiData: any = {};
+
+jest.mock("hooks/authHooks");
+const mockUseUser = useUser as jest.Mock;
+
+describe(`Test FFY ${year} ${measureAbbr}`, () => {
+  let component: JSX.Element;
+  beforeEach(() => {
+    clearMocks();
+    apiData.useGetMeasureValues = {
+      data: {
+        Item: {
+          compoundKey: `${state}${year}${coreSet}${measureAbbr}`,
+          coreSet,
+          createdAt: 1642517935305,
+          description,
+          lastAltered: 1642517935305,
+          lastAlteredBy: "undefined",
+          measure: measureAbbr,
+          state,
+          status: "incomplete",
+          year,
+          data: {},
+        },
+      },
+      isLoading: false,
+      refetch: jest.fn(),
+      isError: false,
+      error: undefined,
+    };
+
+    mockUseUser.mockImplementation(() => {
+      return { isStateUser: false };
+    });
+
+    const measure = createElement(Measures[year][measureAbbr]);
+    component = (
+      <Suspense fallback={MeasuresLoading()}>
+        <RouterWrappedComp>
+          <MeasureWrapper
+            measure={measure}
+            year={`${year}`}
+            name={description}
+            measureId={measureAbbr}
+          />
+        </RouterWrappedComp>
+      </Suspense>
+    );
+  });
+
+  it("SS-1-HH measure should render", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("measure-wrapper-form")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(measureAbbr + " - " + description));
+    });
+  });
+
+  it("Always shows What is the status of the data being reported? question", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    const firstQuestion = screen.getByText(
+      "What is the status of the data being reported?"
+    );
+    expect(firstQuestion).toBeVisible();
+  });
+
+  it("shows corresponding questions if yes to reporting then ", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByText("Status of Data Reported")).toBeInTheDocument();
+    expect(screen.queryByText("Data Source")).toBeInTheDocument();
+    expect(screen.queryByText("Date Range")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Definition of Population Included in the Measure")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Performance Measure")).toBeInTheDocument();
+  });
+
+  it("does not show covid text if periodOfHealthEmergency2023 flag is disabled", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(
+      screen.queryByText(
+        "Describe any COVID-related difficulties encountered while collecting this data:"
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows covid text if periodOfHealthEmergency2023 flag is enabled", async () => {
+    mockLDFlags.setDefault({ periodOfHealthEmergency2023: true });
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(
+      screen.queryByText(
+        "Describe any COVID-related difficulties encountered while collecting this data:"
+      )
+    ).toBeInTheDocument();
+  });
+
+  jest.setTimeout(15000);
+  it("should pass a11y tests", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    await act(async () => {
+      const results = await axe(screen.getByTestId("measure-wrapper-form"));
+      expect(results).toHaveNoViolations();
+    });
+  });
+});
+
+const completedMeasureData = {
+  PerformanceMeasure: {
+    rates: {
+      singleCategory: [
+        {
+          label: "Ages 19 to 50",
+          rate: "100.0",
+          numerator: "55",
+          denominator: "55",
+        },
+        {
+          label: "Ages 51 to 64",
+          rate: "100.0",
+          numerator: "55",
+          denominator: "55",
+        },
+        {
+          label: "Total",
+          isTotal: true,
+          rate: "100.0",
+          numerator: "110",
+          denominator: "110",
+        },
+      ],
+    },
+  },
+  MeasurementSpecification: "NCQA/HEDIS",
+  DidReport: "yes",
+};

--- a/services/ui-src/src/measures/2023/SSHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2023/SSHH/questions/PerformanceMeasure.tsx
@@ -5,6 +5,7 @@ import * as DC from "dataConstants";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "measures/2023/shared/CommonQuestions/types";
 import { useEffect } from "react";
+import { useFlags } from "launchdarkly-react-client-sdk";
 
 interface Props {
   hybridMeasure?: boolean;
@@ -29,6 +30,8 @@ export const PerformanceMeasure = ({
   rateAlwaysEditable,
 }: Props) => {
   const { control, reset } = useFormContext();
+
+  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2023"];
 
   const { fields, remove, append } = useFieldArray({
     name: DC.OPM_RATES,
@@ -83,11 +86,13 @@ export const PerformanceMeasure = ({
             voluntary, CMS encourages states that can collect information safely
             to continue reporting the measures they have reported in the past.
           </CUI.Text>
-          <QMR.TextArea
-            formLabelProps={{ mt: 5 }}
-            {...register(DC.OPM_HYBRID_EXPLANATION)}
-            label="Describe any COVID-related difficulties encountered while collecting this data:"
-          />
+          {pheIsCurrent && (
+            <QMR.TextArea
+              formLabelProps={{ mt: 5 }}
+              {...register(DC.OPM_HYBRID_EXPLANATION)}
+              label="Describe any COVID-related difficulties encountered while collecting this data:"
+            />
+          )}
         </CUI.Box>
       )}
 

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.test.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.test.tsx
@@ -3,26 +3,38 @@ import {
   PerformanceMeasureData,
 } from "measures/2023/shared/CommonQuestions/PerformanceMeasure/data";
 import { data as PCRData } from "measures/2023/PCRAD/data";
+import { data as CBPdata } from "measures/2023/CBPAD/data";
 import fireEvent from "@testing-library/user-event";
 import { PerformanceMeasure } from ".";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { screen } from "@testing-library/react";
 import { PCRRate } from "components";
+import { mockLDFlags } from "../../../../../../setupJest";
 
 interface Props {
   component?: RateComp | undefined;
   calcTotal: boolean;
   data: PerformanceMeasureData;
   rateReadOnly: undefined | boolean;
+  hybridMeasure: undefined | boolean;
 }
 
-const renderComponet = ({ component, calcTotal, data, rateReadOnly }: Props) =>
+mockLDFlags.setDefault({ periodOfHealthEmergency2023: false });
+
+const renderComponet = ({
+  component,
+  calcTotal,
+  data,
+  rateReadOnly,
+  hybridMeasure,
+}: Props) =>
   renderWithHookForm(
     <PerformanceMeasure
       data={data}
       calcTotal={calcTotal}
       RateComponent={component}
       rateReadOnly={rateReadOnly}
+      hybridMeasure={hybridMeasure}
     />
   );
 
@@ -35,6 +47,7 @@ describe("Test the PerformanceMeasure RateComponent prop", () => {
       calcTotal: false,
       data: exampleData,
       rateReadOnly: undefined,
+      hybridMeasure: undefined,
     };
   });
 
@@ -160,5 +173,26 @@ describe("Test the PerformanceMeasure RateComponent prop", () => {
     expect(denominatorTextBox).toHaveDisplayValue("123");
     expect(rateTextBox?.textContent).toEqual("100.0000");
     expect(rateTextBox?.nodeName).toBe("P");
+  });
+
+  test("periodOfHealthEmergency2023 flag is set to false, covid text and textbox should not render", () => {
+    props.data = CBPdata;
+    props.hybridMeasure = true;
+    renderComponet(props);
+    const covidText = screen.queryByLabelText(
+      "Describe any COVID-related difficulties encountered while collecting this data:"
+    );
+    expect(covidText).toBeNull();
+  });
+
+  test("periodOfHealthEmergency2023 flag is set to true, covid text and textbox should render", () => {
+    mockLDFlags.set({ periodOfHealthEmergency2023: true });
+    props.data = CBPdata;
+    props.hybridMeasure = true;
+    renderComponet(props);
+    const covidText = screen.getByLabelText(
+      "Describe any COVID-related difficulties encountered while collecting this data:"
+    );
+    expect(covidText).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -7,6 +7,7 @@ import { PerformanceMeasureData } from "./data";
 import { useWatch } from "react-hook-form";
 import { cleanString, getLabelText } from "utils";
 import { ndrFormula } from "types";
+import { useFlags } from "launchdarkly-react-client-sdk";
 
 interface Props {
   data: PerformanceMeasureData;
@@ -199,6 +200,7 @@ export const PerformanceMeasure = ({
   RateComponent = QMR.Rate, // Default to QMR.Rate
 }: Props) => {
   const register = useCustomRegister<Types.PerformanceMeasure>();
+  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2023"];
   const dataSourceWatch = useWatch<Types.DataSource>({
     name: DC.DATA_SOURCE,
   }) as string[] | string | undefined;
@@ -275,11 +277,13 @@ export const PerformanceMeasure = ({
             voluntary, CMS encourages states that can collect information safely
             to continue reporting the measures they have reported in the past.
           </CUI.Text>
-          <QMR.TextArea
-            formLabelProps={{ mt: 5 }}
-            {...register("PerformanceMeasure.hybridExplanation")}
-            label="Describe any COVID-related difficulties encountered while collecting this data:"
-          />
+          {pheIsCurrent && (
+            <QMR.TextArea
+              formLabelProps={{ mt: 5 }}
+              {...register("PerformanceMeasure.hybridExplanation")}
+              label="Describe any COVID-related difficulties encountered while collecting this data:"
+            />
+          )}
         </CUI.Box>
       )}
       <CUI.Text


### PR DESCRIPTION
## Summary
2023 measures have the text and text box hidden by the flag `periodOfHealthEmergency2023`.

### Description
In 2023, the text `Describe any COVID-related difficulties encountered while collecting this data:` and textbox are hidden behind a flag.

### Related ticket
[jira](https://qmacbis.atlassian.net/jira/software/c/projects/MDCT/boards/232?modal=detail&selectedIssue=MDCT-2248)

### How to test
Measure CPB-AD has this text and text box. Go to this measure in 2021 or 2022, fill out all the fields and you will see the text and text box show up in Performance Measures. If you go into 2023's CPB-AD, you will not.

### Important updates
<!-- Any changed dependencies, .env files, local configs, etc. and
instructions for other engineers, e.g. requires new installs in directories -->

### Author checklist
<!-- Complete the following before marking ready for review -->
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
