### PR TITLE
Tech Spec Changes - IET-HH

### DIFF
--- a/services/ui-src/src/measures/2023/IETHH/data.ts
+++ b/services/ui-src/src/measures/2023/IETHH/data.ts
@@ -6,11 +6,11 @@ export const { categories, qualifiers } = getCatQualLabels("IET-HH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
-    "Percentage of health home enrollees age 13 and older with a new episode of alcohol or other drug (AOD) abuse or dependence who received the following:",
+    "Percentage of new substance use disorder (SUD) episodes that result in treatment initiation and engagement. Two rates are reported:",
   ],
   questionListItems: [
-    "Initiation of AOD Treatment. Percentage of enrollees who initiate treatment through an inpatient AOD admission, outpatient visit, intensive outpatient encounter or partial hospitalization, telehealth, or medication treatment within 14 days of the diagnosis. ",
-    "Engagement of AOD Treatment. Percentage of enrollees who initiated treatment and who were engaged in ongoing AOD treatment within 34 days of the initiation visit.",
+    "Initiation of SUD Treatment. The percentage of new SUD episodes that result in treatment initiation through an inpatient SUD admission, outpatient visit, intensive outpatient encounter, partial hospitalization, telehealth visit, or medication treatment within 14 days.",
+    "Engagement of SUD Treatment. The percentage of new SUD episodes that have evidence of treatment engagement within 34 days of initiation.",
   ],
   categories,
   qualifiers,

--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -289,8 +289,7 @@ export const measureDescriptions: MeasureList = {
     "FUA-HH":
       "Follow-Up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence",
     "FUH-HH": "Follow-Up After Hospitalization for Mental Illness",
-    "IET-HH":
-      "Initiation and Engagement of Alcohol and Other Drug Abuse or Dependence Treatment",
+    "IET-HH": "Initiation and Engagement of Substance Use Disorder Treatment",
     "IU-HH": "Inpatient Utilization",
     "OUD-HH": "Use of Pharmacotherapy for Opioid Use Disorder",
     "PCR-HH": "Plan All-Cause Readmissions",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
1. Text changes to Initiation and Engagement of Alcohol and Other Drug Abuse or Dependence Treatment (IET-HH) measure title for FY 2023
2. Amend the description of the measure

### Related ticket(s)
MDCT-[MDCT-2377](https://qmacbis.atlassian.net/browse/MDCT-2377)

---
### How to test
* Login using the [stateuser4@test.com](mailto:stateuser4@test.com) user
* Add health home core data set
* Open health home core data set, navigate to IET-HH

#### See text changes

**Title change**:  *Initiation and Engagement of Substance Use Disorder Treatment*

**Performance Measure description change:**

*Percentage of new substance use disorder (SUD) episodes that result in treatment initiation and engagement.  Two rates are reported:*

*Initiation of SUD Treatment.  The percentage of new SUD episodes that result in treatment initiation through an inpatient SUD admission, outpatient visit, intensive outpatient encounter, partial hospitalization, telehealth visit, or medication treatment within 14 days.*

*Engagement of SUD Treatment.  The percentage of new SUD episodes that have evidence of treatment engagement within 34 days of initiation.*



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
