### PR TITLE
text change

### DIFF
--- a/services/ui-src/src/views/AddChildCoreSet/index.test.tsx
+++ b/services/ui-src/src/views/AddChildCoreSet/index.test.tsx
@@ -38,13 +38,13 @@ describe("Test Add Child Core Set Component", () => {
   it("Form properly interactable", () => {
     userEvent.click(
       screen.getByText(
-        /Reporting Medicaid and CHIP measures in separate core sets/i
+        /Reporting Medicaid and CHIP measures in separate Core Sets/i
       )
     );
 
     expect(
       screen.getByLabelText(
-        /Reporting Medicaid and CHIP measures in separate core sets/i
+        /Reporting Medicaid and CHIP measures in separate Core Sets/i
       )
     ).toBeChecked();
   });

--- a/services/ui-src/src/views/AddChildCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddChildCoreSet/index.tsx
@@ -92,12 +92,12 @@ export const AddChildCoreSet = () => {
                   options={[
                     {
                       displayValue:
-                        "Reporting Medicaid and CHIP measures in separate Core sets",
+                        "Reporting Medicaid and CHIP measures in separate Core Sets",
                       value: ReportType.SEPARATE,
                     },
                     {
                       displayValue:
-                        "Reporting Medicaid and CHIP measures in combined Core sets",
+                        "Reporting Medicaid and CHIP measures in combined Core Sets",
                       value: ReportType.COMBINED,
                     },
                   ]}


### PR DESCRIPTION
### Description
Small change to capitalize the first 'S' in 'Core Sets' in the 'Add a Child Core Set' page


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2625

---
### How to test
Login (stateuser1) and click 'Add a Child Core Set', see that the text is:

`Reporting Medicaid and CHIP measures in separate Core Sets
Reporting Medicaid and CHIP measures in combined Core Sets`


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
