### PR TITLE
Fix OMS Rate Calculation on AAB-CH

### DIFF
--- a/services/ui-src/src/measures/2023/AABCH/index.tsx
+++ b/services/ui-src/src/measures/2023/AABCH/index.tsx
@@ -23,7 +23,7 @@ export const AABCH = ({
   const data = watch();
   let mask: RegExp = positiveNumbersWithMaxDecimalPlaces(1);
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const rateScale = 1000;
+  const rateScale = 100;
 
   useEffect(() => {
     if (setValidationFunctions) {
@@ -60,6 +60,7 @@ export const AABCH = ({
               customMask={mask}
               rateMultiplicationValue={rateScale}
               allowNumeratorGreaterThanDenominator
+              rateCalc={AABRateCalculation}
             />
           )}
           <CMQ.CombinedRates />

--- a/services/ui-src/src/measures/2023/AABCH/index.tsx
+++ b/services/ui-src/src/measures/2023/AABCH/index.tsx
@@ -74,6 +74,7 @@ export const AABCH = ({
               qualifiers={PMD.qualifiers}
               rateMultiplicationValue={rateScale}
               allowNumeratorGreaterThanDenominator
+              rateCalc={AABRateCalculation}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -67,7 +67,6 @@ const CategoryNdrSets = ({
   return (
     <>
       {categories.map((item) => {
-        console.log(item);
         let rates: QMR.IRate[] | undefined = qualifiers?.map((cat, idx) => ({
           label: cat.label,
           uid: item.id + "." + cat.id,

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -67,6 +67,7 @@ const CategoryNdrSets = ({
   return (
     <>
       {categories.map((item) => {
+        console.log(item);
         let rates: QMR.IRate[] | undefined = qualifiers?.map((cat, idx) => ({
           label: cat.label,
           uid: item.id + "." + cat.id,


### PR DESCRIPTION
### Description
Fixed the OMS rate calculation. Previously it was calculating using this formula N/D x 1000. The correct formula for AAB was 1 - (Numerator/Denominator) x 100. 

[MDCT-2680](https://qmacbis.atlassian.net/browse/MDCT-2680)

---
### How to test
1. Create a 2023 child coreset 
2. Select AAB-CH measure
3. Enter N/D/R for OM 
4. Enter the same N/D/R for OMS
5. The ratio calculations should be the same

Before:
<img width="913" alt="Screenshot 2023-07-19 at 12 09 37 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/14514294/2acb2e50-0aeb-4370-a24b-d7d808c5db98">


After:
<img width="915" alt="Screenshot 2023-07-19 at 12 10 14 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/14514294/86f522fc-b2c0-4ced-a74c-df64e42012f1">


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
