### PR TITLE
Date Range Enhancements

### DIFF
--- a/services/ui-src/src/components/Inputs/RadioButton/index.tsx
+++ b/services/ui-src/src/components/Inputs/RadioButton/index.tsx
@@ -17,6 +17,7 @@ interface RadioButtonProps extends QMR.InputWrapperProps, ControllerRules {
   options: RadioButtonOption[];
   radioGroupProps?: CUI.RadioGroupProps;
   name: string;
+  subTextElement?: JSX.Element;
   valueAsArray?: boolean;
 }
 
@@ -24,6 +25,7 @@ export const RadioButton = ({
   options,
   radioGroupProps,
   name,
+  subTextElement,
   rules,
   valueAsArray,
   ...rest
@@ -62,6 +64,7 @@ export const RadioButton = ({
         }}
         {...radioGroupProps}
       >
+        {subTextElement}
         <CUI.Stack>
           {options.map((option, idx) => {
             const compVal = valueAsArray ? field.value?.[0] : field.value;

--- a/services/ui-src/src/components/MonthPicker/calendarPopup.tsx
+++ b/services/ui-src/src/components/MonthPicker/calendarPopup.tsx
@@ -35,9 +35,13 @@ const monthNames = [
 export const MonthPickerCalendar = ({
   yearForMeasure = config.currentReportingYear,
   selectedMonth,
-  selectedYear = yearForMeasure,
+  selectedYear = parseInt(yearForMeasure) >= 2023
+    ? (parseInt(yearForMeasure) - 1).toString()
+    : yearForMeasure,
   maxYear = parseInt(yearForMeasure),
-  minYear = parseInt(yearForMeasure) - 2,
+  minYear = parseInt(yearForMeasure) >= 2023
+    ? parseInt(yearForMeasure) - 3
+    : parseInt(yearForMeasure) - 2,
   yearLocked = false,
   onChange: handleChange,
 }: CalendarProps) => {

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/DateRange/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/DateRange/index.tsx
@@ -17,6 +17,18 @@ interface Props {
   type: "adult" | "child" | "health";
 }
 
+const subTextElement = (link: string) => {
+  return (
+    <CUI.Text mt="2" mb="2">
+      Information for each measure is available in the{" "}
+      <CUI.Link href={link} color="blue" isExternal>
+        Measurement Period Table
+      </CUI.Link>{" "}
+      resource.
+    </CUI.Text>
+  );
+};
+
 export const DateRange = ({ type }: Props) => {
   const register = useCustomRegister<Types.DateRange>();
   const link = measurementPeriodTableLinks[type];
@@ -27,6 +39,7 @@ export const DateRange = ({ type }: Props) => {
         formLabelProps={{ fontWeight: "bold" }}
         label="Did your state adhere to Core Set specifications in defining the measurement period for calculating this measure?"
         {...register(DC.MEASUREMENT_PERIOD_CORE_SET)}
+        subTextElement={subTextElement(link)}
         options={[
           {
             displayValue:
@@ -46,15 +59,6 @@ export const DateRange = ({ type }: Props) => {
                     the measurement period to determine eligibility or
                     utilization. The measurement period entered in the Start and
                     End Date fields should not include the “look-back period.”
-                  </CUI.Text>
-
-                  <CUI.Text>
-                    More information about the Start and End Date for each
-                    measure is available in the{" "}
-                    <CUI.Link href={link} color="blue" isExternal>
-                      Measurement Period Table
-                    </CUI.Link>{" "}
-                    resource.
                   </CUI.Text>
                 </CUI.Stack>
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
A couple of enhancements added to the date range
1) Update and moving the text "Information for each measure is available in the Measurement Period Table resource" to underneath the header text
2) have the calendar default year be current year - 1 (i.e. if the reporting year is 2023, the date range should default to 2022)
3) The date range min use to be 2021 but now it is 2020


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2763

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account will work
2) Select Reporting Year 2023
3) Go to adult measures AMM-AD
4) Scroll down to Date Range
5) Check for
- Text is the same as the one in the green box
- Calendar pop up, the **default year is 2022**
- The min amount of year back stops at 2020

<img width="857" alt="Screenshot 2023-07-27 at 4 27 40 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/608000f3-06f2-4049-8eb2-9c22624b4678">


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
