### PR TITLE
[MDCT-2416] default scan to iterate across results

### DIFF
--- a/services/app-api/handlers/kafka/get/forceKafkaSync.js
+++ b/services/app-api/handlers/kafka/get/forceKafkaSync.js
@@ -15,7 +15,7 @@ const tableNames = [
 ];
 
 const scanTable = async (tableName, startingKey, keepSearching) => {
-  let results = await dynamoDb.scanExplicit({
+  let results = await dynamoDb.scanOnce({
     TableName: tableName,
     ExclusiveStartKey: startingKey,
   });

--- a/services/app-api/handlers/kafka/get/forceKafkaSync.js
+++ b/services/app-api/handlers/kafka/get/forceKafkaSync.js
@@ -15,7 +15,7 @@ const tableNames = [
 ];
 
 const scanTable = async (tableName, startingKey, keepSearching) => {
-  let results = await dynamoDb.scan({
+  let results = await dynamoDb.scanExplicit({
     TableName: tableName,
     ExclusiveStartKey: startingKey,
   });

--- a/services/app-api/handlers/measures/get.ts
+++ b/services/app-api/handlers/measures/get.ts
@@ -21,23 +21,17 @@ export const listMeasures = handler(async (event, context) => {
   };
 
   const scannedResults: any[] = [];
-  let queryValue;
+  let queryValue = await dynamoDb.scan(params);
+  queryValue?.Items?.forEach((v) => {
+    const measure = measures[parseInt(year)]?.filter(
+      (m) => m.measure === (v as Measure)?.measure
+    )[0];
 
-  do {
-    queryValue = await dynamoDb.scan(params);
-    queryValue?.Items?.forEach((v) => {
-      const measure = measures[parseInt(year)]?.filter(
-        (m) => m.measure === (v as Measure)?.measure
-      )[0];
-
-      scannedResults.push({
-        ...v,
-        autoCompleted: !!measure?.autocompleteOnCreation,
-      });
+    scannedResults.push({
+      ...v,
+      autoCompleted: !!measure?.autocompleteOnCreation,
     });
-
-    params.ExclusiveStartKey = queryValue.LastEvaluatedKey;
-  } while (queryValue.LastEvaluatedKey !== undefined);
+  });
   queryValue.Items = scannedResults;
   return queryValue;
 });

--- a/services/app-api/libs/dynamodb-lib.ts
+++ b/services/app-api/libs/dynamodb-lib.ts
@@ -37,8 +37,16 @@ export default {
   put: (params: DynamoCreate) => client.put(params).promise(),
   post: (params: DynamoCreate) => client.put(params).promise(),
   scan: async <Result = CoreSet | Measure>(params: DynamoScan) => {
-    const result = await client.scan(params).promise();
-    return { ...result, Items: result?.Items as Result[] | undefined };
+    const items = [];
+    let complete = false;
+    while (!complete) {
+      const result = await client.scan(params).promise();
+      console.log(result);
+      items.push(...(result?.Items as Result[] | []));
+      params.ExclusiveStartKey = result.LastEvaluatedKey;
+      complete = result.LastEvaluatedKey === undefined;
+    }
+    return { Items: items, Count: items.length };
   },
   update: (params: DynamoUpdate) => client.update(params).promise(),
   delete: (params: DynamoDelete) => client.delete(params).promise(),

--- a/services/app-api/libs/dynamodb-lib.ts
+++ b/services/app-api/libs/dynamodb-lib.ts
@@ -44,8 +44,7 @@ export default {
     let complete = false;
     while (!complete) {
       const result = await client.scan(params).promise();
-      console.log(result);
-      items.push(...(result?.Items as Result[] | []));
+      items.push(...((result?.Items as Result[]) ?? []));
       params.ExclusiveStartKey = result.LastEvaluatedKey;
       complete = result.LastEvaluatedKey === undefined;
     }

--- a/services/app-api/libs/dynamodb-lib.ts
+++ b/services/app-api/libs/dynamodb-lib.ts
@@ -36,6 +36,9 @@ export default {
   },
   put: (params: DynamoCreate) => client.put(params).promise(),
   post: (params: DynamoCreate) => client.put(params).promise(),
+  /**
+   * Scan operation that continues for all results. More expensive but avoids stopping early when a index is not known.
+   */
   scan: async <Result = CoreSet | Measure>(params: DynamoScan) => {
     const items = [];
     let complete = false;
@@ -47,6 +50,14 @@ export default {
       complete = result.LastEvaluatedKey === undefined;
     }
     return { Items: items, Count: items.length };
+  },
+  /**
+   * Scan operation that iterates and includes a LastEvaluatedKey.
+   * Useful for parsing the results of a scan one page at a time or stopping early.
+   */
+  scanOnce: async <Result = CoreSet | Measure>(params: DynamoScan) => {
+    const result = await client.scan(params).promise();
+    return { ...result, Items: result?.Items as Result[] | undefined };
   },
   update: (params: DynamoUpdate) => client.update(params).promise(),
   delete: (params: DynamoDelete) => client.delete(params).promise(),

--- a/services/app-api/libs/tests/dynamodb-lib.test.ts
+++ b/services/app-api/libs/tests/dynamodb-lib.test.ts
@@ -55,6 +55,11 @@ describe("Test DynamoDB Interaction API Build Structure", () => {
       ExpressionAttributeNames: {},
       ExpressionAttributeValues: {},
     });
+    await dynamoLib.scanOnce({
+      ...testKeyTable,
+      ExpressionAttributeNames: {},
+      ExpressionAttributeValues: {},
+    });
     await dynamoLib.update({
       ...testKeyTable,
       ExpressionAttributeNames: {},
@@ -66,7 +71,7 @@ describe("Test DynamoDB Interaction API Build Structure", () => {
     });
 
     expect(mockPromiseCall).toHaveBeenCalledTimes(6);
-    expect(mockScanPromiseCall).toHaveBeenCalledTimes(2);
+    expect(mockScanPromiseCall).toHaveBeenCalledTimes(3);
   });
 
   describe("Checking Environment Variable Changes", () => {

--- a/services/app-api/libs/tests/dynamodb-lib.test.ts
+++ b/services/app-api/libs/tests/dynamodb-lib.test.ts
@@ -3,6 +3,10 @@ import { CoreSetAbbr, MeasureStatus } from "../../types";
 import AWS from "aws-sdk";
 
 const mockPromiseCall = jest.fn();
+const mockScanPromiseCall = jest
+  .fn()
+  .mockReturnValue({})
+  .mockReturnValueOnce({ LastEvaluatedKey: { key: "val" } });
 
 jest.mock("aws-sdk", () => ({
   __esModule: true,
@@ -14,7 +18,7 @@ jest.mock("aws-sdk", () => ({
           put: (x: any) => ({ promise: mockPromiseCall }),
           post: (x: any) => ({ promise: mockPromiseCall }),
           query: (x: any) => ({ promise: mockPromiseCall }),
-          scan: (x: any) => ({ promise: mockPromiseCall }),
+          scan: (x: any) => ({ promise: mockScanPromiseCall }),
           update: (x: any) => ({ promise: mockPromiseCall }),
           delete: (x: any) => ({ promise: mockPromiseCall }),
         };
@@ -24,7 +28,7 @@ jest.mock("aws-sdk", () => ({
 }));
 
 describe("Test DynamoDB Interaction API Build Structure", () => {
-  test("API structure should be callable", () => {
+  test("API structure should be callable", async () => {
     const testKeyTable = {
       Key: { compoundKey: "testKey", coreSet: CoreSetAbbr.ACS },
       TableName: "testTable",
@@ -42,26 +46,27 @@ describe("Test DynamoDB Interaction API Build Structure", () => {
       description: "",
       data: {},
     };
-    dynamoLib.query(true);
-    dynamoLib.get(testKeyTable);
-    dynamoLib.delete(testKeyTable);
-    dynamoLib.put({ TableName: "testTable", Item: testItem });
-    dynamoLib.scan({
+    await dynamoLib.query(true);
+    await dynamoLib.get(testKeyTable);
+    await dynamoLib.delete(testKeyTable);
+    await dynamoLib.put({ TableName: "testTable", Item: testItem });
+    await dynamoLib.scan({
       ...testKeyTable,
       ExpressionAttributeNames: {},
       ExpressionAttributeValues: {},
     });
-    dynamoLib.update({
+    await dynamoLib.update({
       ...testKeyTable,
       ExpressionAttributeNames: {},
       ExpressionAttributeValues: {},
     });
-    dynamoLib.post({
+    await dynamoLib.post({
       TableName: "",
       Item: testItem,
     });
 
-    expect(mockPromiseCall).toHaveBeenCalledTimes(7);
+    expect(mockPromiseCall).toHaveBeenCalledTimes(6);
+    expect(mockScanPromiseCall).toHaveBeenCalledTimes(2);
   });
 
   describe("Checking Environment Variable Changes", () => {

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -1,3 +1,5 @@
+import { Key } from "aws-sdk/clients/dynamodb";
+
 export interface CoreSet {
   compoundKey: string;
   coreSet: CoreSetAbbr;
@@ -70,6 +72,7 @@ export interface DynamoScan {
   FilterExpression?: string;
   ExpressionAttributeNames: { [key: string]: string };
   ExpressionAttributeValues: { [key: string]: any };
+  ExclusiveStartKey?: Key;
 }
 
 export interface DynamoFetch {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Defaults the scan operation to continue when LastEvaluatedKey is present. This should allow complete deleteion of measures in lower environments, in addition to preventing future oversights when LastEvaluatedKey is ignored.

Also retained the original operation as a scanOnce() operation, as it can still be useful to break early, or in the case of forceKafkaSync, handle the results of a batch one page at a time.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2416

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Generate enough data locally to see the LastEvaluatedKey trigger which takes 1MB of data in a scan. One option for doing this is to find a large string (.5MB) to put in a free text area in the database directly. Do that a few times across items.
- All those results should still return in the UI when iterating through pages. You can do this by inflating a bunch of coreset measures and making sure all the results still appear.
- A delete operation on that same coreset should delete everything and not leave orphaned measures in the db

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
