### PR TITLE
Content Changes to HH - SPA replacement

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/CombinedRates/index.test.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/CombinedRates/index.test.tsx
@@ -98,24 +98,24 @@ describe("Test CombinedRates component for Health Homes", () => {
   it("component renders with different text", () => {
     expect(
       screen.getByText(
-        "Did you combine rates from multiple reporting units (e.g. Health Home Providers) to create a Health Home SPA-Level rate?"
+        "Did you combine rates from multiple reporting units (e.g. Health Home Providers) to create a Health Home Program-Level rate?"
       )
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Did you combine rates from multiple reporting units (e.g. Health Home Providers) to create a Health Home SPA-Level rate?"
+        "Did you combine rates from multiple reporting units (e.g. Health Home Providers) to create a Health Home Program-Level rate?"
       )
     ).toBeInTheDocument();
   });
 
   it("renders suboptions when Yes is clicked", async () => {
     const textArea = await screen.findByLabelText(
-      "Yes, we combined rates from multiple reporting units to create a Health Home SPA-Level rate."
+      "Yes, we combined rates from multiple reporting units to create a Health Home Program-Level rate."
     );
     fireEvent.click(textArea);
     expect(
       screen.getByText(
-        "The rates are not weighted based on the size of the measure-eligible population. All reporting units are given equal weights when calculating a SPA-Level rate."
+        "The rates are not weighted based on the size of the measure-eligible population. All reporting units are given equal weights when calculating a Program-Level rate."
       )
     ).toBeInTheDocument();
     expect(
@@ -133,7 +133,7 @@ describe("Test CombinedRates component for Health Homes", () => {
   it("renders a text area when Yes is clicked and the last option is clicked for Health Homes", async () => {
     fireEvent.click(
       await screen.findByLabelText(
-        "Yes, we combined rates from multiple reporting units to create a Health Home SPA-Level rate."
+        "Yes, we combined rates from multiple reporting units to create a Health Home Program-Level rate."
       )
     );
     fireEvent.click(
@@ -156,12 +156,12 @@ describe("Test CombinedRates component for Health Homes", () => {
 
   it("does not render suboptions when No is clicked", async () => {
     const textArea = await screen.findByLabelText(
-      "No, we did not combine rates from multiple reporting units to create a SPA-Level rate for Health Home measures."
+      "No, we did not combine rates from multiple reporting units to create a Program-Level rate for Health Home measures."
     );
     fireEvent.click(textArea);
     expect(
       screen.queryByText(
-        "The rates are not weighted based on the size of the measure-eligible population. All reporting units are given equal weights when calculating a SPA-Level rate."
+        "The rates are not weighted based on the size of the measure-eligible population. All reporting units are given equal weights when calculating a Program-Level rate."
       )
     ).toBeNull();
     expect(

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/CombinedRates/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/CombinedRates/index.tsx
@@ -25,7 +25,7 @@ export const CombinedRates = ({ healthHomeMeasure }: Props) => {
         ) : (
           <>
             Did you combine rates from multiple reporting units (e.g. Health
-            Home Providers) to create a Health Home SPA-Level rate?
+            Home Providers) to create a Health Home Program-Level rate?
           </>
         )}
       </CUI.Text>
@@ -46,7 +46,7 @@ export const CombinedRates = ({ healthHomeMeasure }: Props) => {
           {
             displayValue: !healthHomeMeasure
               ? "Yes, we combined rates from multiple reporting units to create a State-Level rate."
-              : "Yes, we combined rates from multiple reporting units to create a Health Home SPA-Level rate.",
+              : "Yes, we combined rates from multiple reporting units to create a Health Home Program-Level rate.",
             value: DC.YES,
             children: [
               <QMR.RadioButton
@@ -55,7 +55,7 @@ export const CombinedRates = ({ healthHomeMeasure }: Props) => {
                   {
                     displayValue: !healthHomeMeasure
                       ? "The rates are not weighted based on the size of the measure-eligible population. All reporting units are given equal weights when calculating a State-Level rate."
-                      : "The rates are not weighted based on the size of the measure-eligible population. All reporting units are given equal weights when calculating a SPA-Level rate.",
+                      : "The rates are not weighted based on the size of the measure-eligible population. All reporting units are given equal weights when calculating a Program-Level rate.",
                     value: DC.COMBINED_NOT_WEIGHTED_RATES,
                   },
                   {
@@ -84,7 +84,7 @@ export const CombinedRates = ({ healthHomeMeasure }: Props) => {
           {
             displayValue: !healthHomeMeasure
               ? "No, we did not combine rates from multiple reporting units to create a State-Level rate."
-              : "No, we did not combine rates from multiple reporting units to create a SPA-Level rate for Health Home measures.",
+              : "No, we did not combine rates from multiple reporting units to create a Program-Level rate for Health Home measures.",
             value: DC.NO,
           },
         ]}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Replacing instances of SPA-Level to Program-Level, only in FFY 2023

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2616

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login: [(https://d1em988qnw7xrm.cloudfront.net/)]
- Add a Health home set in FFY 2023
- Pick a measure, scroll down to "Combined Rate(s) from Multiple Reporting Units"
- Confirm that "SPA-Level" is now "Program-Level"

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
