### PR TITLE
Ndr changes

### DIFF
--- a/services/ui-src/src/measures/2023/CCPAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCPAD/index.test.tsx
@@ -244,7 +244,7 @@ const completedMeasureData = {
           denominator: "55",
         },
         {
-          label: "Sixty Days Postpartum Rate",
+          label: "Ninety Days Postpartum Rate",
         },
       ],
     },

--- a/services/ui-src/src/measures/2023/rateLabelText.ts
+++ b/services/ui-src/src/measures/2023/rateLabelText.ts
@@ -307,9 +307,9 @@ export const data = {
                 "id": "ThreeDaysPostpartumRate"
             },
             {
-                "label": "Sixty Days Postpartum Rate",
-                "text": "Sixty Days Postpartum Rate",
-                "id": "SixtyDaysPostpartumRate"
+                "label": "Ninety Days Postpartum Rate",
+                "text": "Ninety Days Postpartum Rate",
+                "id": "NinetyDaysPostpartumRate"
             }
         ],
         "categories": [
@@ -926,44 +926,44 @@ export const data = {
         ],
         "categories": [
             {
-                "label": "Initiation of AOD Treatment: Alcohol Abuse or Dependence",
-                "text": "Initiation of AOD Treatment: Alcohol Abuse or Dependence",
-                "id": "InitiationofAODTreatmentAlcoholAbuseorDependence"
+                "label": "Initiation of SUD Treatment: Alcohol Use Disorder",
+                "text": "Initiation of SUD Treatment: Alcohol Use Disorder",
+                "id": "InitiationofSUDTreatmentAlcoholUseDisorder"
             },
             {
-                "label": "Engagement of AOD Treatment: Alcohol Abuse or Dependence",
-                "text": "Engagement of AOD Treatment: Alcohol Abuse or Dependence",
-                "id": "EngagementofAODTreatmentAlcoholAbuseorDependence"
+                "label": "Engagement of SUD Treatment: Alcohol Use Disorder",
+                "text": "Engagement of SUD Treatment: Alcohol Use Disorder",
+                "id": "EngagementofSUDTreatmentAlcoholUseDisorder"
             },
             {
-                "label": "Initiation of AOD Treatment: Opioid Abuse or Dependence",
-                "text": "Initiation of AOD Treatment: Opioid Abuse or Dependence",
-                "id": "InitiationofAODTreatmentOpioidAbuseorDependence"
+                "label": "Initiation of SUD Treatment: Opioid Use Disorder",
+                "text": "Initiation of SUD Treatment: Opioid Use Disorder",
+                "id": "InitiationofSUDTreatmentOpioidUseDisorder"
             },
             {
-                "label": "Engagement of AOD Treatment: Opioid Abuse or Dependence",
-                "text": "Engagement of AOD Treatment: Opioid Abuse or Dependence",
-                "id": "EngagementofAODTreatmentOpioidAbuseorDependence"
+                "label": "Engagement of SUD Treatment: Opioid Use Disorder",
+                "text": "Engagement of SUD Treatment: Opioid Use Disorder",
+                "id": "EngagementofSUDTreatmentOpioidUseDisorder"
             },
             {
-                "label": "Initiation of AOD Treatment: Other Drug Abuse or Dependence",
-                "text": "Initiation of AOD Treatment: Other Drug Abuse or Dependence",
-                "id": "InitiationofAODTreatmentOtherDrugAbuseorDependence"
+                "label": "Initiation of SUD Treatment: Other Substance Use Disorder",
+                "text": "Initiation of SUD Treatment: Other Substance Use Disorder",
+                "id": "InitiationofSUDTreatmentOtherDrugAbuseorDependence"
             },
             {
-                "label": "Engagement of AOD Treatment: Other Drug Abuse or Dependence",
-                "text": "Engagement of AOD Treatment: Other Drug Abuse or Dependence",
-                "id": "EngagementofAODTreatmentOtherDrugAbuseorDependence"
+                "label": "Engagement of SUD Treatment: Other Substance Use Disorder",
+                "text": "Engagement of SUD Treatment: Other Substance Use Disorder",
+                "id": "EngagementofSUDTreatmentOtherSubstanceUseDisorder"
             },
             {
-                "label": "Initiation of AOD Treatment: Total AOD Abuse or Dependence",
-                "text": "Initiation of AOD Treatment: Total AOD Abuse or Dependence",
-                "id": "InitiationofAODTreatmentTotalAODAbuseorDependence"
+                "label": "Initiation of SUD Treatment: Total",
+                "text": "Initiation of SUD Treatment: Total",
+                "id": "InitiationofSUDTreatmentTotal"
             },
             {
-                "label": "Engagement of AOD Treatment: Total AOD Abuse or Dependence",
-                "text": "Engagement of AOD Treatment: Total AOD Abuse or Dependence",
-                "id": "EngagementofAODTreatmentTotalAODAbuseorDependence"
+                "label": "Engagement of SUD Treatment: Total",
+                "text": "Engagement of SUD Treatment: Total",
+                "id": "EngagementofSUDTreatmentTotal"
             }
         ]
     },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Added / Updated N/D/R for the current measures :  
- CCP-AD
- IET-AD

Not updated here
- COL-AD : ignore, was completed in a separate ticket
- HBD-AD: updates will be made in HPC-AD-2023-Update branch due to abbr not existing currently.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2359

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign in and select Reporting Year to 2023
2) Select Adult Core Set Measures
3) Open CCP-AD
4) Fill in answers until N/D/R fields popup (Selecting the first answer for the first 3 questions should do the trick)
5) Confirm that it says **Ninety** Days Postpartum Rate instead of Sixty Days Postpartum Rate

For IET-AD
6) Repeat for steps 1-4 for IET-AD measures
7) Refer to page 3-5 pdf on ticket for text changes


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
