### PR TITLE
Update HEDIS options for 2023

### DIFF
--- a/services/ui-src/src/dataConstants.ts
+++ b/services/ui-src/src/dataConstants.ts
@@ -109,6 +109,7 @@ export const HEDIS_2019 = "HEDIS 2019";
 export const HEDIS_2020 = "HEDIS 2020";
 export const HEDIS_MY_2020 = "HEDIS MY 2020";
 export const HEDIS_MY_2021 = "HEDIS MY 2021";
+export const HEDIS_MY_2022 = "HEDIS MY 2022";
 export const HRSA = "HRSA";
 export const HYBRID_ADMINSTRATIVE_AND_MEDICAL_RECORDS_DATA =
   "HybridAdministrativeandMedicalRecordsData";

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/MeasurementSpecification/index.test.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/MeasurementSpecification/index.test.tsx
@@ -117,19 +117,6 @@ describe("all specification types", () => {
       expect(
         screen.getByText(specifications[spec].displayValue)
       ).toBeInTheDocument();
-
-      if (spec === "HEDIS") {
-        const radio = await screen.getByLabelText(
-          "National Committee for Quality Assurance (NCQA)/Healthcare Effectiveness Data and Information Set (HEDIS)"
-        );
-        fireEvent.click(radio);
-
-        expect(
-          screen.getByText(
-            "NCQA, the measure steward, changed its naming convention. HEDIS MY 2020 refers to a different federal fiscal year (FFY) than HEDIS 2020. Please note the FFY Core Set specification below."
-          )
-        ).toBeInTheDocument();
-      }
     });
   }
 });

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/MeasurementSpecification/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/MeasurementSpecification/index.tsx
@@ -9,11 +9,6 @@ const HEDISChildren = () => {
 
   return (
     <>
-      <CUI.Text key="measureSpecDescriptor" size="sm" pb="3">
-        NCQA, the measure steward, changed its naming convention. HEDIS MY 2020
-        refers to a different federal fiscal year (FFY) than HEDIS 2020. Please
-        note the FFY Core Set specification below.
-      </CUI.Text>
       <QMR.Select
         {...register(DC.MEASUREMENT_SPECIFICATION_HEDIS)}
         label="Specify the version of HEDIS measurement year used:"

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/MeasurementSpecification/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/MeasurementSpecification/index.tsx
@@ -20,16 +20,16 @@ const HEDISChildren = () => {
         placeholder="Select option"
         options={[
           {
+            displayValue: "HEDIS MY 2022 (FFY 2023 Core Set Reporting)",
+            value: DC.HEDIS_MY_2022,
+          },
+          {
             displayValue: "HEDIS MY 2021 (FFY 2022 Core Set Reporting)",
             value: DC.HEDIS_MY_2021,
           },
           {
             displayValue: "HEDIS MY 2020 (FFY 2021 Core Set Reporting)",
             value: DC.HEDIS_MY_2020,
-          },
-          {
-            displayValue: "HEDIS 2020 (FFY 2020 Core Set Reporting)",
-            value: DC.HEDIS_2020,
           },
         ]}
       />

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/types.ts
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/types.ts
@@ -15,7 +15,7 @@ export interface MeasurementSpecification {
     | typeof DC.HRSA
     | typeof DC.PQA;
   [DC.MEASUREMENT_SPECIFICATION_HEDIS]: // if Measure Spec is NCQA/HEDIS -> which version are they using
-  typeof DC.HEDIS_MY_2021 | typeof DC.HEDIS_MY_2020 | typeof DC.HEDIS_2020;
+  typeof DC.HEDIS_MY_2022 | typeof DC.HEDIS_MY_2021 | typeof DC.HEDIS_MY_2020;
   [DC.MEASUREMENT_SPEC_OMS_DESCRIPTION]: string; // If user selects OTHER in MEASUREMENT_SPECIFICATION -> this is the description
   [DC.MEASUREMENT_SPEC_OMS_DESCRIPTION_UPLOAD]: File; // If user selects OTHER in MEASUREMENT_SPECIFICATION -> this is optional file upload
 }

--- a/tests/cypress/cypress/integration/features/copy_coreset_and_measures_for_new_year.spec.ts
+++ b/tests/cypress/cypress/integration/features/copy_coreset_and_measures_for_new_year.spec.ts
@@ -34,4 +34,20 @@ describe("Coresets and measures should reflect the chosen year", () => {
     cy.goToMeasure("AMM-AD");
     cy.get("#DidReport_radiogroup").should("include.text", "FFY 2022");
   });
+
+  it("displays the correct information based on 2023", () => {
+    cy.get(`[data-cy="year-select"]`).select("2023");
+    cy.get(`[data-cy="reporting-year-heading"]`).should(
+      "include.text",
+      "FFY 2023 Core Set Measures Reporting"
+    );
+    cy.goToAdultMeasures();
+    cy.get(`[data-cy="state-layout-container"]`).should(
+      "include.text",
+      "FFY 2023"
+    );
+    cy.get(`[data-cy="PC01-AD"]`).should("not.exist");
+    cy.goToMeasure("AMM-AD");
+    cy.get("#DidReport_radiogroup").should("include.text", "FFY 2023");
+  });
 });

--- a/tests/cypress/cypress/integration/features/measurement_spec_def_of_pop_validation_text_changes.spec.ts
+++ b/tests/cypress/cypress/integration/features/measurement_spec_def_of_pop_validation_text_changes.spec.ts
@@ -4,15 +4,6 @@ describe("Measurement Specification/Definition of Population/Validation text cha
     cy.goToAdultMeasures();
   });
 
-  it("Ensure that highlighted word changes from Above to Below", () => {
-    cy.goToMeasure("AMR-AD");
-    cy.get("#MeasurementSpecification-NCQAHEDIS").click({ force: true });
-    cy.get("body").should(
-      "include.text",
-      "NCQA, the measure steward, changed its naming convention. HEDIS MY 2020 refers to a different federal fiscal year (FFY) than HEDIS 2020. Please note the FFY Core Set specification below."
-    );
-  });
-
   it("Ensure that What number of your measure-eligible population are included in the measure? is changed to What is the size of the measure-eligible population?", () => {
     cy.goToMeasure("CBP-AD");
     cy.get("#DidReport-yes").click({ force: true });


### PR DESCRIPTION
### Description
Add an option for HEDIS MY 2023, and remove the option for HEDIS 2020.

Since all HEDIS options now use the MY naming scheme, this PR also removes the clarifying text.

### Related ticket(s)
MDCT-2358

I believe this will also address MDCT-2368; 2358 is for adult measures and 2368 is for child measures, but as far as I can tell they use the same code.

---
### How to test
1. Log into QMR
2. Choose the 2023 reporting year
3. Open the adult core sets
4. Open any measure
5. For the third question ("Measurement Specification"), ensure the first radio button is checked
6. Note the absence of any explanatory text regarding the naming conventions for HEDIS 2020 vs HEDIS MY 2020.
7. Expand the nested dropdown; note that the options are correct.

### Important updates
n/a

---
### Author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
