### PR TITLE
remove 'FS' ISO code from constants (and dropdown)

### DIFF
--- a/services/ui-src/src/utils/constants.ts
+++ b/services/ui-src/src/utils/constants.ts
@@ -11,7 +11,6 @@ export const stateAbbreviations = [
   "DC",
   "FM",
   "FL",
-  "FS",
   "GA",
   "GU",
   "HI",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
So there's a 2-char state/territory abbreviation showing up in the dropdown that should not be -- `FS`. The problem is that FS is not a valid ISO code or really anything else, so... why was it ever put there in the first place? We may never know.

Here's the PR where it was added in a few years ago: https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/314

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
n/a

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Pull down and run to make sure `FS` doesn't show up in the dropdown anymore.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
