### PR TITLE
mdct 2670 e2e failure

### DIFF
--- a/tests/cypress/cypress/integration/init/create_delete_child.spec.ts
+++ b/tests/cypress/cypress/integration/init/create_delete_child.spec.ts
@@ -16,6 +16,7 @@ describe("Child Core Sets Should be able to be deleted and created", () => {
     cy.get('[data-cy="add-childbutton"]').click({ force: true }); // clicking on adding child core set measures
     cy.get("#ChildCoreSet-ReportType-combined").click({ force: true }); //selecting combined core set
     cy.get('[data-cy="Create"]').click({ force: true }); //clicking create
+    cy.wait(3000);
     cy.get('[data-cy="add-childbutton"]').should("be.disabled"); // check button diabled if created
   });
 });

--- a/tests/cypress/support/commands/commands.ts
+++ b/tests/cypress/support/commands/commands.ts
@@ -151,10 +151,11 @@ Cypress.Commands.add("displaysSectionsWhenUserNotReporting", () => {
 
 // helper recursive function to remove added core sets
 const removeCoreSetElements = (kebab: string, coreSetAction: string) => {
+  cy.wait(3000);
   cy.get(kebab).first().click();
   cy.get('[data-cy="Delete"]').first().click({ force: true });
   cy.get('[data-cy="delete-table-item-input"]').type("delete{enter}");
-  cy.wait(1000);
+  cy.wait(3000);
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find(kebab).length > 0) {
       removeCoreSetElements(kebab, coreSetAction);

--- a/tests/cypress/support/commands/commands.ts
+++ b/tests/cypress/support/commands/commands.ts
@@ -151,8 +151,8 @@ Cypress.Commands.add("displaysSectionsWhenUserNotReporting", () => {
 
 // helper recursive function to remove added core sets
 const removeCoreSetElements = (kebab: string, coreSetAction: string) => {
-  cy.wait(3000);
   cy.get(kebab).first().click();
+  cy.wait(3000);
   cy.get('[data-cy="Delete"]').first().click({ force: true });
   cy.get('[data-cy="delete-table-item-input"]').type("delete{enter}");
   cy.wait(3000);
@@ -165,6 +165,7 @@ const removeCoreSetElements = (kebab: string, coreSetAction: string) => {
 
 // removes child core set from main page
 Cypress.Commands.add("deleteChildCoreSets", () => {
+  cy.wait(3000);
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find('[data-cy="child-kebab-menu"]').length > 0) {
       removeCoreSetElements(


### PR DESCRIPTION
### Description
create-delete-child.spec fails often. The failures are inconsistent. Added some wait commands to see if it's a timing issue. 


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2670

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
