### PR TITLE
remove age label from rates

### DIFF
--- a/services/ui-src/src/measures/2023/rateLabelText.ts
+++ b/services/ui-src/src/measures/2023/rateLabelText.ts
@@ -396,13 +396,6 @@ export const data = {
     "CCW-AD": {
         "qualifiers": [
             {
-                "label": "All Women Ages 21 to 44",
-                "text": "All Women Ages 21 to 44",
-                "id": "ntJIVl"
-            }
-        ],
-        "categories": [
-            {
                 "label": "Most effective or moderately effective method of contraception",
                 "text": "Most effective or moderately effective method of contraception",
                 "id": "FLFmHi"
@@ -412,7 +405,8 @@ export const data = {
                 "text": "Long-acting reversible method of contraception (LARC)",
                 "id": "qken13"
             }
-        ]
+        ],
+        "categories": [{"id":"ntJIVl", "label": "", "text":""}]
     },
     "CCW-CH": {
         "qualifiers": [


### PR DESCRIPTION
### Description
This was a request to remove the label text `All Women - Ages 21 to 44` from the rate sections.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2253

---
### How to test
Go to 2023 -> measure CCW-AD, fill it out to get OMS options, see that the text `All Women -Ages 21 to 44` does not appear as a label above Performance Measures and Optional Measure Stratification.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
