### PR TITLE
Removing Text in Additional Notes on Reporting Change

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/AdditionalNotes/index.test.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/AdditionalNotes/index.test.tsx
@@ -1,11 +1,19 @@
 import fireEvent from "@testing-library/user-event";
 import { AdditionalNotes } from ".";
+import { Reporting } from "../Reporting";
 import { screen } from "@testing-library/react";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 
 describe("Test AdditionalNotes component", () => {
   beforeEach(() => {
-    renderWithHookForm(<AdditionalNotes />);
+    renderWithHookForm([
+      <Reporting
+        measureName="My Test Measure"
+        reportingYear="2023"
+        measureAbbreviation="MTM"
+      />,
+      <AdditionalNotes />,
+    ]);
   });
 
   it("component renders", () => {
@@ -25,5 +33,27 @@ describe("Test AdditionalNotes component", () => {
     );
     fireEvent.type(textArea, "This is the test text");
     expect(textArea).toHaveDisplayValue("This is the test text");
+  });
+
+  it("input is deleted when measure reporting radio option is changed", async () => {
+    const reportingNo = await screen.findByLabelText(
+      "No, I am not reporting My Test Measure (MTM) for FFY 2023 quality measure reporting."
+    );
+
+    const textArea = await screen.findByLabelText(
+      "Please add any additional notes or comments on the measure not otherwise captured above (state-specific comment):"
+    );
+
+    fireEvent.click(reportingNo);
+    fireEvent.type(textArea, "This is the test text");
+    expect(textArea).toHaveDisplayValue("This is the test text");
+
+    // change reporting radio button option from no to yes
+    const reportingYes = await screen.findByLabelText(
+      "Yes, I am reporting My Test Measure (MTM) for FFY 2023 quality measure reporting."
+    );
+
+    fireEvent.click(reportingYes);
+    expect(textArea).toHaveDisplayValue("");
   });
 });

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/AdditionalNotes/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/AdditionalNotes/index.tsx
@@ -4,9 +4,17 @@ import { useCustomRegister } from "hooks/useCustomRegister";
 import { Upload } from "components/Upload";
 import * as Types from "../types";
 import * as DC from "dataConstants";
+import { useFormContext } from "react-hook-form";
+import { useEffect } from "react";
 
 export const AdditionalNotes = () => {
   const register = useCustomRegister<Types.AdditionalNotes>();
+  const { getValues, resetField } = useFormContext();
+  const didReport = getValues()["DidReport"];
+
+  useEffect(() => {
+    resetField("AdditionalNotes-AdditionalNotes");
+  }, [didReport, resetField]);
 
   return (
     <QMR.CoreQuestionWrapper


### PR DESCRIPTION
### Description
Previously, the "Additional Notes/Comments on the measure (optional)" field content would persist even when the a user changes their Reporting status. The field now deletes it's content when ever a user switches Reporting status, similar to other fields in the form. 


### Related ticket(s)
https://qmacbis.atlassian.net/browse/MDCT-2259
MDCT-2259

---
### How to test
1. Go to 2023 measure
2. In Measure select "Yes" from "Are you reporting on this measure?"
3. Scroll to "Additional Notes/Comments on the measure (optional)" and enter some content
4. Go back to "Are you reporting on this measure?" and change your selection to "No"
5. Scroll down to Additional Notes. The content should be deleted.




### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
