### PR TITLE
Create new measure: CPU-AD

### DIFF
--- a/services/app-api/handlers/dynamoUtils/measureList.ts
+++ b/services/app-api/handlers/dynamoUtils/measureList.ts
@@ -763,6 +763,10 @@ export const measures: Measure = {
     },
     {
       type: "A",
+      measure: "CPU-AD",
+    },
+    {
+      type: "A",
       measure: "FUA-AD",
     },
     {

--- a/services/ui-src/src/dataConstants.ts
+++ b/services/ui-src/src/dataConstants.ts
@@ -12,6 +12,7 @@ export const AHRQ = "AHRQ";
 export const AHRQ_NCQA = "AHRQ-NCQA";
 export const AMOUNT_OF_POP_NOT_COVERED = "AmountOfPopulationNotCovered";
 export const BUDGET_CONSTRAINTS = "BudgetConstraints";
+export const CASE_MANAGEMENT_RECORD_REVIEW = "Case management record review";
 export const CATEGORIES = "categories";
 export const CDC = "CDC";
 export const CHANGE_IN_POP_EXPLANATION = "ChangeInPopulationExplanation";

--- a/services/ui-src/src/measures/2023/CPUAD/data.ts
+++ b/services/ui-src/src/measures/2023/CPUAD/data.ts
@@ -9,8 +9,8 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
     "Percentage of beneficiaries receiving long-term services and supports (LTSS) services ages 18 and older who have documentation of a comprehensive long-term services and supports (LTSS) care plan in a specified time frame that includes core elements. The following rates are reported:",
   ],
   questionListItems: [
-    "Care Plan with Supplemental Elements Documented.  Beneficiaries who had a comprehensive LTSS care plan with 9 core elements and at least 4 supplemental elements documented within 120 days of enrollment (for new beneficiaries) or during the measurement year (for established beneficiaries).",
     "Care Plan with Core Elements Documented.  Beneficiaries who had a comprehensive LTSS care plan with 9 core elements documented within 120 days of enrollment (for new beneficiaries) or during the measurement year (for established beneficiaries).",
+    "Care Plan with Supplemental Elements Documented.  Beneficiaries who had a comprehensive LTSS care plan with 9 core elements and at least 4 supplemental elements documented within 120 days of enrollment (for new beneficiaries) or during the measurement year (for established beneficiaries).",
   ],
   categories,
   qualifiers,

--- a/services/ui-src/src/measures/2023/CPUAD/data.ts
+++ b/services/ui-src/src/measures/2023/CPUAD/data.ts
@@ -1,0 +1,45 @@
+import * as DC from "dataConstants";
+import { getCatQualLabels } from "../rateLabelText";
+import { DataDrivenTypes } from "../shared/CommonQuestions/types";
+
+export const { categories, qualifiers } = getCatQualLabels("CPU-AD");
+
+export const data: DataDrivenTypes.PerformanceMeasure = {
+  questionText: [
+    "Percentage of beneficiaries receiving long-term services and supports (LTSS) services ages 18 and older who have documentation of a comprehensive long-term services and supports (LTSS) care plan in a specified time frame that includes core elements. The following rates are reported:",
+  ],
+  questionListItems: [
+    "Care Plan with Supplemental Elements Documented.  Beneficiaries who had a comprehensive LTSS care plan with 9 core elements and at least 4 supplemental elements documented within 120 days of enrollment (for new beneficiaries) or during the measurement year (for established beneficiaries).",
+    "Care Plan with Core Elements Documented.  Beneficiaries who had a comprehensive LTSS care plan with 9 core elements documented within 120 days of enrollment (for new beneficiaries) or during the measurement year (for established beneficiaries).",
+  ],
+  categories,
+  qualifiers,
+};
+
+export const dataSourceData: DataDrivenTypes.DataSource = {
+  optionsLabel:
+    "If Reporting entities (e.g. health plans) used different data sources, please select all applicable data sources used below",
+  options: [
+    {
+      value: DC.CASE_MANAGEMENT_RECORD_REVIEW,
+      description: false,
+      subOptions: [
+        {
+          label: "What is the case management record data source?",
+          options: [
+            {
+              value: DC.EHR_DATA,
+            },
+            {
+              value: DC.PAPER,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      value: DC.OTHER_DATA_SOURCE,
+      description: true,
+    },
+  ],
+};

--- a/services/ui-src/src/measures/2023/CPUAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CPUAD/index.test.tsx
@@ -1,0 +1,251 @@
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { RouterWrappedComp } from "utils/testing";
+import { MeasureWrapper } from "components/MeasureWrapper";
+import { useApiMock } from "utils/testUtils/useApiMock";
+import { useUser } from "hooks/authHooks";
+import Measures from "measures";
+import { Suspense } from "react";
+import { MeasuresLoading } from "views";
+import { measureDescriptions } from "measures/measureDescriptions";
+import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
+import { validationFunctions } from "./validation";
+import {
+  mockValidateAndSetErrors,
+  clearMocks,
+  validationsMockObj as V,
+} from "measures/2023/shared/util/validationsMock";
+import { axe, toHaveNoViolations } from "jest-axe";
+expect.extend(toHaveNoViolations);
+
+// Test Setup
+const measureAbbr = "CPU-AD";
+const coreSet = "ACS";
+const state = "AL";
+const year = 2023;
+const description = measureDescriptions[`${year}`][measureAbbr];
+const apiData: any = {};
+
+jest.mock("hooks/authHooks");
+const mockUseUser = useUser as jest.Mock;
+
+describe(`Test FFY ${year} ${measureAbbr}`, () => {
+  let component: JSX.Element;
+  beforeEach(() => {
+    clearMocks();
+    apiData.useGetMeasureValues = {
+      data: {
+        Item: {
+          compoundKey: `${state}${year}${coreSet}${measureAbbr}`,
+          coreSet,
+          createdAt: 1642517935305,
+          description,
+          lastAltered: 1642517935305,
+          lastAlteredBy: "undefined",
+          measure: measureAbbr,
+          state,
+          status: "incomplete",
+          year,
+          data: {},
+        },
+      },
+      isLoading: false,
+      refetch: jest.fn(),
+      isError: false,
+      error: undefined,
+    };
+
+    mockUseUser.mockImplementation(() => {
+      return { isStateUser: false };
+    });
+
+    const measure = createElement(Measures[year][measureAbbr]);
+    component = (
+      <Suspense fallback={MeasuresLoading()}>
+        <RouterWrappedComp>
+          <MeasureWrapper
+            measure={measure}
+            name={description}
+            year={`${year}`}
+            measureId={measureAbbr}
+          />
+        </RouterWrappedComp>
+      </Suspense>
+    );
+  });
+
+  it("measure should render", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("measure-wrapper-form")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(measureAbbr + " - " + description));
+    });
+  });
+
+  /**
+   * Render the measure and confirm that all expected components exist.
+   * */
+  it("Always shows Are you reporting question", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("reporting"));
+  });
+
+  it("shows corresponding questions if yes to reporting then ", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("status-of-data")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("measurement-specification")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("data-source")).toBeInTheDocument();
+    expect(screen.queryByTestId("date-range")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("definition-of-population")
+    ).toBeInTheDocument();
+  });
+
+  it("does not show corresponding questions if no to reporting then ", async () => {
+    apiData.useGetMeasureValues.data.Item.data = notReportingData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("status-of-data")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("measurement-specification")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("data-source")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("date-range")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("definition-of-population")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows corresponding components and hides others when primary measure is selected", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("performance-measure")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("deviation-from-measure-specification")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("OPM")).not.toBeInTheDocument();
+  });
+
+  it("shows corresponding components and hides others when primary measure is NOT selected", async () => {
+    apiData.useGetMeasureValues.data.Item.data = OPMData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("OPM"));
+    expect(screen.queryByTestId("performance-measure")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("deviation-from-measure-specification")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows OMS when performance measure data has been entered", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("OMS"));
+  });
+  it("does not show OMS when performance measure data has been entered", async () => {
+    apiData.useGetMeasureValues.data.Item.data = notReportingData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("OMS")).not.toBeInTheDocument();
+  });
+
+  /** Validations Test
+   *
+   * Confirm that correct functions are called. Comprehensive testing of the validations is done in specific test files
+   * for each validation function. See globalValidations directory.
+   */
+  it("(Not Reporting) validationFunctions should call all expected validation functions", async () => {
+    mockValidateAndSetErrors(validationFunctions, notReportingData); // trigger validations
+    expect(V.validateReasonForNotReporting).toHaveBeenCalled();
+    expect(V.validateAtLeastOneRateComplete).not.toHaveBeenCalled();
+    expect(V.validateNumeratorsLessThanDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateRateNotZeroPM).not.toHaveBeenCalled();
+    expect(V.validateRateZeroPM).not.toHaveBeenCalled();
+    expect(
+      V.validateRequiredRadioButtonForCombinedRates
+    ).not.toHaveBeenCalled();
+    expect(V.validateBothDatesCompleted).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSource).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeviationFieldFilled).not.toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatOMS).not.toHaveBeenCalled();
+    expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
+    expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+  });
+
+  it("(Completed) validationFunctions should call all expected validation functions", async () => {
+    mockValidateAndSetErrors(validationFunctions, completedMeasureData); // trigger validations
+    expect(V.validateReasonForNotReporting).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneRateComplete).toHaveBeenCalled();
+    expect(V.validateNumeratorsLessThanDenominatorsPM).toHaveBeenCalled();
+    expect(V.validateRateZeroPM).toHaveBeenCalled();
+    expect(V.validateRequiredRadioButtonForCombinedRates).toHaveBeenCalled();
+    expect(V.validateBothDatesCompleted).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeviationFieldFilled).toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatOMS).not.toHaveBeenCalled();
+    expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
+    expect(V.validateRateZeroOMS).toHaveBeenCalled();
+    expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+  });
+
+  it("should not allow non state users to edit forms by disabling buttons", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+
+    expect(screen.getByTestId("measure-wrapper-form")).toBeInTheDocument();
+    const completeButton = screen.getByText("Complete Measure");
+    fireEvent.click(completeButton);
+    expect(completeButton).toHaveAttribute("disabled");
+  });
+
+  jest.setTimeout(15000);
+  it("should pass a11y tests", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    await act(async () => {
+      const results = await axe(screen.getByTestId("measure-wrapper-form"));
+      expect(results).toHaveNoViolations();
+    });
+  });
+});
+
+const notReportingData = {
+  DidReport: "no",
+};
+
+const OPMData = { MeasurementSpecification: "Other", DidReport: "yes" };
+
+const completedMeasureData = {
+  PerformanceMeasure: {
+    rates: {
+      singleCategory: [
+        {
+          label: "Care Plan with Core Elements Documented",
+          rate: "100.0",
+          numerator: "55",
+          denominator: "55",
+        },
+        {
+          label: "Care Plan with Supplemental Elements Documented",
+        },
+      ],
+    },
+  },
+  MeasurementSpecification: "NCQA/HEDIS",
+  DidReport: "yes",
+};

--- a/services/ui-src/src/measures/2023/CPUAD/index.tsx
+++ b/services/ui-src/src/measures/2023/CPUAD/index.tsx
@@ -1,0 +1,71 @@
+import * as PMD from "./data";
+import * as QMR from "components";
+import * as CMQ from "measures/2023/shared/CommonQuestions";
+
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+
+import { FormData } from "./types";
+import { validationFunctions } from "./validation";
+import { getPerfMeasureRateArray } from "measures/2023/shared/globalValidations";
+
+export const CPUAD = ({
+  name,
+  year,
+  measureId,
+  setValidationFunctions,
+  isNotReportingData,
+  isPrimaryMeasureSpecSelected,
+  isOtherMeasureSpecSelected,
+  showOptionalMeasureStrat,
+}: QMR.MeasureWrapperProps) => {
+  const { watch } = useFormContext<FormData>();
+  const data = watch();
+
+  useEffect(() => {
+    if (setValidationFunctions) {
+      setValidationFunctions(validationFunctions);
+    }
+  }, [setValidationFunctions]);
+
+  const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+
+  return (
+    <>
+      <CMQ.Reporting
+        reportingYear={year}
+        measureName={name}
+        measureAbbreviation={measureId}
+      />
+
+      {!isNotReportingData && (
+        <>
+          <CMQ.StatusOfData />
+          <CMQ.MeasurementSpecification type="HEDIS" />
+          <CMQ.DataSource data={PMD.dataSourceData} />
+          <CMQ.DateRange type="adult" />
+          <CMQ.DefinitionOfPopulation />
+          {isPrimaryMeasureSpecSelected && (
+            <>
+              <CMQ.PerformanceMeasure data={PMD.data} />
+              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+            </>
+          )}
+          {isOtherMeasureSpecSelected && (
+            <CMQ.OtherPerformanceMeasure data={PMD.data} />
+          )}
+          <CMQ.CombinedRates />
+          {showOptionalMeasureStrat && (
+            <CMQ.OptionalMeasureStrat
+              performanceMeasureArray={performanceMeasureArray}
+              qualifiers={PMD.qualifiers}
+              categories={PMD.categories}
+              adultMeasure
+            />
+          )}
+        </>
+      )}
+      <CMQ.AdditionalNotes />
+    </>
+  );
+};

--- a/services/ui-src/src/measures/2023/CPUAD/types.ts
+++ b/services/ui-src/src/measures/2023/CPUAD/types.ts
@@ -1,0 +1,3 @@
+import * as Types from "measures/2023/shared/CommonQuestions/types";
+
+export type FormData = Types.DefaultFormData;

--- a/services/ui-src/src/measures/2023/CPUAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CPUAD/validation.ts
@@ -43,6 +43,7 @@ const CPUADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
 
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/CPUAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CPUAD/validation.ts
@@ -1,0 +1,76 @@
+import * as DC from "dataConstants";
+import * as GV from "measures/2023/shared/globalValidations";
+import * as PMD from "./data";
+import { FormData } from "./types";
+import { OMSData } from "measures/2023/shared/CommonQuestions/OptionalMeasureStrat/data";
+
+const CPUADValidation = (data: FormData) => {
+  const carePlans = PMD.qualifiers;
+  const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
+  const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
+  let errorArray: any[] = [];
+  const OPM = data[DC.OPM_RATES];
+
+  const deviationArray = GV.getDeviationNDRArray(
+    data.DeviationOptions,
+    data.Deviations,
+    true
+  );
+  const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
+  const dateRange = data[DC.DATE_RANGE];
+
+  if (data[DC.DID_REPORT] === DC.NO) {
+    errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
+    return errorArray;
+  }
+
+  errorArray = [
+    ...errorArray,
+    ...GV.validateAtLeastOneRateComplete(
+      performanceMeasureArray,
+      OPM,
+      carePlans,
+      PMD.categories
+    ),
+    ...GV.validateNumeratorsLessThanDenominatorsPM(
+      performanceMeasureArray,
+      OPM,
+      carePlans
+    ),
+    ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, carePlans),
+    ...GV.validateRateZeroPM(performanceMeasureArray, OPM, carePlans, data),
+
+    ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateBothDatesCompleted(dateRange),
+    ...GV.validateYearFormat(dateRange),
+    ...GV.validateAtLeastOneDataSource(data),
+
+    ...GV.validateAtLeastOneDeviationFieldFilled(
+      performanceMeasureArray,
+      carePlans,
+      deviationArray,
+      didCalculationsDeviate
+    ),
+
+    // OMS Validations
+    ...GV.omsValidations({
+      data,
+      qualifiers: PMD.qualifiers,
+      categories: PMD.categories,
+      locationDictionary: GV.omsLocationDictionary(
+        OMSData(true),
+        PMD.qualifiers,
+        PMD.categories
+      ),
+      validationCallbacks: [
+        GV.validateNumeratorLessThanDenominatorOMS(),
+        GV.validateRateZeroOMS(),
+        GV.validateRateNotZeroOMS(),
+      ],
+    }),
+  ];
+
+  return errorArray;
+};
+
+export const validationFunctions = [CPUADValidation];

--- a/services/ui-src/src/measures/2023/index.tsx
+++ b/services/ui-src/src/measures/2023/index.tsx
@@ -92,6 +92,9 @@ const CPAAD = lazy(() =>
 const CPCCH = lazy(() =>
   import("./CPCCH").then((module) => ({ default: module.CPCCH }))
 );
+const CPUAD = lazy(() =>
+  import("./CPUAD").then((module) => ({ default: module.CPUAD }))
+);
 const DEVCH = lazy(() =>
   import("./DEVCH").then((module) => ({ default: module.DEVCH }))
 );
@@ -252,6 +255,7 @@ const twentyTwentyThreeMeasures = {
   "COL-HH": COLHH,
   "CPA-AD": CPAAD,
   "CPC-CH": CPCCH,
+  "CPU-AD": CPUAD,
   "DEV-CH": DEVCH,
   "FUA-AD": FUAAD,
   "FUA-CH": FUACH,

--- a/services/ui-src/src/measures/2023/rateLabelText.ts
+++ b/services/ui-src/src/measures/2023/rateLabelText.ts
@@ -587,6 +587,21 @@ export const data = {
         ],
         "categories": []
     },
+    "CPU-AD": {
+        "qualifiers": [
+            {
+                "label": "Care Plan with Core Elements Documented",
+                "text": "Care Plan with Core Elements Documented",
+                "id": "CarePlanwithCoreElementsDocumented",
+            },
+            {
+                "label": "Care Plan with Supplemental Elements Documented",
+                "text": "Care Plan with Supplemental Elements Documented",
+                "id": "CarePlanwithSupplementalElementsDocumented",
+            },
+        ],
+        "categories": []
+    },
     "DEV-CH": {
         "qualifiers": [
             {

--- a/services/ui-src/src/measures/2023/rateLabelText.ts
+++ b/services/ui-src/src/measures/2023/rateLabelText.ts
@@ -597,15 +597,15 @@ export const data = {
             {
                 "label": "Care Plan with Core Elements Documented",
                 "text": "Care Plan with Core Elements Documented",
-                "id": "CarePlanwithCoreElementsDocumented",
+                "id": "T6dADz",
             },
             {
                 "label": "Care Plan with Supplemental Elements Documented",
                 "text": "Care Plan with Supplemental Elements Documented",
-                "id": "CarePlanwithSupplementalElementsDocumented",
+                "id": "NBz553",
             },
         ],
-        "categories": []
+        "categories": [{"id":"HLXNLW", "label": "", "text":""}]
     },
     "DEV-CH": {
         "qualifiers": [

--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -215,6 +215,8 @@ export const measureDescriptions: MeasureList = {
     "COL-AD": "Colorectal Cancer Screening",
     "CPA-AD":
       "Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H, Adult Version (Medicaid)",
+    "CPU-AD":
+      "Long-Term Services and Supports Comprehensive Care Plan and Update",
     "FUA-AD":
       "Follow-up After Emergency Department Visit for Substance Use: Age 18 and Older",
     "FUH-AD":


### PR DESCRIPTION
### Description
CPU-AD is **Long-Term Services and Supports Comprehensive Care Plan and Update** for adults.

### Related ticket(s)
MDCT-2427

---
### How to test
This is an adult measure for 2023, and it should line up with the story description.

### Important updates
n/a

---
### Author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
