### PR TITLE
bugfix: ensure OMS checkbox displayValue is a string

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
@@ -2,7 +2,7 @@ import * as CUI from "@chakra-ui/react";
 import * as DC from "dataConstants";
 import * as Types from "../types";
 import * as QMR from "components";
-import { LabelData, cleanString, getLabelText } from "utils";
+import { LabelData, cleanString } from "utils";
 import { useFormContext } from "react-hook-form";
 import { ComponentFlagType, usePerformanceMeasureContext } from "./context";
 import { useTotalAutoCalculation } from "./omsUtil";

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
@@ -342,7 +342,6 @@ const useAgeGroupsCheckboxes: CheckBoxBuilder = (name) => {
   const options: QMR.CheckboxOption[] = [];
   const { categories, qualifiers, calcTotal, customPrompt } =
     usePerformanceMeasureContext();
-  const labelText = getLabelText();
 
   const qualRates = useQualRateArray(name);
   const standardRates = useStandardRateArray(name);
@@ -363,7 +362,7 @@ const useAgeGroupsCheckboxes: CheckBoxBuilder = (name) => {
     if (rateArrays?.[idx]?.length) {
       const ageGroupCheckBox = {
         value: value.id,
-        displayValue: labelText[value.label] ?? value,
+        displayValue: value.text,
         children: [
           <CUI.Heading
             key={`${name}.rates.${value.id}Header`}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
A bug is occurring when users attempt to preview the pdf on the `/pdf` route, which uses the `ExportAll` component. Nested deep inside the code for that part of the app was an issue where, if a user had entered any OMS data (thus requiring OMS data to be displayed on that page), an error would be thrown. This is because for OMS checkbox labels, where it looks for the label text to display, we were getting it 2 ways — a primary and a fallback. The problem was the specified label text was an `object` instead of a `string`, so the primary way was failing, then the backup way was grabbing the entire object where it was expecting just a string, and the app won’t render objects as children, and there you go: error.

Extent of this bug is limited to 2023 and OMS data when previewed on `/pdf` route.

Kudos to @benmartin-coforma @britt-mo @ajaitasaini for the great work diving in and researching everything, and @benmartin-coforma for identifying the solution.

Additional test coverage against this type of issue will be deployed with the change from e2e tests to 2023 coverage.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
n/a

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. For any core set, fill out a measure which includes OMS data. Save/complete measure.
2. Generate PDF preview by clicking 'Export', which will render `/pdf` route. If data is displayed, bug is fixed.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
