### PR TITLE
fix radio button bug

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
@@ -3,7 +3,7 @@ import * as CUI from "@chakra-ui/react";
 import * as DC from "dataConstants";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "../types";
-import React, { useEffect } from "react";
+import React from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { DataDrivenTypes } from "../types";
 
@@ -42,7 +42,7 @@ export const OtherPerformanceMeasure = ({
   const register = useCustomRegister<Types.OtherPerformanceMeasure>();
   const { getValues } = useFormContext<Types.OtherPerformanceMeasure>();
   const savedRates = getValues(DC.OPM_RATES);
-  const { control, reset } = useFormContext();
+  const { control } = useFormContext();
   const [showRates, setRates] = React.useState<Types.OtherRatesFields[]>(
     savedRates ?? [
       {
@@ -52,24 +52,11 @@ export const OtherPerformanceMeasure = ({
     ]
   );
 
-  const { fields, remove } = useFieldArray({
+  const { remove } = useFieldArray({
     name: DC.OPM_RATES,
     control,
     shouldUnregister: true,
   });
-
-  useEffect(() => {
-    if (fields.length === 0) {
-      reset({
-        name: DC.OPM_RATES,
-        [DC.OPM_RATES]: [
-          {
-            [DC.DESCRIPTION]: "",
-          },
-        ],
-      });
-    }
-  }, [fields, reset]);
 
   // ! Waiting for data source refactor to type data source here
   const { watch } = useFormContext<Types.DataSource>();


### PR DESCRIPTION
### Description
In `Measure Specifications` the 'Other' radio button was not functioning as expected when clicked. This was due to a `useEffect` that was messing up the life cycle. 


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2338

---
### How to test
Go to any of the measures in 2023, go down to `Measure Specifications` and select the radio button with the text `Other` (don't select the radio button above it. See that it expands to show a text box and an area to upload documents.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
