### PR TITLE
Include readable labels for Mathematica

### DIFF
--- a/services/ui-src/src/components/ComplexRate/index.test.tsx
+++ b/services/ui-src/src/components/ComplexRate/index.test.tsx
@@ -3,9 +3,14 @@ import fireEvent from "@testing-library/user-event";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { ComplexRate } from "../ComplexRate";
 import { usePathParams } from "hooks/api/usePathParams";
+import { getMeasureYear } from "../../utils/getMeasureYear";
 
 jest.mock("hooks/api/usePathParams");
 const mockUsePathParams = usePathParams as jest.Mock;
+
+jest.mock("../../utils/getMeasureYear", () => ({
+  getMeasureYear: jest.fn().mockReturnValue(2023),
+}));
 
 // Example input fields
 export const aifhhQualifiers = [
@@ -51,7 +56,7 @@ describe("Test the AIFHHRate component when readOnly is false", () => {
   beforeEach(() => {
     mockUsePathParams.mockReturnValue({
       state: "DC",
-      year: "2021",
+      year: "2023",
       coreSet: "HHCS_18-0006",
       measureId: "AIF-HH",
     });
@@ -136,7 +141,7 @@ describe("Test the IUHHRate component when readOnly is false", () => {
   beforeEach(() => {
     mockUsePathParams.mockReturnValue({
       state: "DC",
-      year: "2021",
+      year: "2023",
       coreSet: "HHCS_18-0006",
       measureId: "IU-HH",
     });
@@ -180,5 +185,30 @@ describe("Test the IUHHRate component when readOnly is false", () => {
       expect(denominator).toHaveDisplayValue([expectedValues[i].denom]);
       expect(rate).toHaveDisplayValue([expectedValues[i].rate]);
     });
+  });
+});
+
+describe("Rates should have correct properties", () => {
+  beforeEach(() => {
+    mockUsePathParams.mockReturnValue({
+      state: "DC",
+      year: "2023",
+      coreSet: "HHCS_18-0006",
+      measureId: "AIF-HH",
+    });
+    renderWithHookForm(
+      <ComplexRate
+        rates={aifhhRates}
+        name="test-component"
+        readOnly={false}
+        inputFieldNames={aifhhQualifiers}
+        measureName="AIFHH"
+        ndrFormulas={aifhhNdrFormulas}
+      />
+    );
+  });
+
+  test("Should have category property only on FFY 2023", () => {
+    expect(getMeasureYear).toBeCalled();
   });
 });

--- a/services/ui-src/src/components/ComplexRate/index.tsx
+++ b/services/ui-src/src/components/ComplexRate/index.tsx
@@ -152,6 +152,7 @@ export const ComplexRate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
+      prevRate[index]["category"] = categoryName ?? undefined;
     });
 
     prevRate[prevRate.length - 1]["isTotal"] = true;

--- a/services/ui-src/src/components/ComplexRate/index.tsx
+++ b/services/ui-src/src/components/ComplexRate/index.tsx
@@ -153,7 +153,8 @@ export const ComplexRate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      if (getMeasureYear() === 2023) {
+      // human readable text for Mathematica only needed for FFY 2023+
+      if (getMeasureYear() >= 2023) {
         prevRate[index]["category"] = categoryName ?? undefined;
       }
     });

--- a/services/ui-src/src/components/ComplexRate/index.tsx
+++ b/services/ui-src/src/components/ComplexRate/index.tsx
@@ -6,6 +6,7 @@ import objectPath from "object-path";
 import { useEffect, useLayoutEffect } from "react";
 import { IRate } from "components";
 import { defaultRateCalculation } from "utils/rateFormulas";
+import { getMeasureYear } from "utils/getMeasureYear";
 import { ndrFormula } from "types";
 
 interface Props extends QMR.InputWrapperProps {
@@ -152,7 +153,9 @@ export const ComplexRate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      prevRate[index]["category"] = categoryName ?? undefined;
+      if (getMeasureYear() === 2023) {
+        prevRate[index]["category"] = categoryName ?? undefined;
+      }
     });
 
     prevRate[prevRate.length - 1]["isTotal"] = true;

--- a/services/ui-src/src/components/IETRate/index.test.tsx
+++ b/services/ui-src/src/components/IETRate/index.test.tsx
@@ -6,6 +6,7 @@ import fireEvent from "@testing-library/user-event";
 import { IETRate } from ".";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import userEvent from "@testing-library/user-event";
+import { getMeasureYear } from "../../utils/getMeasureYear";
 
 const TestComponent = () => {
   const rates = [
@@ -84,6 +85,10 @@ const TextComponentCategory = () => {
   );
 };
 
+jest.mock("../../utils/getMeasureYear", () => ({
+  getMeasureYear: jest.fn().mockReturnValue(2023),
+}));
+
 describe("Test the IETRate component", () => {
   beforeEach(() => {
     renderWithHookForm(<TestComponent />, {
@@ -100,7 +105,7 @@ describe("Test the IETRate component", () => {
   });
 
   test("Check that component renders and includes a label when passed optionally", () => {
-    expect(screen.getByText(/test/i)).toBeVisible();
+    expect(screen.getAllByText(/test/i)[0]).toBeVisible();
   });
 
   test("Check that number input labels get rendered correctly", () => {
@@ -415,5 +420,23 @@ describe("Test the IETRate component when it includes a total NDR", () => {
     };
 
     checkNDRs(expectedValues);
+  });
+});
+
+describe("Rates should have correct properties", () => {
+  renderWithHookForm(<TestComponent />, {
+    defaultValues: {
+      "test-component": [
+        {
+          numerator: "1",
+          denominator: "1",
+          rate: "1",
+        },
+      ],
+    },
+  });
+
+  test("Should have category property only on FFY 2023", () => {
+    expect(getMeasureYear).toBeCalled();
   });
 });

--- a/services/ui-src/src/components/IETRate/index.test.tsx
+++ b/services/ui-src/src/components/IETRate/index.test.tsx
@@ -11,6 +11,7 @@ const TestComponent = () => {
   const rates = [
     {
       label: "test",
+      category: "test",
       denominator: "",
       numerator: "",
       rate: "",
@@ -26,6 +27,7 @@ const TestComponent2 = () => {
   const rates = [
     {
       label: "test",
+      category: "test",
       denominator: "",
       numerator: "",
       rate: "",

--- a/services/ui-src/src/components/IETRate/index.tsx
+++ b/services/ui-src/src/components/IETRate/index.tsx
@@ -8,6 +8,7 @@ import { useEffect, useLayoutEffect } from "react";
 import { LabelData, getLabelText } from "utils";
 import { IRate } from "components";
 import { defaultRateCalculation } from "utils/rateFormulas";
+import { getMeasureYear } from "utils/getMeasureYear";
 import {
   allNumbers,
   eightNumbersOneDecimal,
@@ -79,7 +80,9 @@ export const IETRate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      prevRate[index]["category"] = categoryName ?? undefined;
+      if (getMeasureYear() === 2023) {
+        prevRate[index]["category"] = categoryName ?? undefined;
+      }
       if (
         categoryName?.toLowerCase().includes("total") ||
         prevRate[index]["uid"].toLowerCase().includes("total")

--- a/services/ui-src/src/components/IETRate/index.tsx
+++ b/services/ui-src/src/components/IETRate/index.tsx
@@ -80,7 +80,8 @@ export const IETRate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      if (getMeasureYear() === 2023) {
+      // human readable text for Mathematica only needed for FFY 2023+
+      if (getMeasureYear() >= 2023) {
         prevRate[index]["category"] = categoryName ?? undefined;
       }
       if (

--- a/services/ui-src/src/components/IETRate/index.tsx
+++ b/services/ui-src/src/components/IETRate/index.tsx
@@ -79,7 +79,7 @@ export const IETRate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-
+      prevRate[index]["category"] = categoryName ?? undefined;
       if (
         categoryName?.toLowerCase().includes("total") ||
         prevRate[index]["uid"].toLowerCase().includes("total")

--- a/services/ui-src/src/components/Rate/index.test.tsx
+++ b/services/ui-src/src/components/Rate/index.test.tsx
@@ -8,6 +8,7 @@ const TestComponent = () => {
   const rates = [
     {
       label: "test",
+      category: "test",
       denominator: "",
       numerator: "",
       rate: "",
@@ -22,6 +23,7 @@ const TestComponent2 = () => {
   const rates = [
     {
       label: "test",
+      category: "category",
       denominator: "",
       numerator: "",
       rate: "",

--- a/services/ui-src/src/components/Rate/index.test.tsx
+++ b/services/ui-src/src/components/Rate/index.test.tsx
@@ -3,6 +3,7 @@ import fireEvent from "@testing-library/user-event";
 import { Rate } from ".";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import userEvent from "@testing-library/user-event";
+import { getMeasureYear } from "../../utils/getMeasureYear";
 
 const TestComponent = () => {
   const rates = [
@@ -34,6 +35,10 @@ const TestComponent2 = () => {
   return <Rate rates={rates} name="test-component" readOnly={false} />;
 };
 
+jest.mock("../../utils/getMeasureYear", () => ({
+  getMeasureYear: jest.fn().mockReturnValue(2023),
+}));
+
 describe("Test the Rate component", () => {
   beforeEach(() => {
     renderWithHookForm(<TestComponent />, {
@@ -50,7 +55,7 @@ describe("Test the Rate component", () => {
   });
 
   test("Check that component renders and includes a label when passed optionally", () => {
-    expect(screen.getByText(/test/i)).toBeVisible();
+    expect(screen.getAllByText(/test/i)[0]).toBeVisible();
   });
 
   test("Check that number input labels get rendered correctly", () => {
@@ -324,5 +329,23 @@ describe("Test the Rate component when it includes a total NDR", () => {
     };
 
     checkNDRs(expectedValues);
+  });
+});
+
+describe("Rates should have correct properties", () => {
+  renderWithHookForm(<TestComponent />, {
+    defaultValues: {
+      "test-component": [
+        {
+          numerator: "1",
+          denominator: "1",
+          rate: "1",
+        },
+      ],
+    },
+  });
+
+  test("Should have category property only on FFY 2023", () => {
+    expect(getMeasureYear).toBeCalled();
   });
 });

--- a/services/ui-src/src/components/Rate/index.tsx
+++ b/services/ui-src/src/components/Rate/index.tsx
@@ -1,6 +1,5 @@
 import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
-
 import { useController, useFormContext } from "react-hook-form";
 import objectPath from "object-path";
 import { useEffect, useLayoutEffect } from "react";
@@ -20,7 +19,6 @@ export interface IRate {
   uid?: string;
   isTotal?: boolean;
 }
-
 interface Props extends QMR.InputWrapperProps {
   rates: IRate[];
   name: string;
@@ -29,6 +27,7 @@ interface Props extends QMR.InputWrapperProps {
   rateMultiplicationValue?: number;
   customMask?: RegExp;
   calcTotal?: boolean;
+  categoryName?: string;
   allowNumeratorGreaterThanDenominator?: boolean;
   customDenominatorLabel?: string;
   customNumeratorLabel?: string;
@@ -44,6 +43,7 @@ export const Rate = ({
   rateMultiplicationValue = 100,
   customMask,
   calcTotal,
+  categoryName,
   allowNumeratorGreaterThanDenominator,
   customDenominatorLabel,
   customNumeratorLabel,
@@ -79,6 +79,7 @@ export const Rate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
+      prevRate[index]["category"] = categoryName ?? undefined;
     });
 
     if (calcTotal) {

--- a/services/ui-src/src/components/Rate/index.tsx
+++ b/services/ui-src/src/components/Rate/index.tsx
@@ -4,8 +4,9 @@ import { useController, useFormContext } from "react-hook-form";
 import objectPath from "object-path";
 import { useEffect, useLayoutEffect } from "react";
 import { getLabelText } from "utils";
-
 import { defaultRateCalculation } from "utils/rateFormulas";
+import { getMeasureYear } from "utils/getMeasureYear";
+
 import {
   allNumbers,
   eightNumbersOneDecimal,
@@ -79,7 +80,10 @@ export const Rate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      prevRate[index]["category"] = categoryName ?? undefined;
+      if (getMeasureYear() === 2023) {
+        prevRate[index]["category"] = categoryName ?? undefined;
+        console.log("only on 2023", prevRate);
+      }
     });
 
     if (calcTotal) {

--- a/services/ui-src/src/components/Rate/index.tsx
+++ b/services/ui-src/src/components/Rate/index.tsx
@@ -80,9 +80,9 @@ export const Rate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      if (getMeasureYear() === 2023) {
+      // human readable text for Mathematica only needed for FFY 2023+
+      if (getMeasureYear() >= 2023) {
         prevRate[index]["category"] = categoryName ?? undefined;
-        console.log("only on 2023", prevRate);
       }
     });
 

--- a/services/ui-src/src/utils/getMeasureYear.ts
+++ b/services/ui-src/src/utils/getMeasureYear.ts
@@ -1,5 +1,6 @@
 export const getMeasureYear = () => {
-  const urlPath = window.location.pathname;
-  const measureYear = parseInt(urlPath.slice(4, 8));
-  return measureYear;
+  const { pathname } = window.location;
+  const params = pathname.split("/");
+  const year = parseInt(params[2]);
+  return year;
 };

--- a/services/ui-src/src/utils/getMeasureYear.ts
+++ b/services/ui-src/src/utils/getMeasureYear.ts
@@ -1,0 +1,5 @@
+export const getMeasureYear = () => {
+  const urlPath = window.location.pathname;
+  const measureYear = parseInt(urlPath.slice(4, 8));
+  return measureYear;
+};


### PR DESCRIPTION
### Description
https://qmacbis.atlassian.net/browse/MDCT-2602

Within the Rates, ComplexRates & IETRates I added a category property to the rates data that links the "Rate category" to it's perspective "Qualifiers". This is only done for FFY 2023. 

Ex. The rates within the two columns will have the same category property of "Initiation of SUD Treatment..." (since they're both under that category).

<img width="1292" alt="Screenshot 2023-06-29 at 1 32 43 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/14514294/45e176e8-5120-445e-a63c-9b79ad9c83b7">

---
### How to test
1. Go to 2023 and select an measure. ( try /MA/2023/ACS/AAB-AD) 
2. Enter rates and check/console log the `prevRate` to see the new category
3. To see a measure with categories ( try /MA/2023/ACS/IET-AD)
4. Fill out all the rates and console log `prevRate` within `IETRate - index.tsx` to see the category show for rates that were filled in.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
