### PR TITLE
[MDCT–2340] Complete Measure when Invalid - Save correct data

### DIFF
--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -354,9 +354,9 @@ export const MeasureWrapper = ({
 
   const handleValidationModalResponse = (continueWithErrors: boolean) => {
     setShowModal(false);
+    if (!continueWithErrors) return;
 
-    if (continueWithErrors) {
-      const data = methods.getValues();
+    const manualSubmit = (data: any) => {
       submitDataToServer({
         data,
         reporting: handleReportingResponse(data),
@@ -365,7 +365,8 @@ export const MeasureWrapper = ({
         },
       });
       setErrors(undefined);
-    }
+    };
+    methods.handleSubmit(manualSubmit)();
   };
 
   if (!params.coreSetId || !params.state) {


### PR DESCRIPTION
### Description
Fix the Measure Wrapper "Complete Measure" functionality to submit the most recent data, rather than all preset data chunks.

When an invalid measure is manually set to "Complete" by clicking through the modal, a bad state could be sent alongside the request. Moved it to allow the form itself to handle the submission after validation. See testing instructions for more details.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2340

---
### How to test
The previous bad state could be triggered as followed:
* Pick a measure with nested items. The child measure WCC-CH, for example.
* Begin populating the measure, but leave some part, like the date fields incomplete to trigger validation warnings (important for the next part)
* In the Data sources, fill some root and nested fields
* Click Save. The database should reflect a populated DataSource, and DataSourceSelections.
* Uncheck the root levels, complete measure, and when the modal pops up, select yes.
* All the DataSource and DataSourceSelections will be cleared!

Before this update, the DataSourceSelections would remain populated.
The original request also found this happening when a measure is set not to reporting, nested options for reasons for not reporting could get out of sync.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
