### PR TITLE
Removed Hedis Validation From Non Hedis Measures

### DIFF
--- a/services/ui-src/src/measures/2023/CPAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CPAAD/validation.ts
@@ -1,12 +1,10 @@
 import { FormData } from "./types";
 import { validateReasonForNotReporting } from "measures/2023/shared/globalValidations";
-import * as GV from "measures/2023/shared/globalValidations";
 import * as DC from "dataConstants";
 
 const CPAADValidation = (data: FormData) => {
   let errorArray: any[] = [];
   const whyDidYouNotCollect = data["WhyDidYouNotCollect"];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data["DidCollect"] === undefined) {
     errorArray.push({
@@ -20,8 +18,6 @@ const CPAADValidation = (data: FormData) => {
     errorArray = [...validateReasonForNotReporting(whyDidYouNotCollect, true)];
     return errorArray;
   }
-
-  errorArray = [...errorArray, ...GV.validateHedisYear(measureSpecifications)];
 
   return errorArray;
 };

--- a/services/ui-src/src/measures/2023/CPCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CPCCH/validation.ts
@@ -1,12 +1,10 @@
 import { FormData } from "./types";
 import { validateReasonForNotReporting } from "measures/2023/shared/globalValidations";
-import * as GV from "measures/2023/shared/globalValidations";
 import * as DC from "dataConstants";
 
 const CPCCHValidation = (data: FormData) => {
   let errorArray: any[] = [];
   const whyDidYouNotCollect = data["WhyDidYouNotCollect"];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data["DidCollect"] === undefined) {
     errorArray.push({
@@ -20,8 +18,6 @@ const CPCCHValidation = (data: FormData) => {
     errorArray = [...validateReasonForNotReporting(whyDidYouNotCollect, true)];
     return errorArray;
   }
-
-  errorArray = [...errorArray, ...GV.validateHedisYear(measureSpecifications)];
 
   return errorArray;
 };

--- a/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
@@ -14,7 +14,6 @@ const HPCMIADValidation = (data: FormData) => {
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -47,7 +46,6 @@ const HPCMIADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/IUHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IUHH/validation.ts
@@ -37,7 +37,6 @@ const IUHHValidation = (data: FormData) => {
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   OPM = data[DC.OPM_RATES];
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data[DC.DID_REPORT] === DC.NO) {
     errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
@@ -50,7 +49,6 @@ const IUHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
     ...GV.validateOPMRates(OPM),
     ...GV.ComplexValidateDualPopInformation(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/SSDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SSDAD/validation.ts
@@ -12,6 +12,7 @@ const SSDValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
+  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -54,6 +55,7 @@ const SSDValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateHedisYear(measureSpecifications),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/W30CH/validation.ts
+++ b/services/ui-src/src/measures/2023/W30CH/validation.ts
@@ -13,6 +13,7 @@ const W30CHValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
+  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data[DC.DID_REPORT] === DC.NO) {
     errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
@@ -52,6 +53,7 @@ const W30CHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateHedisYear(measureSpecifications),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/WCCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCCCH/validation.ts
@@ -11,6 +11,7 @@ const WCCHValidation = (data: FormData) => {
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
+  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -39,6 +40,7 @@ const WCCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateHedisYear(measureSpecifications),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/WCVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCVCH/validation.ts
@@ -13,6 +13,7 @@ const WCVCHValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
+  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -59,6 +60,7 @@ const WCVCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateHedisYear(measureSpecifications),
     ...GV.validateOPMRates(OPM),
     ...GV.validateTotalNDR(performanceMeasureArray),
   ];


### PR DESCRIPTION
### Description
IU-HH & HPCMI-AD have a hedis validation check despite not collecting hedis as information. 


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2619

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR w/ an account that has HH (ex. [stateuserWA@test.com](mailto:stateuserDC@test.com))
2) Go to IU-HH measure
3) Fill out information and press validate
4) If you see "Version of HEDIS measurement year used must be specified" error message, it is broken. That error message should not popup
5) Repeat for **HPCMI-AD**

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
