### PR TITLE
put text behind periodOfHealthEmergency2023 flag

### DIFF
--- a/services/ui-src/src/measures/2023/SSHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2023/SSHH/questions/PerformanceMeasure.tsx
@@ -76,7 +76,7 @@ export const PerformanceMeasure = ({
         formLabelProps={{ fontWeight: 700 }}
         {...register(DC.OPM_EXPLAINATION)}
       />
-      {hybridMeasure && (
+      {hybridMeasure && pheIsCurrent && (
         <CUI.Box my="5">
           <CUI.Text>
             CMS recognizes that social distancing will make onsite medical chart
@@ -86,13 +86,11 @@ export const PerformanceMeasure = ({
             voluntary, CMS encourages states that can collect information safely
             to continue reporting the measures they have reported in the past.
           </CUI.Text>
-          {pheIsCurrent && (
-            <QMR.TextArea
-              formLabelProps={{ mt: 5 }}
-              {...register(DC.OPM_HYBRID_EXPLANATION)}
-              label="Describe any COVID-related difficulties encountered while collecting this data:"
-            />
-          )}
+          <QMR.TextArea
+            formLabelProps={{ mt: 5 }}
+            {...register(DC.OPM_HYBRID_EXPLANATION)}
+            label="Describe any COVID-related difficulties encountered while collecting this data:"
+          />
         </CUI.Box>
       )}
 

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -267,7 +267,7 @@ export const PerformanceMeasure = ({
           {...register(`${DC.PERFORMANCE_MEASURE}.${DC.EXPLAINATION}`)}
         />
       )}
-      {hybridMeasure && (
+      {hybridMeasure && pheIsCurrent && (
         <CUI.Box my="5">
           <CUI.Text>
             CMS recognizes that social distancing will make onsite medical chart
@@ -277,13 +277,11 @@ export const PerformanceMeasure = ({
             voluntary, CMS encourages states that can collect information safely
             to continue reporting the measures they have reported in the past.
           </CUI.Text>
-          {pheIsCurrent && (
-            <QMR.TextArea
-              formLabelProps={{ mt: 5 }}
-              {...register("PerformanceMeasure.hybridExplanation")}
-              label="Describe any COVID-related difficulties encountered while collecting this data:"
-            />
-          )}
+          <QMR.TextArea
+            formLabelProps={{ mt: 5 }}
+            {...register("PerformanceMeasure.hybridExplanation")}
+            label="Describe any COVID-related difficulties encountered while collecting this data:"
+          />
         </CUI.Box>
       )}
       <CUI.Text


### PR DESCRIPTION
### Description
Included a text section in the `periodOfHealthEmergency2023` flag


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2405

---
### How to test
Go to a hybrid measure like CBA-AD, fill out the form to get `Performance Measures` to show up. You will not see the text when the flag is disabled. Have Brendan or Karla enable the flag `periodOfHealthEmergency2023` to see the text appear.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
