### PR TITLE
package.json override of dynamodb local version

### DIFF
--- a/services/database/package.json
+++ b/services/database/package.json
@@ -10,6 +10,12 @@
   "license": "CC0-1.0",
   "devDependencies": {
     "serverless-s3-bucket-helper": "CMSgov/serverless-s3-bucket-helper#0.1.1",
+    "dynamodb-localhost": "https://github.com/99x/dynamodb-localhost#db30898f8c40932c7177be7b2f1a81360d12876d",
     "serverless-dynamodb-local": "0.2.40"
+  },
+  "overrides": {
+    "serverless-dynamodb-local": {
+      "dynamodb-localhost": "https://github.com/99x/dynamodb-localhost#db30898f8c40932c7177be7b2f1a81360d12876d"
+    }
   }
 }


### PR DESCRIPTION
Description
Updates dynamodb local to use direct override while we wait for serverless-dynamodb-local to be updated.

Related ticket(s)
Bugfix
How to test
Perform a fresh checkout
Follow the local build/deploy instructions
Validate that your dynamodb instance spun up without errors.

Important updates


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
