### PR TITLE
Validate that SFM-CH rates have consistent denominators

### DIFF
--- a/services/ui-src/src/measures/2023/SFMCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/SFMCH/index.test.tsx
@@ -183,7 +183,9 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,7 +207,9 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsOMS).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/SFMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/SFMCH/validation.ts
@@ -69,6 +69,11 @@ const SFMCHValidation = (data: FormData) => {
       ageGroups
     ),
     ...filteredSameDenominatorErrors,
+    ...GV.validateEqualCategoryDenominatorsPM(
+      data,
+      PMD.categories,
+      PMD.qualifiers
+    ),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,
@@ -81,6 +86,7 @@ const SFMCHValidation = (data: FormData) => {
       validationCallbacks: [
         GV.validateOneQualRateHigherThanOtherQualOMS(),
         GV.validateNumeratorLessThanDenominatorOMS(),
+        GV.validateEqualCategoryDenominatorsOMS(),
         GV.validateRateZeroOMS(),
         GV.validateRateNotZeroOMS(),
       ],


### PR DESCRIPTION
### Description
This PR adds two validation functions to the SFM-CH measure:
1. Ensure that all denominators match within the Performance Measure section
2. Ensure that denominators are consistent with the Optional Measure Stratification section

The validation functions were pre-existing; this commit only adds them to this measure. Since the validation functions are already unit-tested separately, this commit only tests to ensure they are _called_ when validating this measure.

### Related ticket(s)
MDCT-2258

---
### How to test
1. Select FFY 2023
2. Go to Child Measures
3. Go to SFM-CH
4. Fill out the first three questions on the page, so that the rates section appears
5. Enter two rates with different denominators
6. At the bottom of the page, click "Validate Measure" - notice that an error message appears
7. Fix the rates to have matching denominators
8. Validate Measure again - notice that the error message clears.

The OSM validation can be tested the same way; you will need to drill into a category in order to enter your rates.

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
