### PR TITLE
Dependabot Alerts #173 to #178: xml2js is vulnerable to prototype pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "yargs": "^16.1.1"
   },
   "dependencies": {
-    "cypress-image-snapshot": "^4.0.1"
+    "cypress-image-snapshot": "^4.0.1",
+    "xml2js": "0.6.0"
   }
 }

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -33,14 +33,15 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "aws4": "^1.11.0",
     "aws-sdk": "^2.1310.0",
+    "aws4": "^1.11.0",
     "aws4-axios": "^2.4.9",
     "axios": "^0.27.2",
     "jwt-decode": "^3.1.2",
     "kafkajs": "^1.16.0",
     "prompt-sync": "^4.2.0",
-    "uuid": "^7.0.3"
+    "uuid": "^7.0.3",
+    "xml2js": "0.6.0"
   },
   "jest": {
     "verbose": true,

--- a/services/app-api/yarn.lock
+++ b/services/app-api/yarn.lock
@@ -5791,6 +5791,19 @@ xml2js@0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
+xml2js@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.0.tgz#07afc447a97d2bd6507a1f76eeadddb09f7a8282"
+  integrity sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
 xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"

--- a/services/database/package.json
+++ b/services/database/package.json
@@ -9,13 +9,16 @@
   "author": "",
   "license": "CC0-1.0",
   "devDependencies": {
-    "serverless-s3-bucket-helper": "CMSgov/serverless-s3-bucket-helper#0.1.1",
     "dynamodb-localhost": "https://github.com/99x/dynamodb-localhost#db30898f8c40932c7177be7b2f1a81360d12876d",
-    "serverless-dynamodb-local": "0.2.40"
+    "serverless-dynamodb-local": "0.2.40",
+    "serverless-s3-bucket-helper": "CMSgov/serverless-s3-bucket-helper#0.1.1"
   },
   "overrides": {
     "serverless-dynamodb-local": {
       "dynamodb-localhost": "https://github.com/99x/dynamodb-localhost#db30898f8c40932c7177be7b2f1a81360d12876d"
     }
+  },
+  "dependencies": {
+    "xml2js": "0.6.0"
   }
 }

--- a/services/database/yarn.lock
+++ b/services/database/yarn.lock
@@ -745,6 +745,19 @@ xml2js@0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
+xml2js@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.0.tgz#07afc447a97d2bd6507a1f76eeadddb09f7a8282"
+  integrity sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
 xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"

--- a/services/ui-auth/package.json
+++ b/services/ui-auth/package.json
@@ -12,6 +12,7 @@
     "serverless-s3-bucket-helper": "CMSgov/serverless-s3-bucket-helper#0.1.1"
   },
   "dependencies": {
-    "aws-sdk": "^2.1310.0"
+    "aws-sdk": "^2.1310.0",
+    "xml2js": "0.6.0"
   }
 }

--- a/services/ui-auth/yarn.lock
+++ b/services/ui-auth/yarn.lock
@@ -221,6 +221,19 @@ xml2js@0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
+xml2js@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.0.tgz#07afc447a97d2bd6507a1f76eeadddb09f7a8282"
+  integrity sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
 xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -30,7 +30,8 @@
     "react-scripts": "^5.0.0",
     "react-textarea-autosize": "^8.3.3",
     "sass": "^1.37.5",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "xml2js": "0.6.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -14187,6 +14187,19 @@ xml2js@0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
+xml2js@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.0.tgz#07afc447a97d2bd6507a1f76eeadddb09f7a8282"
+  integrity sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
 xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"

--- a/services/uploads/package.json
+++ b/services/uploads/package.json
@@ -10,7 +10,6 @@
   "author": "",
   "license": "CC0-1.0",
   "devDependencies": {
-    "serverless-s3-local": "^0.6.7",
     "@types/aws-lambda": "^8.10.88",
     "@types/flat": "^5.0.2",
     "@types/json2csv": "^5.0.3",
@@ -18,11 +17,13 @@
     "serverless-associate-waf": "^1.2.1",
     "serverless-plugin-typescript": "^2.1.0",
     "serverless-s3-bucket-helper": "CMSgov/serverless-s3-bucket-helper#0.1.1",
+    "serverless-s3-local": "^0.6.7",
     "typescript": "^4.5.4"
   },
   "dependencies": {
     "flat": "^5.0.2",
     "json2csv": "^5.0.6",
-    "uuid": "^7.0.3"
+    "uuid": "^7.0.3",
+    "xml2js": "0.6.0"
   }
 }

--- a/services/uploads/yarn.lock
+++ b/services/uploads/yarn.lock
@@ -3699,6 +3699,19 @@ xml2js@0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
+xml2js@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.0.tgz#07afc447a97d2bd6507a1f76eeadddb09f7a8282"
+  integrity sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
 xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12135,10 +12135,23 @@ xml2js@0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
+xml2js@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.0.tgz#07afc447a97d2bd6507a1f76eeadddb09f7a8282"
+  integrity sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
 xmlbuilder@^9.0.7, xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
[Dependabot 173](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/security/dependabot/173)
[Dependabot 174](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/security/dependabot/174)
[Dependabot 175](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/security/dependabot/175)
[Dependabot 176](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/security/dependabot/176)
[Dependabot 177](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/security/dependabot/177)
[Dependabot 178](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/security/dependabot/178)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
