### PR TITLE
Update destroy.sh to fix bug w/ variable subsitutiton

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -120,7 +120,9 @@ done
 
 echo "Removing certificate from stage"
 
-restApiId=$(aws apigateway get-rest-apis | jq -r '.[] | .[] |  select(.name=="fix-destroy-issues-app-api") | .id|tostring')
+restApiName=$stage-app-api
+
+restApiId=$(aws apigateway get-rest-apis | jq -r ".[] | .[] |  select(.name==\"$restApiName\") | .id|tostring")
 
 aws apigateway update-stage \
   --rest-api-id $restApiId \


### PR DESCRIPTION
### Description
Variables weren't being substituted correctly, causing the destroy script to fail.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
[MDCT-2467](https://qmacbis.atlassian.net/browse/MDCT-2467)
---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
N/A, destroy action should pass.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
