### PR TITLE
HH Qualifier - Individual Total 

### DIFF
--- a/services/ui-src/src/components/Inputs/NumberInput/index.tsx
+++ b/services/ui-src/src/components/Inputs/NumberInput/index.tsx
@@ -12,6 +12,7 @@ interface NumberInputProps extends QMR.InputWrapperProps {
   name: string;
   mask?: RegExp;
   readonly?: boolean;
+  onChange?: Function;
 }
 
 export const NumberInput = ({
@@ -23,6 +24,7 @@ export const NumberInput = ({
   readonly,
   mask = allNumbers,
   ariaLabel = name,
+  onChange,
   ...rest
 }: NumberInputProps) => {
   const {
@@ -34,6 +36,16 @@ export const NumberInput = ({
     name,
     control,
   });
+
+  //expanding onChange to allow the parent to access the event information
+  const change = (v: any) => {
+    onChange?.(v);
+
+    return mask.test(v.target.value) || !v.target.value
+      ? field.onChange(v.target.value || "")
+      : null;
+  };
+
   return (
     <QMR.InputWrapper
       isInvalid={!!objectPath.get(errors, name)?.message}
@@ -48,11 +60,7 @@ export const NumberInput = ({
           value={field.value ?? ""}
           name={name}
           data-cy={name}
-          onChange={(v) =>
-            mask.test(v.target.value) || !v.target.value
-              ? field.onChange(v.target.value || "")
-              : null
-          }
+          onChange={change}
           data-testid="test-number-input"
           onBlur={field.onBlur}
           ref={field.ref}

--- a/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.test.tsx
+++ b/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.test.tsx
@@ -2,7 +2,6 @@ import { AdministrativeQuestions } from ".";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import * as CUI from "@chakra-ui/react";
 import { fireEvent, screen } from "@testing-library/react";
-// import userEvent from "@testing-library/user-event";
 
 const fieldKeys = [
   "numberOfAdults",

--- a/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.test.tsx
+++ b/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.test.tsx
@@ -1,0 +1,85 @@
+import { AdministrativeQuestions } from ".";
+import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
+import * as CUI from "@chakra-ui/react";
+import { fireEvent, screen } from "@testing-library/react";
+// import userEvent from "@testing-library/user-event";
+
+const fieldKeys = [
+  "numberOfAdults",
+  "minAgeOfAdults",
+  "numberOfChildren",
+  "maxAgeChildren",
+  "numberOfIndividuals",
+  "numberOfProviders",
+];
+
+const AdministrativeList = () => {
+  return (
+    <CUI.OrderedList>
+      <AdministrativeQuestions />
+    </CUI.OrderedList>
+  );
+};
+
+describe("Test AdministrativeQuestions Component", () => {
+  beforeEach(() => {
+    renderWithHookForm(<AdministrativeList />);
+  });
+
+  it("Check that the input fields are rendered", () => {
+    fieldKeys.forEach((key) => {
+      expect(screen.getByLabelText(`AdministrativeData.${key}`));
+    });
+  });
+
+  it("Check entering a number into the input fields", () => {
+    fieldKeys.forEach((key) => {
+      const inputField = screen.getByLabelText(`AdministrativeData.${key}`);
+      fireEvent.change(inputField, { target: { value: "5" } });
+      expect(inputField).toHaveDisplayValue("5");
+    });
+  });
+});
+
+describe("Test Summation Of Total Number Of Individuals", () => {
+  beforeEach(() => {
+    renderWithHookForm(<AdministrativeList />);
+  });
+
+  it("Check auto sum of number of individuals", () => {
+    const numOfAdults = screen.getByLabelText(
+      `AdministrativeData.numberOfAdults`
+    );
+    fireEvent.change(numOfAdults, { target: { value: "3" } });
+
+    const numOfChildren = screen.getByLabelText(
+      `AdministrativeData.numberOfChildren`
+    );
+    fireEvent.change(numOfChildren, { target: { value: "5" } });
+
+    const numberOfIndividuals = screen.getByLabelText(
+      `AdministrativeData.numberOfIndividuals`
+    );
+    expect(numberOfIndividuals).toHaveDisplayValue("8");
+  });
+
+  it("Check number of individuals is changable after summation", () => {
+    const numOfAdults = screen.getByLabelText(
+      `AdministrativeData.numberOfAdults`
+    );
+    fireEvent.change(numOfAdults, { target: { value: "3" } });
+
+    const numOfChildren = screen.getByLabelText(
+      `AdministrativeData.numberOfChildren`
+    );
+    fireEvent.change(numOfChildren, { target: { value: "5" } });
+
+    const numberOfIndividuals = screen.getByLabelText(
+      `AdministrativeData.numberOfIndividuals`
+    );
+    expect(numberOfIndividuals).toHaveDisplayValue("8");
+
+    fireEvent.change(numberOfIndividuals, { target: { value: "15" } });
+    expect(numberOfIndividuals).toHaveDisplayValue("15");
+  });
+});

--- a/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.tsx
+++ b/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.tsx
@@ -7,10 +7,37 @@ import {
   allPositiveIntegersWith10Digits,
   allPositiveIntegersWith3Digits,
 } from "utils";
+import { useFormContext } from "react-hook-form";
+import { HHCSQualifierForm } from "../types";
 
 export const AdministrativeQuestions = () => {
   const register = useCustomRegister<Types.HHCSQualifierForm>();
   const padding = "10px";
+
+  const { setValue, watch } = useFormContext<HHCSQualifierForm>();
+  const data = watch();
+
+  //function to only invoke when the value has changed for number of adult or number of children
+  //only want the function to run when the value of numberOfAdults or numberOfChildren change
+  //the numberOfIndividuals needs to allow overwrite from states; is NOT always the sum of children + adult
+  const sumOnChange = (v: any) => {
+    if (data.AdministrativeData) {
+      let name: string = v.target.name;
+      let numOfAdults = name.includes("numberOfAdults")
+        ? v.target.value
+        : data.AdministrativeData.numberOfAdults;
+      let numOfChildren = name.includes("numberOfChildren")
+        ? v.target.value
+        : data.AdministrativeData.numberOfChildren;
+
+      data.AdministrativeData.numberOfIndividuals = (
+        parseInt(numOfAdults) + parseInt(numOfChildren)
+      ).toString();
+
+      setValue("AdministrativeData", data.AdministrativeData);
+    }
+  };
+
   return (
     <CUI.ListItem mr="4">
       <Common.QualifierHeader
@@ -21,6 +48,7 @@ export const AdministrativeQuestions = () => {
         {...register("AdministrativeData.numberOfAdults")}
         mask={allPositiveIntegersWith10Digits}
         formLabelProps={{ fontWeight: "400", padding: padding }}
+        onChange={sumOnChange}
         label={
           <>
             What is the total annual number of{" "}
@@ -47,6 +75,7 @@ export const AdministrativeQuestions = () => {
       />
       <QMR.NumberInput
         {...register("AdministrativeData.numberOfChildren")}
+        onChange={sumOnChange}
         mask={allPositiveIntegersWith10Digits}
         formLabelProps={{ fontWeight: "400", padding: padding }}
         label={

--- a/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.tsx
+++ b/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.tsx
@@ -30,9 +30,8 @@ export const AdministrativeQuestions = () => {
         ? v.target.value
         : data.AdministrativeData.numberOfChildren;
 
-      data.AdministrativeData.numberOfIndividuals = (
-        parseInt(numOfAdults) + parseInt(numOfChildren)
-      ).toString();
+      let sum = parseInt(numOfAdults) + parseInt(numOfChildren);
+      data.AdministrativeData.numberOfIndividuals = sum ? sum.toString() : "";
 
       setValue("AdministrativeData", data.AdministrativeData);
     }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
In Health Home qualifier questions, the state users want the total annual number of individuals to be auto sum but also changeable if desired. 

The NumberInput component has been updated to run an any function passed from it's layer up as to trigger the calculations for the sum.

<img width="1265" alt="Screenshot 2023-07-10 at 2 58 17 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/90826e09-8960-41f4-89e5-85cf2ea71968">

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2243

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR with an account that has HH (i.e. [stateuserWA@test.com](mailto:stateuserDC@test.com) )
2) Add a Health Home Measure
3) Click the text link in the gray box
<img width="1053" alt="Screenshot 2023-07-10 at 3 01 34 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/ae7bc038-b590-4582-9bd5-8c239e999132">
4) Add random numbers to "total annual number of adults" and "total annual number of children"
5) "total annual number of individuals" should auto sum but still allow you to change the values to be different.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
