### PR TITLE
LSC-CH Hybrid Text

### DIFF
--- a/services/ui-src/src/measures/2023/LSCCH/index.tsx
+++ b/services/ui-src/src/measures/2023/LSCCH/index.tsx
@@ -41,7 +41,7 @@ export const LSCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure populationSampleSize />
+          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
LSC-CH turns out to be a hybrid so the hybrid text needs to be turned on.

<img width="1238" alt="Screenshot 2023-07-07 at 11 50 16 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/11d6e884-7f9e-4e87-85e9-5ccfd183b6fc">

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2686

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Go to Reporting Year 2023
2) Select Child Core Set
3) Enter LSC-CH
4) Look at "Definition of Population Included in the Measure" section
5) Look and confirm the existence of text 
     - "If you are reporting as a hybrid measure, provide the measure eligible population and sample size."

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
