### PR TITLE
Combined Rates Validation Flag

### DIFF
--- a/services/ui-src/src/measures/2023/AABCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AABCH/index.test.tsx
@@ -177,6 +177,9 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(
+      V.validateRequiredRadioButtonForCombinedRates
+    ).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -194,6 +197,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateRequiredRadioButtonForCombinedRates).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AABCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AABCH/validation.ts
@@ -45,6 +45,7 @@ const AABCHValidation = (data: FormData) => {
       OPM,
       PMD.qualifiers
     ),
+    ...GV.validateRequiredRadioButtonForCombinedRates(data),
 
     // OMS Validations
     ...GV.omsValidations({


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adding a validation flag to AAB-CH if a user does not select one of the indented buttons after selecting "Yes, we combined rates from multiple reporting units to create a State-Level rate."

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2622

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Add a child core set in 2023 and navigate to AAB-CH
- Under the section "Combined Rate(s) from Multiple Reporting Units" click "Yes, we combined rates from multiple reporting units to create a State-Level Rate" but *do not click* any of the sub options
- Click "Validate measure" and confirm that the Combined Rate(s) Error shows up

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
