### PR TITLE
Add a type hint to getLabelText

### DIFF
--- a/services/ui-src/src/utils/getLabelText.tsx
+++ b/services/ui-src/src/utils/getLabelText.tsx
@@ -9,7 +9,7 @@ const addLabelTextData = (acc: LabelText, data: LabelData) => {
   return acc;
 };
 
-export const getLabelText = () => {
+export const getLabelText = (): { [key: string]: [value: string] } => {
   const { pathname } = window.location;
   const params = pathname.split("/");
   const year = params[2];

--- a/services/ui-src/src/utils/getLabelText.tsx
+++ b/services/ui-src/src/utils/getLabelText.tsx
@@ -9,7 +9,7 @@ const addLabelTextData = (acc: LabelText, data: LabelData) => {
   return acc;
 };
 
-export const getLabelText = (): { [key: string]: [value: string] } => {
+export const getLabelText = (): { [key: string]: string } => {
   const { pathname } = window.location;
   const params = pathname.split("/");
   const year = params[2];


### PR DESCRIPTION
### Description
This function returns `any`, which hamstrings the type checker. It should not return `any`.

This type hint _would_ have prevented the bug fixed by https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/1845 . It's too late to prevent that bug, but we might as well add it now.

### Related ticket(s)
n/a

---
### How to test
n/a - This function's behavior has been thoroughly tested, and this change does not affect that behavior at all.

### Important updates
n/a

---
### Author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
