### PR TITLE
Health home text changes

### DIFF
--- a/services/ui-src/src/views/AddHHCoreSet/index.test.tsx
+++ b/services/ui-src/src/views/AddHHCoreSet/index.test.tsx
@@ -32,7 +32,9 @@ describe("Test HealthHome coreset component", () => {
 
   it("renders the correct child components", () => {
     expect(
-      screen.getByLabelText(/Select the SPA you are reporting on/i)
+      screen.getByLabelText(
+        /Select the Health Home program you are reporting on/i
+      )
     ).toBeInTheDocument();
 
     expect(

--- a/services/ui-src/src/views/AddHHCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddHHCoreSet/index.tsx
@@ -93,7 +93,7 @@ export const AddHHCoreSet = () => {
           <CUI.Text>
             Complete the details below and when finished create the additional
             Health Home Core Set package. You can submit one Health Home Core
-            set for each SPA that requires reporting.
+            set for each Health Home program that requires reporting.
           </CUI.Text>
           <FormProvider {...methods}>
             <form onSubmit={methods.handleSubmit(handleSubmit)}>
@@ -111,7 +111,7 @@ export const AddHHCoreSet = () => {
                       formLabelProps={{ fontWeight: 600 }}
                       {...register("HealthHomeCoreSet-SPA")}
                       options={sortedSPAs}
-                      label="Select the SPA you are reporting on?"
+                      label="Select the Health Home program you are reporting on"
                     />
                   </CUI.ListItem>
                   <CUI.ListItem>


### PR DESCRIPTION
### Description
https://qmacbis.atlassian.net/jira/software/c/projects/MDCT/boards/232?modal=detail&selectedIssue=MDCT-2553

"We would like to request a change in language for the Health Home landing page when a user goes to add a Core Set. Please replace the word SPA with "Health Home program" Please also remove the question mark so that the field reads: "Select the Health Home program you are reporting on."

Replace SPA on this page with Health Home program.
Remove ? mark after “on” 


### Updates:
<img width="1267" alt="Screenshot 2023-06-01 at 10 16 04 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/14514294/79473c5b-65b9-4ed0-b135-ae956578134b">

---
### How to test
1. Create a health home set and view landing page



