### PR TITLE
Bug Fix: IU-HH Validation

### DIFF
--- a/services/ui-src/src/measures/2023/shared/globalValidations/ComplexValidations/ComplexValueSameCrossCategory/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/ComplexValidations/ComplexValueSameCrossCategory/index.tsx
@@ -37,7 +37,6 @@ export const ComplexValueSameCrossCategoryOMS = (
     }
   }
 
-  // if (performanceMeasureArray)
   let errorArray: any[] = ComplexValueSameCrossCategory({
     rateData: performanceMeasureArray,
     OPM: undefined,
@@ -78,7 +77,7 @@ export const ComplexValueSameCrossCategory = ({
     } = {};
     for (const category of rateData) {
       for (const qualifier of category.slice(0, -1)) {
-        const cleanQual = qualifier.id;
+        const cleanQual = qualifier.uid.split(".")[1];
         if (tempValues[cleanQual]?.value) {
           if (
             qualifier.fields[fieldIndex]?.value &&


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
In IU-HH, the validation for comparing the number of enrollee months, which should be the same value across categories, is firing no matter if the value is the same or not. The error keeps showing **Value of "Number of Enrollee Months" in Ages 0 to 17 must be the same across all measurement categories.**, despite it being 0 to 17

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2620

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, use an account that shows HH ([stateuserWA@test.com](mailto:stateuserDC@test.com))
2) Add Health Home measures
3) Go to IU-HH
4) Under Measure Specification section, select the first radio button
5) In Performance Measure, enter values into the N / D / R sets. The Number of Enrollee Months if different across categories should trigger the correct error per qualifier. 
- All ages 0 to 17 qualifiers should have the same Number of Enrollee Months or there will be a validation error
- Same applies for ages 18 to 64, age 65 and older & ages unknown

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
