### PR TITLE
Add missing validation for CPU-AD

### DIFF
--- a/services/ui-src/src/measures/2023/CPUAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CPUAD/index.test.tsx
@@ -169,6 +169,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorsLessThanDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroPM).not.toHaveBeenCalled();
     expect(V.validateRateZeroPM).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(
       V.validateRequiredRadioButtonForCombinedRates
     ).not.toHaveBeenCalled();
@@ -176,12 +178,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDataSource).not.toHaveBeenCalled();
     expect(V.validateAtLeastOneDeviationFieldFilled).not.toHaveBeenCalled();
     expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
-    expect(V.validateOneCatRateHigherThanOtherCatOMS).not.toHaveBeenCalled();
-    expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
-    expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
-    expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
-    expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -190,17 +187,14 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneRateComplete).toHaveBeenCalled();
     expect(V.validateNumeratorsLessThanDenominatorsPM).toHaveBeenCalled();
     expect(V.validateRateZeroPM).toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsPM).toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualPM).toHaveBeenCalled();
     expect(V.validateRequiredRadioButtonForCombinedRates).toHaveBeenCalled();
     expect(V.validateBothDatesCompleted).toHaveBeenCalled();
     expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
     expect(V.validateAtLeastOneDeviationFieldFilled).toHaveBeenCalled();
     expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
-    expect(V.validateOneCatRateHigherThanOtherCatOMS).not.toHaveBeenCalled();
-    expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
-    expect(V.validateRateZeroOMS).toHaveBeenCalled();
-    expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
-    expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/CPUAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CPUAD/validation.ts
@@ -2,7 +2,6 @@ import * as DC from "dataConstants";
 import * as GV from "measures/2023/shared/globalValidations";
 import * as PMD from "./data";
 import { FormData } from "./types";
-import { OMSData } from "measures/2023/shared/CommonQuestions/OptionalMeasureStrat/data";
 
 const CPUADValidation = (data: FormData) => {
   const carePlans = PMD.qualifiers;
@@ -36,6 +35,12 @@ const CPUADValidation = (data: FormData) => {
     ),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, carePlans),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, carePlans, data),
+    ...GV.validateEqualCategoryDenominatorsPM(
+      data,
+      PMD.categories,
+      PMD.qualifiers
+    ),
+    ...GV.validateOneQualRateHigherThanOtherQualPM(data, PMD),
 
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateBothDatesCompleted(dateRange),
@@ -48,23 +53,6 @@ const CPUADValidation = (data: FormData) => {
       didCalculationsDeviate,
       deviationReason
     ),
-
-    // OMS Validations
-    ...GV.omsValidations({
-      data,
-      qualifiers: PMD.qualifiers,
-      categories: PMD.categories,
-      locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
-        PMD.qualifiers,
-        PMD.categories
-      ),
-      validationCallbacks: [
-        GV.validateNumeratorLessThanDenominatorOMS(),
-        GV.validateRateZeroOMS(),
-        GV.validateRateNotZeroOMS(),
-      ],
-    }),
   ];
 
   return errorArray;


### PR DESCRIPTION
### Description
CPU-AD has two rates: plans with core documentation, and plans with supplemental documentation. These rates are talking about the same universe of plans, so the denominators should be the same. And we assume that any plan with supplemental documentation will have core documentation, so the first rate should be larger. These two facts are now part of the validation for the measure.

While I was working on this, I noticed that CPU-AD still has OMS validation in place, despite its OMS section having been recently removed. That dead code is now deleted.

### Related ticket(s)
MDCT-2624

---
### How to test
1. Open the CPU-AD measure for FFY 2023.
2. Enter a rate for Core, like 2/10
3. Enter a higher rate for Supplemental, with a different denominator. Like 4/8
4. Note the validation errors
5. Change the Supplemental rate to match denominators. Note that error goes away.
6. Change the Supplemental rate to be less than or equal to the Core rate. Note that the error goes away.

### Important updates
none

---
### Author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
