### PR TITLE
MDCT-2260 - update to text

### DIFF
--- a/services/ui-src/src/measures/2023/AIFHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AIFHH/index.test.tsx
@@ -368,7 +368,7 @@ const completedMeasureData = {
             },
           ],
           isTotal: true,
-          label: "Total",
+          label: "Total (Age 18 and older)",
         },
       ],
     },

--- a/services/ui-src/src/measures/2023/rateLabelText.ts
+++ b/services/ui-src/src/measures/2023/rateLabelText.ts
@@ -60,9 +60,9 @@ export const data = {
                 "id": "Age85andolder"
             },
             {
-                "label": "Total",
-                "text": "Total",
-                "id": "Total"
+                "label": "Total (Age 18 and older)",
+                "text": "Total (Age 18 and older)",
+                "id": "Total (Age 18 and older)"
             }
         ],
         "categories": []


### PR DESCRIPTION
### Description
Added `(Age 18 and older)` to `Total` text in AIF-HH


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2260

---
### How to test
Login as a state user that has Home Health (stateuserME), fill out the entire measure to see the rates come up, scroll down to  `Total` and see that 1(Age 18 and older)` has been added.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
