### PR TITLE
Remove Health Home Core Sets for CA, DE, OK in 2023- Mdct 2471

### DIFF
--- a/services/ui-src/src/views/StateHome/__tests__/AddCoreSetCards.test.tsx
+++ b/services/ui-src/src/views/StateHome/__tests__/AddCoreSetCards.test.tsx
@@ -5,7 +5,10 @@ import { AddCoreSetCards } from "../AddCoreSetCards";
 beforeEach(() => {
   render(
     <RouterWrappedComp>
-      <AddCoreSetCards />
+      <AddCoreSetCards
+        childCoreSetExists={true}
+        healthHomesCoreSetExists={true}
+      />
     </RouterWrappedComp>
   );
 });

--- a/services/ui-src/src/views/StateHome/__tests__/index.test.tsx
+++ b/services/ui-src/src/views/StateHome/__tests__/index.test.tsx
@@ -73,3 +73,24 @@ describe("Test StateHome accessibility", () => {
     expect(results).toHaveNoViolations();
   });
 });
+
+describe("Test 2023 state without health home core sets", () => {
+  jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useParams: jest.fn().mockReturnValue({
+      year: "2023",
+      state: "CA",
+    }),
+    useNavigate: () => mockedNavigate,
+  }));
+
+  beforeEach(() => {
+    useApiMock({});
+    render(testComponent);
+  });
+  test("Should not render health home core sets for CA", () => {
+    expect(
+      screen.queryByText(/Need to report on Health home data/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -221,8 +221,6 @@ const StateHome = () => {
 
   const selectedStates = ["CA", "DE", "OK"];
   const hideHealthHome = year === "2023" && selectedStates.includes(userState);
-  console.log(userState, "state");
-  console.log(hideHealthHome, "hideHealthHome");
 
   return (
     <QMR.StateLayout

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -219,6 +219,11 @@ const StateHome = () => {
     )
   );
 
+  const selectedStates = ["CA", "DE", "OK"];
+  const hideHealthHome = year === "2023" && selectedStates.includes(userState);
+  console.log(userState, "state");
+  console.log(hideHealthHome, "hideHealthHome");
+
   return (
     <QMR.StateLayout
       breadcrumbItems={[
@@ -242,7 +247,7 @@ const StateHome = () => {
         <AddCoreSetCards
           childCoreSetExists={childCoreSetExists}
           healthHomesCoreSetExists={allPossibleHealthHomeCoreSetsExist}
-          renderHealthHomeCoreSet={!!spaIds?.length}
+          renderHealthHomeCoreSet={!hideHealthHome && !!spaIds?.length}
         />
       </CUI.HStack>
     </QMR.StateLayout>

--- a/tests/cypress/support/commands/commands.ts
+++ b/tests/cypress/support/commands/commands.ts
@@ -32,8 +32,8 @@ Cypress.Commands.add(
       stateuser1: Cypress.env("TEST_USER_1"),
     };
     cy.visit("/");
-    cy.xpath(emailForCognito).type(`${users[user]}`);
-    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
+    cy.xpath(emailForCognito).type("stateuser3@test.com");
+    cy.xpath(passwordForCognito).type("R*ezKG4HAAvU");
     cy.get('[data-cy="login-with-cognito-button"]').click();
   }
 );

--- a/tests/cypress/support/commands/commands.ts
+++ b/tests/cypress/support/commands/commands.ts
@@ -32,8 +32,8 @@ Cypress.Commands.add(
       stateuser1: Cypress.env("TEST_USER_1"),
     };
     cy.visit("/");
-    cy.xpath(emailForCognito).type("stateuser3@test.com");
-    cy.xpath(passwordForCognito).type("R*ezKG4HAAvU");
+    cy.xpath(emailForCognito).type(`${users[user]}`);
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
     cy.get('[data-cy="login-with-cognito-button"]').click();
   }
 );


### PR DESCRIPTION
### Description
removing the ability to add Home health Core Sets for FFY 23 for states CA, DE, and OK.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2471

---
### How to test
Log in as stateuser[STATE]@test.com (e.g.: stateuserCA@test.com) and see that in 2021 and 2022 you have the Health Home call to action and in 2023 it is gone. Login as a user not from CA, DE or OK (stateuserME has Home Health) and see that you still have the HH call to action in all reporting years.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
