### PR TITLE
Added validation for identical OPM rate descriptions - FFY 2023 measures.

### DIFF
--- a/services/ui-src/src/measures/2023/AABAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AABAD/validation.ts
@@ -48,6 +48,7 @@ const AABADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/ADDCH/validation.ts
+++ b/services/ui-src/src/measures/2023/ADDCH/validation.ts
@@ -43,6 +43,7 @@ const ADDCHValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/AIFHH/validation.ts
+++ b/services/ui-src/src/measures/2023/AIFHH/validation.ts
@@ -56,6 +56,7 @@ const AIFHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
 
     ...GV.ComplexValidateDualPopInformation(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/AMBCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBCH/validation.ts
@@ -44,6 +44,7 @@ const AMBCHValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateTotalNDR(performanceMeasureArray, undefined, undefined),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateOPMRates(OPM),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/AMBHH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBHH/validation.ts
@@ -35,6 +35,7 @@ const AMBHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
 
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(

--- a/services/ui-src/src/measures/2023/AMMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMMAD/validation.ts
@@ -110,6 +110,7 @@ const AMMADValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/AMRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRAD/validation.ts
@@ -32,6 +32,7 @@ const AMRADValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,
       ageGroups,

--- a/services/ui-src/src/measures/2023/AMRCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRCH/validation.ts
@@ -32,6 +32,7 @@ const AMRCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,
       ageGroups,

--- a/services/ui-src/src/measures/2023/APMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APMCH/validation.ts
@@ -61,6 +61,7 @@ const APMCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/APPCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APPCH/validation.ts
@@ -46,6 +46,7 @@ const APPCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,
       PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/BCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/BCSAD/validation.ts
@@ -67,6 +67,7 @@ const BCSValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,
       ageGroups,

--- a/services/ui-src/src/measures/2023/CBPAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPAD/validation.ts
@@ -50,6 +50,7 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CBPHH/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPHH/validation.ts
@@ -49,6 +49,7 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateTotalNDR(performanceMeasureArray),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CCPAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCPAD/validation.ts
@@ -33,6 +33,7 @@ const CCPADValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateOneQualRateHigherThanOtherQualPM(data, PMD.data, 1, 0),
     ...GV.validateEqualCategoryDenominatorsPM(data, PMD.categories),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2023/CCPCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CCPCH/validation.ts
@@ -33,6 +33,7 @@ const CCPCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateEqualCategoryDenominatorsPM(data, PMD.categories),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/CCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCSAD/validation.ts
@@ -65,6 +65,7 @@ const CCSADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/CCWAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCWAD/validation.ts
@@ -48,6 +48,7 @@ const CCWADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       [memeRates, larcRates],

--- a/services/ui-src/src/measures/2023/CCWCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CCWCH/validation.ts
@@ -39,6 +39,7 @@ const CCWCHValidation = (data: FormData) => {
     ),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateOneQualRateHigherThanOtherQualPM(data, PMD),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CDFAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFAD/validation.ts
@@ -50,6 +50,7 @@ const CDFADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CDFCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFCH/validation.ts
@@ -50,6 +50,7 @@ const CDFCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CDFHH/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFHH/validation.ts
@@ -35,6 +35,7 @@ const CDFHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
 
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(

--- a/services/ui-src/src/measures/2023/CHLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLAD/validation.ts
@@ -42,6 +42,7 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CHLCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLCH/validation.ts
@@ -42,6 +42,7 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CISCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CISCH/validation.ts
@@ -70,6 +70,7 @@ const CISCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/COBAD/validation.ts
+++ b/services/ui-src/src/measures/2023/COBAD/validation.ts
@@ -52,6 +52,7 @@ const COBADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/COLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/COLAD/validation.ts
@@ -53,6 +53,7 @@ const COLADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/COLHH/validation.ts
+++ b/services/ui-src/src/measures/2023/COLHH/validation.ts
@@ -53,6 +53,7 @@ const COLHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/DEVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/DEVCH/validation.ts
@@ -51,6 +51,7 @@ const DEVCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/FUAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAAD/validation.ts
@@ -56,6 +56,7 @@ const FUAADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/FUACH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUACH/validation.ts
@@ -44,6 +44,7 @@ const FUACHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/FUAHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAHH/validation.ts
@@ -36,6 +36,7 @@ const FUAHHValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/FUHAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHAD/validation.ts
@@ -68,6 +68,7 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/FUHCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHCH/validation.ts
@@ -61,6 +61,7 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/FUHHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHHH/validation.ts
@@ -36,6 +36,7 @@ const FUHHHValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/FUMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMAD/validation.ts
@@ -60,6 +60,7 @@ const FUMADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD.data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/FUMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMCH/validation.ts
@@ -60,6 +60,7 @@ const FUMCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/FUMHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMHH/validation.ts
@@ -38,6 +38,7 @@ const FUMHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
 
     // Performance Measure Validations
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/FVAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FVAAD/validation.ts
@@ -44,6 +44,7 @@ const FVAADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,
       ageGroups,

--- a/services/ui-src/src/measures/2023/HBDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HBDAD/validation.ts
@@ -74,6 +74,7 @@ const HBDADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
@@ -51,6 +51,7 @@ const HPCMIADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/HVLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HVLAD/validation.ts
@@ -66,6 +66,7 @@ const HVLADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/IETAD/validation.ts
+++ b/services/ui-src/src/measures/2023/IETAD/validation.ts
@@ -139,6 +139,7 @@ const IETValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/IETHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IETHH/validation.ts
@@ -143,6 +143,7 @@ const IETValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/IMACH/validation.ts
+++ b/services/ui-src/src/measures/2023/IMACH/validation.ts
@@ -51,6 +51,7 @@ const DEVCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/IUHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IUHH/validation.ts
@@ -53,6 +53,7 @@ const IUHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.ComplexValidateDualPopInformation(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/MSCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/MSCAD/validation.ts
@@ -47,6 +47,7 @@ const MSCADValidation = (data: Types.DefaultFormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2023/OEVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/OEVCH/validation.ts
@@ -27,6 +27,7 @@ const OEVCHValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/OHDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/OHDAD/validation.ts
@@ -49,6 +49,7 @@ const OHDValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/OUDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/OUDAD/validation.ts
@@ -33,6 +33,7 @@ const OUDValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/OUDHH/validation.ts
+++ b/services/ui-src/src/measures/2023/OUDHH/validation.ts
@@ -32,6 +32,7 @@ const OUDValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/PCRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRAD/validation.ts
@@ -51,6 +51,7 @@ const PCRADValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
 

--- a/services/ui-src/src/measures/2023/PCRHH/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRHH/validation.ts
@@ -53,7 +53,7 @@ const PCRHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-
+    ...GV.validateOPMRates(OPM),
     // Performance Measure Validations
     ...GV.PCRatLeastOneRateComplete(performanceMeasureArray, OPM, ageGroups),
     ...GV.PCRnoNonZeroNumOrDenom(performanceMeasureArray, OPM, ndrForumlas),

--- a/services/ui-src/src/measures/2023/PPCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCAD/validation.ts
@@ -65,6 +65,7 @@ const PPCADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/PPCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCCH/validation.ts
@@ -65,6 +65,7 @@ const PPCCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/PQI01AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI01AD/validation.ts
@@ -40,6 +40,7 @@ const PQI01Validation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, PMD.qualifiers),
     ...GV.validateRateZeroPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/PQI05AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI05AD/validation.ts
@@ -34,6 +34,7 @@ const PQI05Validation = (data: FormData) => {
     ...errorArray,
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, PMD.qualifiers),
     ...GV.validateRateZeroPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/PQI08AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI08AD/validation.ts
@@ -38,6 +38,7 @@ const PQI08Validation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateDualPopInformationPM(
       validateDualPopInformationArray,

--- a/services/ui-src/src/measures/2023/PQI15AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI15AD/validation.ts
@@ -32,6 +32,7 @@ const PQI15Validation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2023/PQI92HH/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI92HH/validation.ts
@@ -35,7 +35,7 @@ const PQI92Validation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-
+    ...GV.validateOPMRates(OPM),
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/SAAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SAAAD/validation.ts
@@ -59,6 +59,7 @@ const SAAADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/SFMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/SFMCH/validation.ts
@@ -56,6 +56,7 @@ const SFMCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/SSDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SSDAD/validation.ts
@@ -58,6 +58,7 @@ const SSDValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/SSHH/validation.ts
+++ b/services/ui-src/src/measures/2023/SSHH/validation.ts
@@ -124,6 +124,7 @@ const SSHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/TFLCH/validation.ts
+++ b/services/ui-src/src/measures/2023/TFLCH/validation.ts
@@ -48,6 +48,7 @@ const TFLCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateTotalNDR(performanceMeasureArray),
     ...sameDenominatorError,

--- a/services/ui-src/src/measures/2023/W30CH/validation.ts
+++ b/services/ui-src/src/measures/2023/W30CH/validation.ts
@@ -55,6 +55,7 @@ const W30CHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/WCCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCCCH/validation.ts
@@ -44,6 +44,7 @@ const WCCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/WCVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCVCH/validation.ts
@@ -65,6 +65,7 @@ const WCVCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateTotalNDR(performanceMeasureArray),
   ];
 

--- a/services/ui-src/src/measures/2023/shared/globalValidations/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/index.ts
@@ -19,6 +19,7 @@ export * from "./validateReasonForNotReporting";
 export * from "./validateRequiredRadioButtonForCombinedRates";
 export * from "./validateTotals";
 export * from "./validateYearFormat";
+export * from "./validateOPMRates";
 
 // PCR-XX Specific Validations
 export { PCRatLeastOneRateComplete } from "./PCRValidations/PCRatLeastOneRateComplete";

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.test.ts
@@ -14,12 +14,17 @@ describe("OPM Validation", () => {
     formData = JSON.parse(JSON.stringify(testFormData)); // reset data
   });
 
-  it("Should throw error if there are duplicate opm rates", () => {
-    formData[DC.OPM_RATES][0][DC.DESCRIPTION] = "18-64";
-    formData[DC.OPM_RATES][1][DC.DESCRIPTION] = "18-64";
-    const errorMessage = "Measure description must be unique.";
+  it("Should not throw error if there are no duplicates", () => {
+    formData[DC.OPM_RATES][0][DC.DESCRIPTION] = "18-30";
+    formData[DC.OPM_RATES][1][DC.DESCRIPTION] = "31-64";
     const errorArray = run_validation(formData);
-    expect(errorArray.length).toBe(1);
-    expect(errorArray[0].errorMessage).toBe(errorMessage);
+    expect(errorArray.length).toBe(0);
+  });
+
+  it("Should not treat multiple empty descriptions as duplicates", () => {
+    formData[DC.OPM_RATES][0][DC.DESCRIPTION] = "";
+    formData[DC.OPM_RATES][1][DC.DESCRIPTION] = "";
+    const errorArray = run_validation(formData);
+    expect(errorArray.length).toBe(0);
   });
 });

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.test.ts
@@ -1,0 +1,25 @@
+import * as DC from "dataConstants";
+import { testFormData } from "../testHelpers/_testFormData";
+import { validateOPMRates } from ".";
+
+describe("OPM Validation", () => {
+  let formData: any;
+
+  const run_validation = (data: any): FormError[] => {
+    const OPM = data[DC.OPM_RATES];
+    return [...validateOPMRates(OPM)];
+  };
+
+  beforeEach(() => {
+    formData = JSON.parse(JSON.stringify(testFormData)); // reset data
+  });
+
+  it("Should throw error if there are duplicate opm rates", () => {
+    formData[DC.OPM_RATES][0][DC.DESCRIPTION] = "18-64";
+    formData[DC.OPM_RATES][1][DC.DESCRIPTION] = "18-64";
+    const errorMessage = "Measure description must be unique.";
+    const errorArray = run_validation(formData);
+    expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe(errorMessage);
+  });
+});

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.ts
@@ -1,0 +1,29 @@
+import { OtherPerformanceMeasure } from "measures/2023/shared/CommonQuestions/types";
+
+/* Other Performance Measure Rate Description. Check all rate descriptions 
+to make sure there are no identical descriptions */
+
+export const validateOPMRates = (
+  otherPerformanceMeasure: OtherPerformanceMeasure["OtherPerformanceMeasure-Rates"],
+  errorMessage?: string
+) => {
+  const errorArray: FormError[] = [];
+
+  if (otherPerformanceMeasure) {
+    const opm_descriptions = otherPerformanceMeasure.map(
+      (item) => item.description
+    );
+    const hasDuplicates = opm_descriptions.some((desc, index) => {
+      return opm_descriptions.indexOf(desc) !== index;
+    });
+
+    if (hasDuplicates) {
+      errorArray.push({
+        errorLocation: "Other Performance Measure",
+        errorMessage: errorMessage ?? "Measure description must be unique.",
+      });
+    }
+  }
+
+  return errorArray;
+};

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.ts
@@ -18,8 +18,6 @@ export const validateOPMRates = (
       item.description.trim()
     );
 
-    console.log(formattedDescriptions);
-
     const hasDuplicates = formattedDescriptions.some((desc: any, index) => {
       return formattedDescriptions.indexOf(desc) !== index;
     });

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.ts
@@ -10,11 +10,18 @@ export const validateOPMRates = (
   const errorArray: FormError[] = [];
 
   if (otherPerformanceMeasure) {
-    const opm_descriptions = otherPerformanceMeasure.map(
-      (item) => item.description
+    const opm_descriptions = otherPerformanceMeasure.filter(
+      (item: any) => item.description !== ""
     );
-    const hasDuplicates = opm_descriptions.some((desc, index) => {
-      return opm_descriptions.indexOf(desc) !== index;
+
+    const formattedDescriptions = opm_descriptions.map((item: any) =>
+      item.description.trim()
+    );
+
+    console.log(formattedDescriptions);
+
+    const hasDuplicates = formattedDescriptions.some((desc: any, index) => {
+      return formattedDescriptions.indexOf(desc) !== index;
     });
 
     if (hasDuplicates) {

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateOPMRates/index.ts
@@ -11,7 +11,7 @@ export const validateOPMRates = (
 
   if (otherPerformanceMeasure) {
     const opm_descriptions = otherPerformanceMeasure.filter(
-      (item: any) => item.description !== ""
+      (item: any) => !!item.description
     );
 
     const formattedDescriptions = opm_descriptions.map((item: any) =>


### PR DESCRIPTION
### Description
Create a validation that fires when states create data labels for rates in the Other Performance Section that are identical (e.g. two rates that are both labeled 18-64 with no other distinction). These labels must be distinct from one another to be read into the Mathematica database correctly.

When fields match and user validates measure display error message:

H1: Other Performance Measure Error
Body: Measure description must be unique 

* The validation only notifies user. They can still complete the form.

### Related ticket(s)
https://qmacbis.atlassian.net/jira/software/c/projects/MDCT/boards/232?modal=detail&selectedIssue=MDCT-2333
MDCT-2333

https://user-images.githubusercontent.com/14514294/235723363-61986e9e-41b6-4f5e-99f0-cbac40b9e2c5.mov


---
### How to test
1. Login as user
2. Go to 2023 FY
3. Select a core set
4. Select a measure
5. In "Measurement Specification" select 'Other'
6. Scroll down to Other Performance Measure and add two performance measures with identical descriptions in the 'Describe the Rate' section.
7. Validate
8. You should see an 'Other Performance Measure Error' validation message below

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
