### PR TITLE
Add hyphen to "sub-categories" in OMS

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -54,7 +54,7 @@ const renderRadioButtonOptions = ({
     {
       displayValue: `No, we are reporting disaggregated data for ${
         omsNode?.aggregateTitle || omsNode?.id
-      } subcategories`,
+      } sub-categories`,
       value: "NoIndependentData",
       children: [
         <QMR.Checkbox


### PR DESCRIPTION
### Description
Add hyphen to word 'sub-categories'


BEFORE
![Screenshot 2023-07-12 at 10 42 07 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/57802560/2947b052-1590-4b64-8e93-bf4852857b1a)
![Screenshot 2023-07-12 at 10 42 15 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/57802560/1c287b52-3067-41fd-a4f4-e783cedcbf6e)

AFTER
![Screenshot 2023-07-12 at 11 23 59 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/57802560/8ddcd7e5-f8b2-49fe-a692-2fa9ab7609d4)
![Screenshot 2023-07-12 at 11 24 23 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/57802560/dedc612e-458b-41a1-9e28-686136183fc4)


### Related ticket(s)
MDCT-2682

---
### How to test
- Navigate to [deployed env](https://d17z68pmnn1088.cloudfront.net/), or view locally
- Login -> Adult -> First option
  - Under "Measure Specification" select HEDIS (first option)
  - Select any from that dropdown
  - Scroll down to "Performance Measure"
  - Enter amounts into the first numerator/denominator fields
  - This should make the OMS section pop up below
- Verify text updates under "Optional Measure Stratification"
  - Race
    - Asian
    - Native Hawaiian or Other Pacific Islander
  - Ethnicity
    - Hispanic, Latino/a, or Spanish origin

All of the above should have a hyphen in the word 'sub-categories' at the end of the second option (the 'No' option)


### Important updates
n/a


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
