### PR TITLE
Hedis Validation For Other

### DIFF
--- a/services/ui-src/src/measures/2023/AABAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AABAD/validation.ts
@@ -14,7 +14,6 @@ const AABADValidation = (data: FormData) => {
   const OPM = data[DC.OPM_RATES];
   const dateRange = data[DC.DATE_RANGE];
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data[DC.DID_REPORT] === DC.NO) {
     errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
@@ -45,7 +44,7 @@ const AABADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/AABCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AABCH/validation.ts
@@ -13,7 +13,6 @@ const AABCHValidation = (data: FormData) => {
   const deviationReason = data[DC.DEVIATION_REASON];
 
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -25,7 +24,7 @@ const AABCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/ADDCH/validation.ts
+++ b/services/ui-src/src/measures/2023/ADDCH/validation.ts
@@ -13,7 +13,6 @@ const ADDCHValidation = (data: FormData) => {
   const OPM = data[DC.OPM_RATES];
   const dateRange = data[DC.DATE_RANGE];
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data[DC.DID_REPORT] === DC.NO) {
     errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
@@ -42,7 +41,7 @@ const ADDCHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/AMBCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBCH/validation.ts
@@ -12,7 +12,6 @@ const AMBCHValidation = (data: FormData) => {
   const OPM = data[DC.OPM_RATES];
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -29,7 +28,7 @@ const AMBCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/AMBHH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBHH/validation.ts
@@ -12,7 +12,6 @@ const AMBHHValidation = (data: FormData) => {
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
   const dateRange = data[DC.DATE_RANGE];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   let errorArray: any[] = [];
@@ -35,7 +34,7 @@ const AMBHHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/AMMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMMAD/validation.ts
@@ -52,7 +52,6 @@ const AMMADValidation = (data: FormData) => {
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const dateRange = data[DC.DATE_RANGE];
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -108,7 +107,7 @@ const AMMADValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/AMRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRAD/validation.ts
@@ -12,7 +12,6 @@ const AMRADValidation = (data: FormData) => {
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -29,7 +28,7 @@ const AMRADValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/AMRCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRCH/validation.ts
@@ -12,7 +12,6 @@ const AMRCHValidation = (data: FormData) => {
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -29,7 +28,7 @@ const AMRCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/APMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APMCH/validation.ts
@@ -11,7 +11,6 @@ const APMCHValidation = (data: FormData) => {
   const OPM = data[DC.OPM_RATES];
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -58,7 +57,7 @@ const APMCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/APPCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APPCH/validation.ts
@@ -9,7 +9,6 @@ const APPCHValidation = (data: FormData) => {
   const OPM = data[DC.OPM_RATES];
   const dateRange = data[DC.DATE_RANGE];
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
 
@@ -42,7 +41,7 @@ const APPCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/BCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/BCSAD/validation.ts
@@ -14,7 +14,6 @@ const BCSValidation = (data: FormData) => {
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -63,7 +62,7 @@ const BCSValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/CBPAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPAD/validation.ts
@@ -14,7 +14,6 @@ const CBPValidation = (data: FormData) => {
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const dateRange = data[DC.DATE_RANGE];
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -47,7 +46,7 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CBPHH/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPHH/validation.ts
@@ -13,7 +13,6 @@ const CBPValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -47,7 +46,7 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateTotalNDR(performanceMeasureArray),
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/CCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCSAD/validation.ts
@@ -13,7 +13,6 @@ const CCSADValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -60,7 +59,7 @@ const CCSADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
   ];
 

--- a/services/ui-src/src/measures/2023/CHLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLAD/validation.ts
@@ -12,7 +12,6 @@ const CHLValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -39,7 +38,7 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CHLCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLCH/validation.ts
@@ -12,7 +12,6 @@ const CHLValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -39,7 +38,7 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CISCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CISCH/validation.ts
@@ -13,7 +13,6 @@ const CISCHValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -65,7 +64,7 @@ const CISCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
   ];
 

--- a/services/ui-src/src/measures/2023/COLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/COLAD/validation.ts
@@ -15,7 +15,6 @@ const COLADValidation = (data: FormData) => {
   const errorReplacementText = "Ages 65 to 75";
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -49,7 +48,7 @@ const COLADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/COLHH/validation.ts
+++ b/services/ui-src/src/measures/2023/COLHH/validation.ts
@@ -15,7 +15,6 @@ const COLHHValidation = (data: FormData) => {
   const errorReplacementText = "Ages 65 to 75";
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -49,7 +48,7 @@ const COLHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CPAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CPAAD/validation.ts
@@ -6,7 +6,6 @@ import * as DC from "dataConstants";
 const CPAADValidation = (data: FormData) => {
   let errorArray: any[] = [];
   const whyDidYouNotCollect = data["WhyDidYouNotCollect"];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data["DidCollect"] === undefined) {
     errorArray.push({
@@ -21,7 +20,7 @@ const CPAADValidation = (data: FormData) => {
     return errorArray;
   }
 
-  errorArray = [...errorArray, ...GV.validateHedisYear(measureSpecifications)];
+  errorArray = [...errorArray, ...GV.validateHedisYear(data)];
 
   return errorArray;
 };

--- a/services/ui-src/src/measures/2023/CPCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CPCCH/validation.ts
@@ -6,7 +6,6 @@ import * as DC from "dataConstants";
 const CPCCHValidation = (data: FormData) => {
   let errorArray: any[] = [];
   const whyDidYouNotCollect = data["WhyDidYouNotCollect"];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data["DidCollect"] === undefined) {
     errorArray.push({
@@ -21,7 +20,7 @@ const CPCCHValidation = (data: FormData) => {
     return errorArray;
   }
 
-  errorArray = [...errorArray, ...GV.validateHedisYear(measureSpecifications)];
+  errorArray = [...errorArray, ...GV.validateHedisYear(data)];
 
   return errorArray;
 };

--- a/services/ui-src/src/measures/2023/CPUAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CPUAD/validation.ts
@@ -8,7 +8,6 @@ const CPUADValidation = (data: FormData) => {
   const carePlans = PMD.qualifiers;
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   const OPM = data[DC.OPM_RATES];
@@ -40,7 +39,7 @@ const CPUADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
 

--- a/services/ui-src/src/measures/2023/FUAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAAD/validation.ts
@@ -14,7 +14,6 @@ const FUAADValidation = (data: FormData) => {
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -52,7 +51,7 @@ const FUAADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/FUACH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUACH/validation.ts
@@ -13,7 +13,6 @@ const FUACHValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data[DC.DID_REPORT] === DC.NO) {
     return [...GV.validateReasonForNotReporting(whyNotReporting)];
@@ -40,7 +39,7 @@ const FUACHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/FUAHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAHH/validation.ts
@@ -14,7 +14,6 @@ const FUAHHValidation = (data: FormData) => {
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const sixtyDaysIndex = 2;
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -33,7 +32,7 @@ const FUAHHValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/FUHAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHAD/validation.ts
@@ -13,7 +13,6 @@ const FUHValidation = (data: FormData) => {
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -65,7 +64,7 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),

--- a/services/ui-src/src/measures/2023/FUHCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHCH/validation.ts
@@ -12,7 +12,6 @@ const FUHValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -58,7 +57,7 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2023/FUHHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHHH/validation.ts
@@ -14,7 +14,6 @@ const FUHHHValidation = (data: FormData) => {
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const sixtyDaysIndex = 2;
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -33,7 +32,7 @@ const FUHHHValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/FUMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMAD/validation.ts
@@ -14,7 +14,6 @@ const FUMADValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data["DidReport"] === DC.NO) {
@@ -56,7 +55,7 @@ const FUMADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD.data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),

--- a/services/ui-src/src/measures/2023/FUMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMCH/validation.ts
@@ -12,7 +12,6 @@ const FUMCHValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -57,7 +56,7 @@ const FUMCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2023/FUMHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMHH/validation.ts
@@ -13,7 +13,6 @@ const FUMHHValidation = (data: FormData) => {
   const OPM = data[DC.OPM_RATES];
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
 
@@ -35,7 +34,7 @@ const FUMHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
 
     // Performance Measure Validations

--- a/services/ui-src/src/measures/2023/FVAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FVAAD/validation.ts
@@ -13,7 +13,6 @@ const FVAADValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data[DC.DID_REPORT] === DC.NO) {
     errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
@@ -40,7 +39,7 @@ const FVAADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/HBDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HBDAD/validation.ts
@@ -21,7 +21,6 @@ const HBDADValidation = (data: FormData) => {
     return errorArray;
   }
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   errorArray = [
     ...errorArray,
@@ -69,7 +68,7 @@ const HBDADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
   ];
 

--- a/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
@@ -14,7 +14,6 @@ const HPCMIADValidation = (data: FormData) => {
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -47,7 +46,6 @@ const HPCMIADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/IETAD/validation.ts
+++ b/services/ui-src/src/measures/2023/IETAD/validation.ts
@@ -54,7 +54,6 @@ const IETValidation = (data: FormData) => {
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   const locationDictionary = GV.omsLocationDictionary(
     OMSData(true),
@@ -136,7 +135,7 @@ const IETValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/IETHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IETHH/validation.ts
@@ -56,7 +56,6 @@ const IETValidation = (data: FormData) => {
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   const locationDictionary = GV.omsLocationDictionary(
     OMSData(true),
@@ -139,7 +138,7 @@ const IETValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/IMACH/validation.ts
+++ b/services/ui-src/src/measures/2023/IMACH/validation.ts
@@ -12,7 +12,6 @@ const DEVCHValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -48,7 +47,7 @@ const DEVCHValidation = (data: FormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/IUHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IUHH/validation.ts
@@ -37,7 +37,6 @@ const IUHHValidation = (data: FormData) => {
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   OPM = data[DC.OPM_RATES];
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data[DC.DID_REPORT] === DC.NO) {
     errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
@@ -50,7 +49,6 @@ const IUHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
     ...GV.validateOPMRates(OPM),
     ...GV.ComplexValidateDualPopInformation(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/LSCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/LSCCH/validation.ts
@@ -12,7 +12,6 @@ const LSCCHValidation = (data: FormData) => {
   const OPM = data[DC.OPM_RATES];
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -23,7 +22,7 @@ const LSCCHValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/MSCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/MSCAD/validation.ts
@@ -14,7 +14,6 @@ const MSCADValidation = (data: Types.DefaultFormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -43,7 +42,7 @@ const MSCADValidation = (data: Types.DefaultFormData) => {
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),

--- a/services/ui-src/src/measures/2023/PCRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRAD/validation.ts
@@ -36,7 +36,6 @@ const PCRADValidation = (data: FormData) => {
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const OPM = data[DC.OPM_RATES];
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data[DC.DID_REPORT] === DC.NO) {
     errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
@@ -48,7 +47,7 @@ const PCRADValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2023/PCRHH/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRHH/validation.ts
@@ -36,7 +36,6 @@ const PCRHHValidation = (data: FormData) => {
   const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
   const OPM = data[DC.OPM_RATES];
   const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (data[DC.DID_REPORT] === DC.NO) {
     errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
@@ -50,7 +49,7 @@ const PCRHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     // Performance Measure Validations
     ...GV.PCRatLeastOneRateComplete(performanceMeasureArray, OPM, ageGroups),

--- a/services/ui-src/src/measures/2023/PPCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCAD/validation.ts
@@ -13,7 +13,6 @@ const PPCADValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -60,7 +59,7 @@ const PPCADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
   ];
 

--- a/services/ui-src/src/measures/2023/PPCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCCH/validation.ts
@@ -13,7 +13,6 @@ const PPCCHValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -60,7 +59,7 @@ const PPCCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
   ];
 

--- a/services/ui-src/src/measures/2023/SAAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SAAAD/validation.ts
@@ -12,7 +12,6 @@ const SAAADValidation = (data: FormData) => {
   const dateRange = data[DC.DATE_RANGE];
   const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
   const deviationReason = data[DC.DEVIATION_REASON];
-  const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {
@@ -56,7 +55,7 @@ const SAAADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(measureSpecifications),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/SSDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SSDAD/validation.ts
@@ -54,6 +54,7 @@ const SSDValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/W30CH/validation.ts
+++ b/services/ui-src/src/measures/2023/W30CH/validation.ts
@@ -52,6 +52,7 @@ const W30CHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/WCCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCCCH/validation.ts
@@ -39,6 +39,7 @@ const WCCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/WCVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCVCH/validation.ts
@@ -59,6 +59,7 @@ const WCVCHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateTotalNDR(performanceMeasureArray),
   ];

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateHedisYear/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateHedisYear/index.test.ts
@@ -6,8 +6,7 @@ describe("Hedis Year Validation - FY 2023", () => {
   let formData: any;
 
   const run_validation = (data: any): FormError[] => {
-    const measureSpecifications = data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
-    return [...validateHedisYear(measureSpecifications)];
+    return [...validateHedisYear(data)];
   };
 
   beforeEach(() => {
@@ -31,5 +30,11 @@ describe("Hedis Year Validation - FY 2023", () => {
     formData[DC.MEASUREMENT_SPECIFICATION_HEDIS] = "";
     const errorArray = run_validation(formData);
     expect(errorArray.length).toBe(1);
+  });
+
+  it("Should show no error when measure specification is other", () => {
+    formData[DC.MEASUREMENT_SPECIFICATION] = "Other";
+    const errorArray = run_validation(formData);
+    expect(errorArray.length).toBe(0);
   });
 });

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateHedisYear/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateHedisYear/index.ts
@@ -1,12 +1,19 @@
+import * as Types from "measures/2023/shared/CommonQuestions/types";
+import * as DC from "dataConstants";
+
 export const validateHedisYear = (
-  measurementSpecificationHedis: string,
+  data: Types.MeasurementSpecification,
   errorMessage?: string
 ) => {
   const errorArray: FormError[] = [];
+  const measurementSpecification: string = data[DC.MEASUREMENT_SPECIFICATION];
+  const measurementSpecificationHedis: string =
+    data[DC.MEASUREMENT_SPECIFICATION_HEDIS];
 
   if (
     measurementSpecificationHedis === "" ||
-    measurementSpecificationHedis === undefined
+    (measurementSpecificationHedis === undefined &&
+      measurementSpecification !== "Other")
   ) {
     errorArray.push({
       errorLocation: "Measure Specification",


### PR DESCRIPTION
### Description
For measures with Hedis validation, it is not capturing the option of "Other" which causes the validation to fail even though the user has selected an option.

<img width="1349" alt="Screenshot 2023-06-13 at 12 31 33 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/a8cdac94-298e-4eb7-b0aa-2a1d8321187f">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2621

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account.
2) Pick a measure that captures Hedis Year (i.e. AAB-AD )
3) Validate measure, one of the errors should be: 
<img width="1250" alt="Screenshot 2023-06-13 at 12 34 21 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/e064ed28-2790-41a7-9bf3-b2d1fc749a7d">

4) Go back to Measure Specification, select the radio button **Other**
5) Validate measure again and the error should be gone now.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
