### PR TITLE
remove adult eligibility group in OMS section

### DIFF
--- a/services/ui-src/src/measures/2023/AABAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AABAD/validation.ts
@@ -58,7 +58,7 @@ const AABADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/AABCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AABCH/validation.ts
@@ -53,7 +53,7 @@ const AABCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/ADDCH/validation.ts
+++ b/services/ui-src/src/measures/2023/ADDCH/validation.ts
@@ -55,7 +55,7 @@ const ADDCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/AIFHH/validation.ts
+++ b/services/ui-src/src/measures/2023/AIFHH/validation.ts
@@ -80,7 +80,7 @@ const AIFHHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/AMBCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBCH/validation.ts
@@ -47,7 +47,7 @@ const AMBCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/AMBHH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBHH/validation.ts
@@ -62,7 +62,7 @@ const AMBHHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/AMMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMMAD/validation.ts
@@ -81,7 +81,7 @@ const AMMADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/AMRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRAD/validation.ts
@@ -50,7 +50,7 @@ const AMRADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/AMRCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRCH/validation.ts
@@ -50,7 +50,7 @@ const AMRCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/APMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APMCH/validation.ts
@@ -84,7 +84,7 @@ const APMCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/APPCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APPCH/validation.ts
@@ -55,7 +55,7 @@ const APPCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/BCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/BCSAD/validation.ts
@@ -48,7 +48,7 @@ const BCSValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CBPAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPAD/validation.ts
@@ -54,7 +54,7 @@ const CBPValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CBPHH/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPHH/validation.ts
@@ -55,7 +55,7 @@ const CBPValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CCPAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCPAD/validation.ts
@@ -54,7 +54,7 @@ const CCPADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CCPCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CCPCH/validation.ts
@@ -54,7 +54,7 @@ const CCPCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCSAD/validation.ts
@@ -27,7 +27,7 @@ const CCSADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CCWAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCWAD/validation.ts
@@ -51,7 +51,7 @@ const CCWADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CCWCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CCWCH/validation.ts
@@ -41,7 +41,7 @@ const CCWCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CDFAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFAD/validation.ts
@@ -53,7 +53,7 @@ const CDFADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CDFCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFCH/validation.ts
@@ -53,7 +53,7 @@ const CDFCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CDFHH/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFHH/validation.ts
@@ -66,7 +66,7 @@ const CDFHHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CHLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLAD/validation.ts
@@ -46,7 +46,7 @@ const CHLValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CHLCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLCH/validation.ts
@@ -46,7 +46,7 @@ const CHLValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/CISCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CISCH/validation.ts
@@ -27,7 +27,7 @@ const CISCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/COBAD/validation.ts
+++ b/services/ui-src/src/measures/2023/COBAD/validation.ts
@@ -55,7 +55,7 @@ const COBADValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/COLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/COLAD/validation.ts
@@ -57,7 +57,7 @@ const COLADValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/COLHH/validation.ts
+++ b/services/ui-src/src/measures/2023/COLHH/validation.ts
@@ -57,7 +57,7 @@ const COLHHValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/DEVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/DEVCH/validation.ts
@@ -26,7 +26,7 @@ const DEVCHValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FUAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAAD/validation.ts
@@ -59,7 +59,7 @@ const FUAADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FUACH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUACH/validation.ts
@@ -55,7 +55,7 @@ const FUACHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FUAHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAHH/validation.ts
@@ -72,7 +72,7 @@ const FUAHHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FUHAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHAD/validation.ts
@@ -78,7 +78,7 @@ const FUHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FUHCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHCH/validation.ts
@@ -71,7 +71,7 @@ const FUHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FUHHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHHH/validation.ts
@@ -71,7 +71,7 @@ const FUHHHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FUMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMAD/validation.ts
@@ -69,7 +69,7 @@ const FUMADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FUMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMCH/validation.ts
@@ -70,7 +70,7 @@ const FUMCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FUMHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMHH/validation.ts
@@ -74,7 +74,7 @@ const FUMHHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/FVAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FVAAD/validation.ts
@@ -53,7 +53,7 @@ const FVAADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/HBDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HBDAD/validation.ts
@@ -30,7 +30,7 @@ const HBDADValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
@@ -61,7 +61,7 @@ const HPCMIADValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/HVLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HVLAD/validation.ts
@@ -48,7 +48,7 @@ const HVLADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/IETAD/validation.ts
+++ b/services/ui-src/src/measures/2023/IETAD/validation.ts
@@ -16,7 +16,7 @@ const IETValidation = (data: FormData) => {
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
 
   const locationDictionary = GV.omsLocationDictionary(
-    OMSData(true),
+    OMSData(),
     PMD.qualifiers,
     PMD.categories
   );

--- a/services/ui-src/src/measures/2023/IETHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IETHH/validation.ts
@@ -16,7 +16,7 @@ const IETValidation = (data: FormData) => {
   const DefinitionOfDenominator = data[DC.DEFINITION_OF_DENOMINATOR];
 
   const locationDictionary = GV.omsLocationDictionary(
-    OMSData(true),
+    OMSData(),
     PMD.qualifiers,
     PMD.categories
   );

--- a/services/ui-src/src/measures/2023/IMACH/validation.ts
+++ b/services/ui-src/src/measures/2023/IMACH/validation.ts
@@ -26,7 +26,7 @@ const DEVCHValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/IUHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IUHH/validation.ts
@@ -80,7 +80,7 @@ const IUHHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/LSCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/LSCCH/validation.ts
@@ -53,7 +53,7 @@ const LSCCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/MSCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/MSCAD/validation.ts
@@ -58,7 +58,7 @@ const MSCADValidation = (data: Types.DefaultFormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/OEVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/OEVCH/validation.ts
@@ -53,7 +53,7 @@ const OEVCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/OHDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/OHDAD/validation.ts
@@ -52,7 +52,7 @@ const OHDValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/OUDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/OUDAD/validation.ts
@@ -53,7 +53,7 @@ const OUDValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/OUDHH/validation.ts
+++ b/services/ui-src/src/measures/2023/OUDHH/validation.ts
@@ -54,7 +54,7 @@ const OUDValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/PCRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRAD/validation.ts
@@ -67,7 +67,7 @@ const PCRADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/PCRHH/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRHH/validation.ts
@@ -66,7 +66,7 @@ const PCRHHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/PPCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCAD/validation.ts
@@ -28,7 +28,7 @@ const PPCADValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/PPCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCCH/validation.ts
@@ -28,7 +28,7 @@ const PPCCHValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/PQI01AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI01AD/validation.ts
@@ -63,7 +63,7 @@ const PQI01Validation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/PQI05AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI05AD/validation.ts
@@ -68,7 +68,7 @@ const PQI05Validation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/PQI08AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI08AD/validation.ts
@@ -59,7 +59,7 @@ const PQI08Validation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/PQI15AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI15AD/validation.ts
@@ -43,7 +43,7 @@ const PQI15Validation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/PQI92HH/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI92HH/validation.ts
@@ -60,7 +60,7 @@ const PQI92Validation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/SAAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SAAAD/validation.ts
@@ -42,7 +42,7 @@ const SAAADValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/SFMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/SFMCH/validation.ts
@@ -76,7 +76,7 @@ const SFMCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/SSDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SSDAD/validation.ts
@@ -41,7 +41,7 @@ const SSDValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/TFLCH/validation.ts
+++ b/services/ui-src/src/measures/2023/TFLCH/validation.ts
@@ -64,7 +64,7 @@ const TFLCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/W30CH/validation.ts
+++ b/services/ui-src/src/measures/2023/W30CH/validation.ts
@@ -71,7 +71,7 @@ const W30CHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/WCCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCCCH/validation.ts
@@ -84,7 +84,7 @@ const WCCHValidation = (data: FormData) => {
       categories: PMD.categories,
       dataSource: data[DC.DATA_SOURCE],
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/WCVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCVCH/validation.ts
@@ -27,7 +27,7 @@ const WCVCHValidation = (data: FormData) => {
       qualifiers: PMD.qualifiers,
       categories: PMD.categories,
       locationDictionary: GV.omsLocationDictionary(
-        OMSData(true),
+        OMSData(),
         PMD.qualifiers,
         PMD.categories
       ),

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/data.ts
@@ -13,7 +13,7 @@ export interface OmsNode {
   aggregateTitle?: string;
 }
 
-export const OMSData = (adultMeasure?: boolean): OmsNode[] => {
+export const OMSData = (): OmsNode[] => {
   const data: OmsNode[] = [
     {
       id: "Race",
@@ -88,13 +88,6 @@ export const OMSData = (adultMeasure?: boolean): OmsNode[] => {
       addMore: true,
     },
   ];
-
-  /** if adult measure add ACA */
-  adultMeasure &&
-    data.push({
-      id: "Adult Eligibility Group (ACA Expansion Group)",
-      addMore: false,
-    });
 
   return data;
 };

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/index.tsx
@@ -125,7 +125,6 @@ export const OptionalMeasureStrat = ({
   ndrFormulas,
   data,
   calcTotal = false,
-  adultMeasure,
   rateMultiplicationValue,
   allowNumeratorGreaterThanDenominator = false,
   customMask,
@@ -139,7 +138,7 @@ export const OptionalMeasureStrat = ({
   customPrompt,
   rateCalc,
 }: Props) => {
-  const omsData = data ?? OMSData(adultMeasure);
+  const omsData = data ?? OMSData();
   const { watch, getValues, unregister } = useFormContext<OMSType>();
   const values = getValues();
 

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.test.ts
@@ -48,7 +48,7 @@ describe("Testing OMS validation processor", () => {
           simpleRate,
         ]),
         true,
-        OMSData(false)
+        OMSData()
       ) as DefaultFormData,
       validationCallbacks: [],
     });


### PR DESCRIPTION
### Description
This removes the "Adult Eligibility Group (ACA Expansion Group)" category from the Optional Measure Stratification section for all Adult measures for FFY 2023. 

This category is only found in the Adult Core Set.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2687

---
### How to test
Fill out an adult core set measure and see that "Adult Eligibility Group (ACA Expansion Group)" is not an option.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
