### PR TITLE
Fix IETRate for IET-HH

### DIFF
--- a/services/ui-src/src/components/IETRate/index.test.tsx
+++ b/services/ui-src/src/components/IETRate/index.test.tsx
@@ -37,6 +37,51 @@ const TestComponent2 = () => {
   return <IETRate rates={rates} name="test-component" readOnly={false} />;
 };
 
+const categories = [
+  {
+    label: "cat1: cat",
+    text: "cat1: cat",
+    id: "cat1-id",
+  },
+  {
+    label: "cat1: Total",
+    text: "cat1: Total",
+    id: "cat1-total",
+  },
+];
+
+const qualifiers = [
+  {
+    label: "qual1",
+    text: "qual1",
+    id: "qual1-id",
+  },
+  {
+    label: "qual2",
+    text: "qual2",
+    id: "qual2-id",
+  },
+];
+
+const TextComponentCategory = () => {
+  let rates = qualifiers?.map((qual, idx) => ({
+    label: qual.label,
+    uid: categories[0].id + "." + qual.id,
+    id: idx,
+  }));
+
+  return (
+    <IETRate
+      rates={rates}
+      categories={categories}
+      categoryName="cat1: cat"
+      name="test-component"
+      readOnly={false}
+      calcTotal={true}
+    />
+  );
+};
+
 describe("Test the IETRate component", () => {
   beforeEach(() => {
     renderWithHookForm(<TestComponent />, {
@@ -84,6 +129,44 @@ describe("Test the IETRate component", () => {
     fireEvent.type(rateTextBox, "4321");
 
     expect(rateTextBox).toHaveDisplayValue("1");
+  });
+});
+
+describe("Test rate component by category", () => {
+  beforeEach(() => {
+    let allRates: any = {};
+    let defaultValues: any = { PerformanceMeasure: { rates: "" } };
+
+    categories.forEach((cat) => {
+      let rates: any[] = [];
+      qualifiers.forEach((qual, index) => {
+        let rate = {
+          id: index,
+          label: qual.label,
+          denominator: "",
+          numerator: "",
+          rate: "",
+          uid: cat.id + "." + qual.id,
+          isTotal: cat.label.includes("Total"),
+        };
+
+        rates.push(rate);
+      });
+
+      defaultValues[cat.id] = rates;
+      allRates[cat.id] = rates;
+      defaultValues.PerformanceMeasure.rates = allRates;
+    });
+
+    renderWithHookForm(<TextComponentCategory />, {
+      defaultValues: defaultValues,
+    });
+  });
+
+  test("Check that calculateTotalCategory had run", () => {
+    let numerator = screen.getAllByLabelText(/numerator/i)[0];
+    fireEvent.type(numerator, "43");
+    expect(numerator).toHaveValue("43");
   });
 });
 

--- a/services/ui-src/src/components/IETRate/index.test.tsx
+++ b/services/ui-src/src/components/IETRate/index.test.tsx
@@ -15,6 +15,7 @@ const TestComponent = () => {
       numerator: "",
       rate: "",
       id: 1,
+      uid: "test",
     },
   ];
 
@@ -29,6 +30,7 @@ const TestComponent2 = () => {
       numerator: "",
       rate: "",
       id: 1,
+      uid: "test",
     },
   ];
 
@@ -116,6 +118,7 @@ const TestComponentWithTotal = () => {
       numerator: "",
       rate: "",
       id: 1,
+      uid: "test1",
     },
     {
       label: "test2",
@@ -123,6 +126,7 @@ const TestComponentWithTotal = () => {
       numerator: "",
       rate: "",
       id: 2,
+      uid: "test2",
     },
     {
       label: "total",
@@ -131,6 +135,7 @@ const TestComponentWithTotal = () => {
       rate: "",
       id: 3,
       isTotal: true,
+      uid: "Total",
     },
   ];
 


### PR DESCRIPTION
### Description
Missed a part during original ticket, IET-HH needed an extra set of calculations for the qualifiers. It needed to do a total calculation per qualifier set and as well as within the category type.
<img width="1306" alt="Screenshot 2023-06-09 at 4 11 03 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/4fe7a73a-4a9b-4d47-b8e5-aca6a6882076">
---

<img width="1333" alt="Screenshot 2023-06-09 at 4 11 21 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/f9009119-007d-4b97-a4ad-33ee27588d0d">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2452

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Login to a user with Health Home access (e.g. [stateuserWA@test.com](mailto:stateuserDC@test.com) )
2) Go to IET-HH measures
3) Trigger the performance measure section. (Selecting the first radio button for the first three questions)
4) Enter value in the N/D/R 
5) It should two sets of calculation, the "Total (age 13 and older)" qualifier in that category should update & either Initiation of SUD Treatment: Total OR Engagement of SUD Treatment: Total qualifiers will update depending on the category your value was entered in

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
