### PR TITLE
Tech Spec Changes - FUA-HH

### DIFF
--- a/services/ui-src/src/measures/2023/FUAHH/data.ts
+++ b/services/ui-src/src/measures/2023/FUAHH/data.ts
@@ -5,7 +5,7 @@ export const { categories, qualifiers } = getCatQualLabels("FUA-HH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
-    "Percentage of emergency department (ED) visits for health home enrollees age 13 and older with a principal diagnosis of alcohol or other drug (AOD) abuse or dependence who had a follow-up visit for AOD abuse or dependence.  Two rates are reported:",
+    "Percentage of emergency department (ED) visits for health home enrollees age 13 and older with a principal diagnosis of  substance use disorder (SUD), or any diagnosis of drug overdose, for which there was follow-up.  Two rates are reported:",
   ],
   questionListItems: [
     "Percentage of ED visits for which the enrollee received follow-up within 30 days of the ED visit (31 total days)",

--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -286,8 +286,7 @@ export const measureDescriptions: MeasureList = {
     "CBP-HH": "Controlling High Blood Pressure",
     "CDF-HH": "Screening for Depression and Follow-Up Plan",
     "COL-HH": "Colorectal Cancer Screening",
-    "FUA-HH":
-      "Follow-Up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence",
+    "FUA-HH": "Follow-Up After Emergency Department Visit for Substance Use",
     "FUH-HH": "Follow-Up After Hospitalization for Mental Illness",
     "IET-HH":
       "Initiation and Engagement of Alcohol and Other Drug Abuse or Dependence Treatment",


### PR DESCRIPTION
### Description
Text changes for FUA-HH (specifically FFY 2023 measures)

### Related ticket(s)
MDCT-2374

---
### How to test
- Login using the stateuser4@test.com user
- Add health home core data set
- Open health home core data set, navigate to FUA-HH
- See corresponding text changes
    - Title change: Follow-Up After Emergency Department Visit for *Substance Use*
    - Measure description change: Choose HEDIS under "Measurement Specification", navigate down to Performance Measure section and confirm text changes

### Important updates
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_