### PR TITLE
Set Login Year to 2023

### DIFF
--- a/services/ui-src/src/config.ts
+++ b/services/ui-src/src/config.ts
@@ -32,7 +32,7 @@ const configToExport = {
     REDIRECT_SIGNOUT: window._env_.COGNITO_REDIRECT_SIGNOUT,
   },
   POST_SIGNOUT_REDIRECT: window._env_.POST_SIGNOUT_REDIRECT,
-  currentReportingYear: "2021",
+  currentReportingYear: "2023",
   REACT_APP_LD_SDK_CLIENT: window._env_.REACT_APP_LD_SDK_CLIENT,
 };
 

--- a/services/ui-src/src/views/AdminHome/index.tsx
+++ b/services/ui-src/src/views/AdminHome/index.tsx
@@ -7,7 +7,7 @@ import { useFlags } from "launchdarkly-react-client-sdk";
 
 export const AdminHome = () => {
   const [locality, setLocality] = useState("AL");
-  const releaseYearByFlag = useFlags()
+  const releaseYearByFlag = useFlags()?.["release2023"]
     ? config.currentReportingYear
     : parseInt(config.currentReportingYear) - 1;
   const navigate = useNavigate();

--- a/services/ui-src/src/views/AdminHome/index.tsx
+++ b/services/ui-src/src/views/AdminHome/index.tsx
@@ -3,9 +3,13 @@ import * as CUI from "@chakra-ui/react";
 import { stateAbbreviations } from "utils/constants";
 import { useNavigate } from "react-router";
 import config from "config";
+import { useFlags } from "launchdarkly-react-client-sdk";
 
 export const AdminHome = () => {
   const [locality, setLocality] = useState("AL");
+  const releaseYearByFlag = useFlags()
+    ? config.currentReportingYear
+    : parseInt(config.currentReportingYear) - 1;
   const navigate = useNavigate();
   return (
     <CUI.Container maxW="7xl" py="4">
@@ -26,9 +30,7 @@ export const AdminHome = () => {
         </CUI.Select>
         <CUI.Button
           colorScheme="blue"
-          onClick={() =>
-            navigate(`/${locality}/${config.currentReportingYear}`)
-          }
+          onClick={() => navigate(`/${locality}/${releaseYearByFlag}`)}
           isFullWidth
           data-cy="Go To State Home"
         >

--- a/services/ui-src/src/views/Home/index.tsx
+++ b/services/ui-src/src/views/Home/index.tsx
@@ -5,9 +5,13 @@ import * as CUI from "@chakra-ui/react";
 import "./index.module.scss";
 import * as QMR from "components";
 import { useUser } from "hooks/authHooks";
+import { useFlags } from "launchdarkly-react-client-sdk";
 
 export function Home() {
   const { userRole, userState } = useUser();
+  const releaseYearByFlag = useFlags()
+    ? config.currentReportingYear
+    : parseInt(config.currentReportingYear) - 1;
   if (
     userRole === UserRoles.HELP ||
     userRole === UserRoles.ADMIN ||
@@ -27,5 +31,5 @@ export function Home() {
       </CUI.Box>
     );
   }
-  return <Navigate to={`/${userState}/${config.currentReportingYear}`} />;
+  return <Navigate to={`/${userState}/${releaseYearByFlag}`} />;
 }

--- a/services/ui-src/src/views/Home/index.tsx
+++ b/services/ui-src/src/views/Home/index.tsx
@@ -9,7 +9,7 @@ import { useFlags } from "launchdarkly-react-client-sdk";
 
 export function Home() {
   const { userRole, userState } = useUser();
-  const releaseYearByFlag = useFlags()
+  const releaseYearByFlag = useFlags()?.["release2023"]
     ? config.currentReportingYear
     : parseInt(config.currentReportingYear) - 1;
   if (

--- a/tests/cypress/cypress/integration/a11y/ADDCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ADDCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("ADD-CH Page 508 Compliance Test", () => {
   it("Check a11y on ADD-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("ADD-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/AMBCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/AMBCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("AMB-CH Page 508 Compliance Test", () => {
   it("Check a11y on AMB-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("AMB-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/AMRCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/AMRCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("AMR-CH Page 508 Compliance Test", () => {
   it("Check a11y on AMR-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("AMR-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/APMCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/APMCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("APM-CH Page 508 Compliance Test", () => {
   it("Check a11y on APM-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("APM-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/APPCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/APPCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("APP-CH Page 508 Compliance Test", () => {
   it("Check a11y on APP-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("APP-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/AUDCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/AUDCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("AUD-CH Page 508 Compliance Test", () => {
   it("Check a11y on AUD-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("AUD-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/CCPCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/CCPCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("CCP-CH Page 508 Compliance Test", () => {
   it("Check a11y on CCP-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CCP-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/CCWCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/CCWCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("CCW-CH Page 508 Compliance Test", () => {
   it("Check a11y on CCW-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CCW-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/CDFCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/CDFCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("CDF-CH Page 508 Compliance Test", () => {
   it("Check a11y on CDF-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CDF-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/CHLCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/CHLCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("CHL-CH Page 508 Compliance Test", () => {
   it("Check a11y on CHL-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CHL-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/CISCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/CISCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("CIS-CH Page 508 Compliance Test", () => {
   it("Check a11y on CIS-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CIS-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/CPCCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/CPCCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("CPC-CH Page 508 Compliance Test", () => {
   it("Check a11y on CPC-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CPC-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/DEVCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/DEVCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("DEV-CH Page 508 Compliance Test", () => {
   it("Check a11y on DEV-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("DEV-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/FUHCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/FUHCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("FUH-CH Page 508 Compliance Test", () => {
   it("Check a11y on FUH-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("FUH-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/IMACHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/IMACHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("IMA-CH Page 508 Compliance Test", () => {
   it("Check a11y on IMA-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("IMA-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/LBWCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/LBWCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe.skip("LBW-CH Page 508 Compliance Test", () => {
   it("Check a11y on LBW-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("LBW-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/LRCDCH.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/LRCDCH.spec.ts
@@ -1,6 +1,7 @@
 describe.skip("LRCD-CH Page 508 Compliance Test", () => {
   it("Check a11y on LRCD-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("LRCD-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/PDENTpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/PDENTpage.spec.ts
@@ -1,6 +1,7 @@
 describe.skip("PDENT-CH Page 508 Compliance Test", () => {
   it("Check a11y on PDENT-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("PDENT-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/PPCCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/PPCCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("PPC-CH Page 508 Compliance Test", () => {
   it("Check a11y on PPC-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("PPC-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/SFMCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/SFMCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("SFM-CH Page 508 Compliance Test", () => {
   it("Check a11y on SFM-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("SFM-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/W30CHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/W30CHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("W30-CH Page 508 Compliance Test", () => {
   it("Check a11y on W30-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("W30-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/WCCCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/WCCCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("WCC-CH Page 508 Compliance Test", () => {
   it("Check a11y on WCC-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("WCC-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/WCVCHpage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/WCVCHpage.spec.ts
@@ -1,6 +1,7 @@
 describe("WCV-CH Page 508 Compliance Test", () => {
   it("Check a11y on WCV-CH Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("WCV-CH");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/ammadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ammadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("AMM-AD Page 508 Compliance Test", () => {
   it("Check a11y on AMMAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("AMM-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/amradPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/amradPage.spec.ts
@@ -1,6 +1,7 @@
 describe("AMR-AD Page 508 Compliance Test", () => {
   it("Check a11y on AMRAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("AMR-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/bcsadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/bcsadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("BCS-AD Page 508 Compliance Test", () => {
   it("Check a11y on BCSAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("BCS-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/cbpadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/cbpadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("CBP-AD Page 508 Compliance Test", () => {
   it("Check a11y on CBPAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CBP-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/ccpadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ccpadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("CCP-AD Page 508 Compliance Test", () => {
   it("Check a11y on CCPAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCP-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/ccsadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ccsadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("CCS-AD Page 508 Compliance Test", () => {
   it("Check a11y on CCSAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCS-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/ccwadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ccwadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("CCW-AD Page 508 Compliance Test", () => {
   it("Check a11y on CCWAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCW-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/cdfadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/cdfadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("CDF-AD Page 508 Compliance Test", () => {
   it("Check a11y on CDFAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CDF-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/chladPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/chladPage.spec.ts
@@ -1,6 +1,7 @@
 describe("CHL-AD Page 508 Compliance Test", () => {
   it("Check a11y on CHLAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CHL-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/cobadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/cobadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("COB-AD Page 508 Compliance Test", () => {
   it("Check a11y on COBAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("COB-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/commonPages.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/commonPages.spec.ts
@@ -1,6 +1,7 @@
 describe("Check A11y on Common Pages", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
   });
 
   it("Check a11y on Home Page", () => {

--- a/tests/cypress/cypress/integration/a11y/cpaadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/cpaadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("CPA-AD Page 508 Compliance Test", () => {
   it("Check a11y on CPAAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CPA-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/fuadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/fuadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("FUAD Page 508 Compliance Test", () => {
   it("Check a11y on FUAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("FUA-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/fuhadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/fuhadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("FUH-AD Page 508 Compliance Test", () => {
   it("Check a11y on FUHAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("FUH-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/fumadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/fumadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("FUM-AD Page 508 Compliance Test", () => {
   it("Check a11y on FUMAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("FUM-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/fvaadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/fvaadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("FVA-AD Page 508 Compliance Test", () => {
   it("Check a11y on FVAAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("FVA-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/hpcadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/hpcadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("HPC-AD Page 508 Compliance Test", () => {
   it("Check a11y on HPCAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("HPC-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/hpcmiadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/hpcmiadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("HPCMI-AD Page 508 Compliance Test", () => {
   it("Check a11y on HPCMIAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("HPCMI-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/hvladPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/hvladPage.spec.ts
@@ -1,6 +1,7 @@
 describe("HVL-AD Page 508 Compliance Test", () => {
   it("Check a11y on HVLAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("HVL-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/ietadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ietadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("IETAD Page 508 Compliance Test", () => {
   it("Check a11y on IETAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("IET-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/mscadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/mscadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("MSC-AD Page 508 Compliance Test", () => {
   it("Check a11y on MSCAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("MSC-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/nciddsPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/nciddsPage.spec.ts
@@ -1,6 +1,7 @@
 describe.skip("NCIDDS-AD Page 508 Compliance Test", () => {
   it("Check a11y on NCIDDSAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("NCIDDS-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/ohdadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ohdadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("OHD-AD Page 508 Compliance Test", () => {
   it("Check a11y on OHDAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("OHD-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/oudadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/oudadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("OUD-AD Page 508 Compliance Test", () => {
   it("Check a11y on OUDAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("OUD-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/pc01adPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/pc01adPage.spec.ts
@@ -1,6 +1,7 @@
 describe("PC01-AD Page 508 Compliance Test", () => {
   it("Check a11y on PC01AD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PC01-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/pcradPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/pcradPage.spec.ts
@@ -1,6 +1,7 @@
 describe("PCR-AD Page 508 Compliance Test", () => {
   it("Check a11y on PCRAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PCR-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/ppcadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ppcadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("PPC-AD Page 508 Compliance Test", () => {
   it("Check a11y on PPCAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PPC-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/pqi01adPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/pqi01adPage.spec.ts
@@ -1,6 +1,7 @@
 describe("PQI01-AD Page 508 Compliance Test", () => {
   it("Check a11y on PQI01AD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PQI01-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/pqi05adPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/pqi05adPage.spec.ts
@@ -1,6 +1,7 @@
 describe("PQI05-AD Page 508 Compliance Test", () => {
   it("Check a11y on PQI05AD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PQI05-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/pqi08adPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/pqi08adPage.spec.ts
@@ -1,6 +1,7 @@
 describe("PQI08-AD Page 508 Compliance Test", () => {
   it("Check a11y on PQI08AD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PQI08-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/pqi15adPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/pqi15adPage.spec.ts
@@ -1,6 +1,7 @@
 describe("PQI15-AD Page 508 Compliance Test", () => {
   it("Check a11y on PQI15AD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PQI15-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/ssaadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ssaadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("SAA-AD Page 508 Compliance Test", () => {
   it("Check a11y on SAAAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("SAA-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/a11y/ssdadPage.spec.ts
+++ b/tests/cypress/cypress/integration/a11y/ssdadPage.spec.ts
@@ -1,6 +1,7 @@
 describe("SSD-AD Page 508 Compliance Test", () => {
   it("Check a11y on SSDAD Page", () => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("SSD-AD");
     cy.checkA11yOfPage();

--- a/tests/cypress/cypress/integration/features/NDR_validation_updates.spec.ts
+++ b/tests/cypress/cypress/integration/features/NDR_validation_updates.spec.ts
@@ -1,6 +1,7 @@
 describe("OY2 16341 NDR set validation updates for all measures ", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
   });
 
   it("Click on NO for the first question then click on validate and complete button for CCP-AD", () => {

--- a/tests/cypress/cypress/integration/features/PRINT.spec.ts
+++ b/tests/cypress/cypress/integration/features/PRINT.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: AMR-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("AMR-AD");
   });

--- a/tests/cypress/cypress/integration/features/add_validation_to_rate_when_user_selects_multiple_Data_Sources.spec.ts
+++ b/tests/cypress/cypress/integration/features/add_validation_to_rate_when_user_selects_multiple_Data_Sources.spec.ts
@@ -1,6 +1,7 @@
 describe("Add Validation to Rate when user selects multiple Data Sources.", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCP-AD");
   });

--- a/tests/cypress/cypress/integration/features/adding_link_to_combined_rates_component.spec.ts
+++ b/tests/cypress/cypress/integration/features/adding_link_to_combined_rates_component.spec.ts
@@ -1,6 +1,7 @@
 describe("OY2 16411 Restructuring Data Source Text boxes", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCP-AD");
   });

--- a/tests/cypress/cypress/integration/features/combined_rates_validation_warnings.spec.ts
+++ b/tests/cypress/cypress/integration/features/combined_rates_validation_warnings.spec.ts
@@ -1,6 +1,7 @@
 describe("Combined rates validation testing", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("OUD-AD");
   });

--- a/tests/cypress/cypress/integration/features/copy_coreset_and_measures_for_new_year.spec.ts
+++ b/tests/cypress/cypress/integration/features/copy_coreset_and_measures_for_new_year.spec.ts
@@ -1,6 +1,7 @@
 describe("Coresets and measures should reflect the chosen year", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
   });
 
   it("displays the correct information based on 2021", () => {

--- a/tests/cypress/cypress/integration/features/data_source_rate_to_auto_calculate_in_OPM.spec.ts
+++ b/tests/cypress/cypress/integration/features/data_source_rate_to_auto_calculate_in_OPM.spec.ts
@@ -1,6 +1,7 @@
 describe("Data source/ Rate to auto calculate in OPM", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("FUA-AD");
   });

--- a/tests/cypress/cypress/integration/features/date_range_adjustment.spec.ts
+++ b/tests/cypress/cypress/integration/features/date_range_adjustment.spec.ts
@@ -1,6 +1,7 @@
 describe("Date Range Adjustment for Start/End date", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCP-AD");
   });

--- a/tests/cypress/cypress/integration/features/export_all_measures.spec.ts
+++ b/tests/cypress/cypress/integration/features/export_all_measures.spec.ts
@@ -3,6 +3,7 @@ import { measureAbbrList2021 } from "../../../support/commands/commands";
 describe.skip("Export All Measures", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.window().then((win) => {
       cy.stub(win, "open").callsFake((url) => {
         win.location.href = url;

--- a/tests/cypress/cypress/integration/features/kebab_menu_measures.spec.ts
+++ b/tests/cypress/cypress/integration/features/kebab_menu_measures.spec.ts
@@ -1,6 +1,7 @@
 describe.skip("Measure kebab menus", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
   });
 
   it('displays "View" option', () => {

--- a/tests/cypress/cypress/integration/features/measure_validation_error_creation_updates.spec.ts
+++ b/tests/cypress/cypress/integration/features/measure_validation_error_creation_updates.spec.ts
@@ -1,6 +1,7 @@
 describe("Confirm Validate Measure Errors", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CHL-AD");
   });

--- a/tests/cypress/cypress/integration/features/measurement_spec_def_of_pop_validation_text_changes.spec.ts
+++ b/tests/cypress/cypress/integration/features/measurement_spec_def_of_pop_validation_text_changes.spec.ts
@@ -1,6 +1,7 @@
 describe("Measurement Specification/Definition of Population/Validation text changes (#85, #87, #93)", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
   });
 

--- a/tests/cypress/cypress/integration/features/partially_completed_validation.spec.ts
+++ b/tests/cypress/cypress/integration/features/partially_completed_validation.spec.ts
@@ -1,6 +1,7 @@
 describe.skip("OY2 16341 NDR set validation updates for all measures ", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
   });
 
   it("should throw validation error for partially completed ndr sets - just qualifiers", () => {

--- a/tests/cypress/cypress/integration/features/reporting_in_FY21_tag_for_alt_data_sources.spec.ts
+++ b/tests/cypress/cypress/integration/features/reporting_in_FY21_tag_for_alt_data_sources.spec.ts
@@ -1,6 +1,7 @@
 describe("OY2 15211 Reporting in FY22 Tag for Alt Data Sources", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
   });
 
   it("N/A And Completed Statuses", () => {

--- a/tests/cypress/cypress/integration/features/restructuring_data_source_text_boxes.spec.ts
+++ b/tests/cypress/cypress/integration/features/restructuring_data_source_text_boxes.spec.ts
@@ -1,6 +1,7 @@
 describe("OY2 16411 Restructuring Data Source Text boxes", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCP-AD");
   });

--- a/tests/cypress/cypress/integration/features/state_specific_measures.spec.ts
+++ b/tests/cypress/cypress/integration/features/state_specific_measures.spec.ts
@@ -1,6 +1,7 @@
 describe.skip("Add state specific measure testing", () => {
   before(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.get('[data-cy="add-hhbutton"]').click(); // clicking on adding child core set measures
     cy.get('[data-cy="HealthHomeCoreSet-SPA"]').select(1); // select first available SPA
     cy.get('[data-cy="Create"]').click(); //clicking create

--- a/tests/cypress/cypress/integration/features/submit_coreset.spec.ts
+++ b/tests/cypress/cypress/integration/features/submit_coreset.spec.ts
@@ -1,6 +1,7 @@
 describe.skip("Submit Core Set button", () => {
   beforeEach(() => {
     cy.login("stateuser4");
+    cy.selectYear("2021");
     cy.get('[data-cy="adult-kebab-menu"]').click();
     cy.get('[data-cy="Reset All Measures"]').first().click();
     cy.wait(1000);

--- a/tests/cypress/cypress/integration/features/update_user_auth_handling_in_ui.spec.ts
+++ b/tests/cypress/cypress/integration/features/update_user_auth_handling_in_ui.spec.ts
@@ -5,6 +5,7 @@ describe("Confirm Admin View", () => {
     cy.xpath("//input[@name='password']").type(Cypress.env("TEST_PASSWORD_1"));
     cy.get('[data-cy="login-with-cognito-button"]').click();
     cy.get('[data-cy="Go To State Home"]').click();
+    cy.selectYear("2021");
     cy.get('[data-cy="ACS"]').click();
     cy.get('[data-cy="HPC-AD"]').click();
     cy.get('[data-cy="Save"]').should("be.disabled");

--- a/tests/cypress/cypress/integration/features/user_must_select_a_data_source_selection_validation.spec.ts
+++ b/tests/cypress/cypress/integration/features/user_must_select_a_data_source_selection_validation.spec.ts
@@ -1,6 +1,7 @@
 describe("User must select a data source selection validation", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
   });
   it("verify error message when no data entered and click on validate button", () => {
     cy.get('[data-cy="ACS"]').click();

--- a/tests/cypress/cypress/integration/init/create_delete_child.spec.ts
+++ b/tests/cypress/cypress/integration/init/create_delete_child.spec.ts
@@ -1,6 +1,7 @@
 describe("Child Core Sets Should be able to be deleted and created", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
   });
 
   it("Creates separate child core-set", () => {

--- a/tests/cypress/cypress/integration/init/create_delete_healthhome.spec.ts
+++ b/tests/cypress/cypress/integration/init/create_delete_healthhome.spec.ts
@@ -1,6 +1,7 @@
 describe("Health Home Sets Should be able to be deleted and created", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.wait(2000);
   });
 

--- a/tests/cypress/cypress/integration/measures/adult/AMMAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/AMMAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: AMM-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("AMM-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/AMRAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/AMRAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: AMR-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("AMR-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/BCSAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/BCSAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: BCS-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("BCS-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/CBPAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/CBPAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure 34: CBP-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CBP-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/CCPAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/CCPAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: CCP-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCP-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/CCSAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/CCSAD.spec.ts
@@ -1,6 +1,7 @@
 describe("CCS-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCS-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/CCWAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/CCWAD.spec.ts
@@ -1,6 +1,7 @@
 describe("CCW-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CCW-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/CDFAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/CDFAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: CDF-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CDF-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/CHLAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/CHLAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: CHL-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("CHL-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/COBAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/COBAD.spec.ts
@@ -1,6 +1,7 @@
 describe("OY2 9940 COB-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("COB-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/FUAAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/FUAAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: FUA-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("FUA-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/FUHAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/FUHAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure 10: FUH-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("FUH-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/FUMAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/FUMAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: FUM-AD", () => {
   before(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("FUM-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/FVAAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/FVAAD.spec.ts
@@ -1,6 +1,7 @@
 describe("OY2 9898 FVA-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("FVA-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/HPCAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/HPCAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: HPC-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("HPC-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/HPCMIAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/HPCMIAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: HPCMI-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("HPCMI-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/HVLAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/HVLAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: HVL-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("HVL-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/MSCAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/MSCAD.spec.ts
@@ -1,6 +1,7 @@
 describe("OY2 8977 Measure 15 MSC-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("MSC-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/NCIDDSAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/NCIDDSAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: HPCMI-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("HPCMI-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/OHDAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/OHDAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: OHD-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("OHD-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/OUDAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/OUDAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: OUD-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("OUD-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/PC01AD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/PC01AD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: PC01-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PC01-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/PCRAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/PCRAD.spec.ts
@@ -1,6 +1,7 @@
 describe("PCR-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PCR-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/PPCAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/PPCAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: PPC-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PPC-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/PQI01AD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/PQI01AD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: PQI01-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PQI01-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/PQI05AD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/PQI05AD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: PQI05-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PQI05-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/PQI08AD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/PQI08AD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: PQI08-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PQI08-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/PQI15AD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/PQI15AD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: PQI15-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("PQI15-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/QUALIFIERS_adult.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/QUALIFIERS_adult.spec.ts
@@ -1,6 +1,7 @@
 describe("AdultMeasure Qualifiers", () => {
   beforeEach(() => {
     cy.login("stateuser2");
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
   });
 

--- a/tests/cypress/cypress/integration/measures/adult/SAAAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/SAAAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: SAA-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("SAA-AD");
   });

--- a/tests/cypress/cypress/integration/measures/adult/SSDAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/SSDAD.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: SSD-AD", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToAdultMeasures();
     cy.goToMeasure("SSD-AD");
   });

--- a/tests/cypress/cypress/integration/measures/child/ADDCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/ADDCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: oy2-9921 ADD-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("ADD-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/AMBCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/AMBCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure 20: AMB-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("AMB-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/AMBHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/AMBHH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure 19: AMB-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("AMB-HH");
   });

--- a/tests/cypress/cypress/integration/measures/child/AMRCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/AMRCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: AMR-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("AMR-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/APMCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/APMCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: APM-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("APM-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/APPCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/APPCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: APP-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("APP-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/AUDCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/AUDCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: oy2_9922 AUD-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("AUD-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/CCPCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/CCPCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure CCP-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CCP-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/CCWCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/CCWCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: CCW-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CCW-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/CDFCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/CDFCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: oy2-8979 CDF-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CDF-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/CHLCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/CHLCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: oy2-9923 CHL-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CHL-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/CISCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/CISCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: CIS-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CIS-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/CPCCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/CPCCH.spec.ts
@@ -1,6 +1,7 @@
 describe("OY2 9963 CPC CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("CPC-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/DEVCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/DEVCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: DEV-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("DEV-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/FUHCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/FUHCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: FUH-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("FUH-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/IMACH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/IMACH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: IMA-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("IMA-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/PPCCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/PPCCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: PPC-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("PPC-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/QUALIFIERS_child.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/QUALIFIERS_child.spec.ts
@@ -1,6 +1,7 @@
 describe("Child Measure Qualifier: CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
   });
 
   it("Child Core Set Measures: Combined", () => {

--- a/tests/cypress/cypress/integration/measures/child/SFMCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/SFMCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: oy2-9936 SFM-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("SFM-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/W30CH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/W30CH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure 45: W30-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("W30-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/WCCCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/WCCCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: WCC-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("WCC-CH");
   });

--- a/tests/cypress/cypress/integration/measures/child/WCVCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/child/WCVCH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: oy2-9916 WCV-CH", () => {
   beforeEach(() => {
     cy.login();
+    cy.selectYear("2021");
     cy.goToChildCoreSetMeasures();
     cy.goToMeasure("WCV-CH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/AIFHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/AIFHH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: AIF-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("AIF-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/CBPHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/CBPHH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: CBP-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("CBP-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/CDFHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/CDFHH.spec.ts
@@ -3,6 +3,7 @@ import { should } from "chai";
 describe("Measure: CDF-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("CDF-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/FUAHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/FUAHH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: FUA-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("FUA-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/FUHHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/FUHHH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: FUH-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("FUH-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/IETHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/IETHH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: IET-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("IET-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/IUHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/IUHH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: IU-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("IU-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/OUDHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/OUDHH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: OUD-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("OUD-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/PCRHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/PCRHH.spec.ts
@@ -1,6 +1,7 @@
 describe("PCR-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("PCR-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/PQI92HH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/PQI92HH.spec.ts
@@ -1,6 +1,7 @@
 describe("Measure: PQI92-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.goToMeasure("PQI92-HH");
   });

--- a/tests/cypress/cypress/integration/measures/healthhome/QUALIFIERS_healthhome.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/QUALIFIERS_healthhome.spec.ts
@@ -1,6 +1,7 @@
 describe("Health Home Measure Qualifier: HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
   });
 
   it("Health Home Core Set Measures", () => {

--- a/tests/cypress/cypress/integration/measures/healthhome/SSHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/healthhome/SSHH.spec.ts
@@ -1,6 +1,7 @@
 describe.skip("Measure: SS-HH", () => {
   beforeEach(() => {
     cy.loginHealthHome();
+    cy.selectYear("2021");
     cy.goToHealthHomeSetMeasures();
     cy.addStateSpecificMeasure();
   });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We're finally doing it, we're making the login default reporting year 2023 in QMR. 

Also, cypress test have been updated to select year 2021 so that it doesn't break everything.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2764

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Sign into QMR
- Look at the Reporting Year, it's now 2023

We will never have to make this mistake again.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [X] I have performed a self-review of my code
- [X] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
