### PR TITLE
[MDCT-2442] - OMS Bugfix

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/data.ts
@@ -63,7 +63,6 @@ export const OMSData = (adultMeasure?: boolean): OmsNode[] => {
             { id: "Puerto Rican" },
             { id: "Cuban" },
             { id: "Another Hispanic, Latino/a or Spanish origin" },
-            { id: "Add Another Sub-category" },
           ],
         },
         { id: "Missing or not reported" },

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.test.ts
@@ -124,7 +124,6 @@ describe("Testing OMS validation processor", () => {
         },
       ],
     });
-    console.log(errors);
     expect(errors.length).toBe(74);
   });
 });

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.test.ts
@@ -89,7 +89,7 @@ describe("Testing OMS validation processor", () => {
       validationCallbacks: [],
     });
 
-    expect(errors.length).toBe(140);
+    expect(errors.length).toBe(136);
     expect(
       errors.some((e) =>
         e.errorMessage.includes("Must fill out at least one NDR set.")
@@ -124,7 +124,7 @@ describe("Testing OMS validation processor", () => {
         },
       ],
     });
-
-    expect(errors.length).toBe(76);
+    console.log(errors);
+    expect(errors.length).toBe(74);
   });
 });


### PR DESCRIPTION
### Description
Removed check box that said "add another subcategory". The Add Another Sub-category should be a button. Button was already added.

Previous display:
![image-20230612-210127](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/14514294/3d9c3058-6042-42cb-85e0-ebc7e616abd5)


Fixed display:
<img width="1180" alt="Screenshot 2023-06-20 at 11 58 58 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/14514294/aaaa3221-a801-4404-8149-5a3da219cbf1">


### Related ticket(s)
https://qmacbis.atlassian.net/browse/MDCT-2442
`MDCT-2442`

---
### How to test
Go to any measure and fill out form so that OMS is showing. Check the Ethnicity dropdown in the sequence shown in the screenshot. "Add another subcategory" should be shown as a button not a checkbox. 


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
