### PR TITLE
Associate OMS qualifiers with PM qualifiers by ID

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
@@ -255,7 +255,7 @@ const useStandardRateArray: RateArrayBuilder = (name) => {
 };
 
 /** Creates Rate Components for each Qualifier if filled in PM */
-const useQualRateArray: RateArrayBuilder = (name) => {
+const useRatesForCompletedPmQualifiers: RateArrayBuilder = (name) => {
   const {
     categories,
     qualifiers,
@@ -277,13 +277,22 @@ const useQualRateArray: RateArrayBuilder = (name) => {
   const quals = calcTotal ? qualifiers.slice(0, -1) : qualifiers;
   const rateArrays: React.ReactElement[][] = [];
 
+  /*
+   * Each qualifier should only show in OMS if the rate for that qualifier
+   * has been filled out in the Performance Measure.
+   * This is determined by pulling the qualifier ID out of the rate UID.
+   */
+  const completedQualifierIds = performanceMeasureArray?.[0]
+    ?.filter((qualRateFields) => qualRateFields?.rate)
+    .map((qualRateFields) => qualRateFields.uid?.split(".")[1]);
+
   quals?.forEach((singleQual, qualIndex) => {
     const categoryID = categories[0]?.id
       ? categories[0].id
       : DC.SINGLE_CATEGORY;
     const cleanedName = `${name}.rates.${categoryID}.${singleQual.id}`;
 
-    if (performanceMeasureArray?.[0]?.[qualIndex]?.rate) {
+    if (completedQualifierIds?.includes(singleQual.id)) {
       rateArrays.push([
         <QMR.Rate
           readOnly={rateReadOnly}
@@ -343,7 +352,7 @@ const useAgeGroupsCheckboxes: CheckBoxBuilder = (name) => {
   const { categories, qualifiers, calcTotal, customPrompt } =
     usePerformanceMeasureContext();
 
-  const qualRates = useQualRateArray(name);
+  const qualRates = useRatesForCompletedPmQualifiers(name);
   const standardRates = useStandardRateArray(name);
   const rateArrays =
     !categories.length || !categories.some((item) => item.label)


### PR DESCRIPTION
### Description
This fixes a bug in CIS-CH. Since previously we were associating OMS quals with PM quals by index, and CIS-CH has excludeFromOms on non-consecutive quals, we were seeing weird behavior. Completing the DTaP rate in PM would cause the MMR rate to show in OMS. Likewise IPV -> Combo 3, and MMR -> Combo 10.

Other measures seemed to be unaffected by this bug, and are likewise unaffected by the fix.

### Related ticket(s)
MDCT-2681

---
### How to test
Log in and fill out some FFY 2023 performance measures. The appropriate rates should show up in OMS, as you fill out (or clear) rates in the main Performance Measure section. Some interesting measures are
* CIS-CH: OMS includes nonconsecutive qualifiers.
* DEV-CH: Multiple qualifiers and one category. All but the total qualifier are excluded from OMS.
* FUA-CH: One qualifier and two categories
* FUA-AD: Two qualifiers and two categories, none of which are excluded from OMS
* FUH-HH: Multiple qualifiers and two categories. Most qualifiers are excluded from OMS.
* HBD-AD: Two qualifiers and two categories. One category is excluded from OMS.

### Important updates
n/a

---
### Author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
