### PR TITLE
MDCT-2765 Pt. II: Add New Definition of Population Validation

### DIFF
--- a/services/ui-src/src/measures/2023/AABAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AABAD/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -193,6 +194,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
     expect(V.validateAtLeastOneDeviationFieldFilled).toHaveBeenCalled();
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AABAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AABAD/validation.ts
@@ -51,6 +51,7 @@ const AABADValidation = (data: FormData) => {
       didCalculationsDeviate,
       deviationReason
     ),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/AABCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AABCH/index.test.tsx
@@ -180,6 +180,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(
       V.validateRequiredRadioButtonForCombinedRates
     ).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -198,6 +199,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
     expect(V.validateRequiredRadioButtonForCombinedRates).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AABCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AABCH/validation.ts
@@ -46,6 +46,7 @@ const AABCHValidation = (data: FormData) => {
       PMD.qualifiers
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/ADDCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/ADDCH/index.test.tsx
@@ -184,6 +184,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     ).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOneQualDenomHigherThanOtherDenomOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/ADDCH/validation.ts
+++ b/services/ui-src/src/measures/2023/ADDCH/validation.ts
@@ -48,6 +48,7 @@ const ADDCHValidation = (data: FormData) => {
       didCalculationsDeviate,
       deviationReason
     ),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/AIFHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AIFHH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it.skip("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -192,6 +193,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateBothDatesCompleted).toHaveBeenCalled();
     expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AIFHH/validation.ts
+++ b/services/ui-src/src/measures/2023/AIFHH/validation.ts
@@ -54,6 +54,7 @@ const AIFHHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     ...GV.ComplexValidateDualPopInformation(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/AMBCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMBCH/index.test.tsx
@@ -183,6 +183,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +205,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AMBCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBCH/validation.ts
@@ -40,6 +40,7 @@ const AMBCHValidation = (data: FormData) => {
     ...GV.validateTotalNDR(performanceMeasureArray, undefined, undefined),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/AMBHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMBHH/index.test.tsx
@@ -181,12 +181,12 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
     mockValidateAndSetErrors(validationFunctions, completedMeasureData); // trigger validations
     expect(V.validateReasonForNotReporting).not.toHaveBeenCalled();
-
     expect(V.validateAtLeastOneRateComplete).toHaveBeenCalled();
     expect(V.validateNumeratorsLessThanDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroPM).toHaveBeenCalled();
@@ -200,6 +200,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AMBHH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBHH/validation.ts
@@ -36,6 +36,7 @@ const AMBHHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/AMMAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMMAD/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +203,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/AMMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMMAD/validation.ts
@@ -75,6 +75,7 @@ const AMMADValidation = (data: FormData) => {
       didCalculationsDeviate,
       deviationReason
     ),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AMRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRAD/validation.ts
@@ -44,6 +44,7 @@ const AMRADValidation = (data: FormData) => {
       ageGroups
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateTotalNDR(performanceMeasureArray),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/AMRCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMRCH/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +203,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AMRCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRCH/validation.ts
@@ -44,6 +44,7 @@ const AMRCHValidation = (data: FormData) => {
       ageGroups
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateTotalNDR(performanceMeasureArray),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/APMCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/APMCH/index.test.tsx
@@ -183,6 +183,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +205,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/APMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APMCH/validation.ts
@@ -65,6 +65,7 @@ const APMCHValidation = (data: FormData) => {
       didCalculationsDeviate,
       deviationReason
     ),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateTotalNDR(
       performanceMeasureArray,
       undefined,

--- a/services/ui-src/src/measures/2023/APPCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/APPCH/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +203,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/APPCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APPCH/validation.ts
@@ -50,6 +50,7 @@ const APPCHValidation = (data: FormData) => {
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateTotalNDR(performanceMeasureArray),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/BCSAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/BCSAD/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +198,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/BCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/BCSAD/validation.ts
@@ -41,6 +41,7 @@ const BCSValidation = (data: FormData) => {
     ),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/CBPAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CBPAD/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +198,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CBPAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPAD/validation.ts
@@ -49,6 +49,7 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CBPHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CBPHH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CBPHH/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPHH/validation.ts
@@ -49,6 +49,7 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateTotalNDR(performanceMeasureArray),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CCPAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCPAD/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCPAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCPAD/validation.ts
@@ -47,6 +47,7 @@ const CCPADValidation = (data: FormData) => {
     ),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD.data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Specific Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/CCPCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCPCH/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +205,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCPCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CCPCH/validation.ts
@@ -47,6 +47,7 @@ const CCPCHValidation = (data: FormData) => {
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD.data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateOneQualRateHigherThanOtherQualPM(data, PMD.data, 1, 0),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Specific Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/CCSAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCSAD/index.test.tsx
@@ -178,6 +178,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -194,6 +195,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCSAD/validation.ts
@@ -62,6 +62,7 @@ const CCSADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/CCWAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCWAD/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +203,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCWAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCWAD/validation.ts
@@ -41,6 +41,7 @@ const CCWADValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/CCWCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCWCH/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCWCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CCWCH/validation.ts
@@ -27,6 +27,7 @@ const CCWCHValidation = (data: FormData) => {
       PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/CDFAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CDFAD/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +198,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CDFAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFAD/validation.ts
@@ -48,6 +48,7 @@ const CDFADValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CDFCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CDFCH/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CDFCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFCH/validation.ts
@@ -48,6 +48,7 @@ const CDFCHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CDFHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CDFHH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CDFHH/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFHH/validation.ts
@@ -34,6 +34,7 @@ const CDFHHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(

--- a/services/ui-src/src/measures/2023/CHLAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CHLAD/index.test.tsx
@@ -178,6 +178,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -195,6 +196,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CHLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLAD/validation.ts
@@ -41,6 +41,7 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CHLCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CHLCH/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/CHLCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLCH/validation.ts
@@ -40,6 +40,7 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CISCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CISCH/index.test.tsx
@@ -184,6 +184,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -206,6 +207,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(44000);

--- a/services/ui-src/src/measures/2023/CISCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CISCH/validation.ts
@@ -49,6 +49,7 @@ const CISCHValidation = (data: FormData) => {
       PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/COBAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/COBAD/index.test.tsx
@@ -180,6 +180,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -199,6 +200,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/COBAD/validation.ts
+++ b/services/ui-src/src/measures/2023/COBAD/validation.ts
@@ -45,6 +45,7 @@ const COBADValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),

--- a/services/ui-src/src/measures/2023/COLAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/COLAD/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +198,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/COLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/COLAD/validation.ts
@@ -51,6 +51,7 @@ const COLADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/COLHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/COLHH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/COLHH/validation.ts
+++ b/services/ui-src/src/measures/2023/COLHH/validation.ts
@@ -49,6 +49,7 @@ const COLHHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/CPUAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CPUAD/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDeviationFieldFilled).not.toHaveBeenCalled();
     expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -195,6 +196,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDeviationFieldFilled).toHaveBeenCalled();
     expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/CPUAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CPUAD/validation.ts
@@ -44,6 +44,7 @@ const CPUADValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/DEVCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/DEVCH/index.test.tsx
@@ -186,6 +186,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -210,6 +211,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/DEVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/DEVCH/validation.ts
@@ -50,6 +50,7 @@ const DEVCHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/FUAAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUAAD/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAAD/validation.ts
@@ -53,6 +53,7 @@ const FUAADValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/FUACH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUACH/index.test.tsx
@@ -186,6 +186,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -210,6 +211,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/FUACH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUACH/validation.ts
@@ -43,6 +43,7 @@ const FUACHValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/FUAHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUAHH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUAHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAHH/validation.ts
@@ -42,6 +42,7 @@ const FUAHHValidation = (data: FormData) => {
       PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // Performance Measure Validations
     ...GV.validateDualPopInformationPM(

--- a/services/ui-src/src/measures/2023/FUHAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUHAD/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUHAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHAD/validation.ts
@@ -68,6 +68,7 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2023/FUHCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUHCH/index.test.tsx
@@ -186,6 +186,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -210,6 +211,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/FUHCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHCH/validation.ts
@@ -62,6 +62,7 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/FUHHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUHHH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUHHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHHH/validation.ts
@@ -41,6 +41,7 @@ const FUHHHValidation = (data: FormData) => {
       ageGroups
     ),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // Performance Measure Validations
     ...GV.validateDualPopInformationPM(

--- a/services/ui-src/src/measures/2023/FUMAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUMAD/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMAD/validation.ts
@@ -57,6 +57,7 @@ const FUMADValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD.data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),

--- a/services/ui-src/src/measures/2023/FUMCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUMCH/index.test.tsx
@@ -186,6 +186,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -210,6 +211,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/FUMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMCH/validation.ts
@@ -61,6 +61,7 @@ const FUMCHValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/FUMHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUMHH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUMHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMHH/validation.ts
@@ -37,6 +37,7 @@ const FUMHHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // Performance Measure Validations
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/FVAAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FVAAD/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOneCatRateHigherThanOtherCatOMS).not.toHaveBeenCalled();
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
   });
 

--- a/services/ui-src/src/measures/2023/FVAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FVAAD/validation.ts
@@ -42,6 +42,7 @@ const FVAADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/HBDAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/HBDAD/index.test.tsx
@@ -178,6 +178,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -195,6 +196,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/HBDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HBDAD/validation.ts
@@ -71,6 +71,7 @@ const HBDADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/HPCMIAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/HPCMIAD/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateDualPopInformationPM).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +198,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateDualPopInformationPM).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
@@ -49,6 +49,7 @@ const HPCMIADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/HVLAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/HVLAD/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/HVLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HVLAD/validation.ts
@@ -64,6 +64,7 @@ const HVLADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/IETAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/IETAD/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +204,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/IETAD/validation.ts
+++ b/services/ui-src/src/measures/2023/IETAD/validation.ts
@@ -77,6 +77,7 @@ const IETValidation = (data: FormData) => {
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD.data, 0, 1, 2),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/IETHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/IETHH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/IETHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IETHH/validation.ts
@@ -77,6 +77,7 @@ const IETValidation = (data: FormData) => {
     ...filteredSameDenominatorErrors,
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/IMACH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/IMACH/index.test.tsx
@@ -186,6 +186,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -210,6 +211,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/IMACH/validation.ts
+++ b/services/ui-src/src/measures/2023/IMACH/validation.ts
@@ -51,6 +51,7 @@ const DEVCHValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/IUHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/IUHH/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -190,6 +191,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateBothDatesCompleted).toHaveBeenCalled();
     expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/IUHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IUHH/validation.ts
@@ -47,6 +47,7 @@ const IUHHValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),

--- a/services/ui-src/src/measures/2023/LSCCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/LSCCH/index.test.tsx
@@ -189,6 +189,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -213,6 +214,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/LSCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/LSCCH/validation.ts
@@ -46,6 +46,7 @@ const LSCCHValidation = (data: FormData) => {
       ageGroups
     ),
     ...GV.validateTotalNDR(performanceMeasureArray, undefined, undefined),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/MSCAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/MSCAD/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +198,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/MSCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/MSCAD/validation.ts
@@ -41,6 +41,7 @@ const MSCADValidation = (data: Types.DefaultFormData) => {
       ageGroups
     ),
     ...GV.validateDateRangeRadioButtonCompletion(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),

--- a/services/ui-src/src/measures/2023/OEVCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/OEVCH/index.test.tsx
@@ -186,6 +186,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -210,6 +211,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/OEVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/OEVCH/validation.ts
@@ -46,6 +46,7 @@ const OEVCHValidation = (data: FormData) => {
       ageGroups
     ),
     ...GV.validateTotalNDR(performanceMeasureArray, undefined, undefined),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/OHDAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/OHDAD/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/OHDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/OHDAD/validation.ts
@@ -46,6 +46,7 @@ const OHDValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/OUDAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/OUDAD/index.test.tsx
@@ -184,6 +184,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -206,6 +207,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/OUDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/OUDAD/validation.ts
@@ -31,6 +31,7 @@ const OUDValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/OUDHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/OUDHH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/OUDHH/validation.ts
+++ b/services/ui-src/src/measures/2023/OUDHH/validation.ts
@@ -31,6 +31,7 @@ const OUDValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/PCRAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PCRAD/index.test.tsx
@@ -180,6 +180,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.PCRnoNonZeroNumOrDenom).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -198,6 +199,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.PCRnoNonZeroNumOrDenom).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PCRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRAD/validation.ts
@@ -52,6 +52,7 @@ const PCRADValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // Performance Measure Validations
     ...GV.PCRatLeastOneRateComplete(performanceMeasureArray, OPM, ageGroups),

--- a/services/ui-src/src/measures/2023/PCRHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PCRHH/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -190,6 +191,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateBothDatesCompleted).toHaveBeenCalled();
     expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PCRHH/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRHH/validation.ts
@@ -52,6 +52,7 @@ const PCRHHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     // Performance Measure Validations
     ...GV.PCRatLeastOneRateComplete(performanceMeasureArray, OPM, ageGroups),
     ...GV.PCRnoNonZeroNumOrDenom(performanceMeasureArray, OPM, ndrForumlas),

--- a/services/ui-src/src/measures/2023/PPCAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PPCAD/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PPCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCAD/validation.ts
@@ -62,6 +62,7 @@ const PPCADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/PPCCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PPCCH/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +205,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PPCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCCH/validation.ts
@@ -62,6 +62,7 @@ const PPCCHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/PQI01AD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI01AD/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI01AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI01AD/validation.ts
@@ -58,6 +58,7 @@ const PQI01Validation = (data: FormData) => {
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/PQI05AD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI05AD/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI05AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI05AD/validation.ts
@@ -63,6 +63,7 @@ const PQI05Validation = (data: FormData) => {
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/PQI08AD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI08AD/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI08AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI08AD/validation.ts
@@ -36,6 +36,7 @@ const PQI08Validation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateDualPopInformationPM(
       validateDualPopInformationArray,
       OPM,

--- a/services/ui-src/src/measures/2023/PQI15AD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI15AD/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI15AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI15AD/validation.ts
@@ -34,6 +34,7 @@ const PQI15Validation = (data: FormData) => {
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/PQI92HH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI92HH/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI92HH/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI92HH/validation.ts
@@ -34,6 +34,7 @@ const PQI92Validation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/SAAAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/SAAAD/index.test.tsx
@@ -181,6 +181,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +201,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/SAAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SAAAD/validation.ts
@@ -59,6 +59,7 @@ const SAAADValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/SFMCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/SFMCH/index.test.tsx
@@ -186,6 +186,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -210,6 +211,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/SFMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/SFMCH/validation.ts
@@ -56,6 +56,7 @@ const SFMCHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/SSDAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/SSDAD/index.test.tsx
@@ -179,6 +179,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +198,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/SSDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SSDAD/validation.ts
@@ -58,6 +58,7 @@ const SSDValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/SSHH/validation.ts
+++ b/services/ui-src/src/measures/2023/SSHH/validation.ts
@@ -126,6 +126,7 @@ const SSHHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/TFLCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/TFLCH/index.test.tsx
@@ -184,6 +184,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -206,6 +207,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/TFLCH/validation.ts
+++ b/services/ui-src/src/measures/2023/TFLCH/validation.ts
@@ -48,6 +48,7 @@ const TFLCHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateTotalNDR(performanceMeasureArray),
     ...sameDenominatorError,
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/W30CH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/W30CH/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +203,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/W30CH/validation.ts
+++ b/services/ui-src/src/measures/2023/W30CH/validation.ts
@@ -56,6 +56,7 @@ const W30CHValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/WCCCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/WCCCH/index.test.tsx
@@ -184,6 +184,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -206,6 +207,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/WCCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCCCH/validation.ts
@@ -42,6 +42,7 @@ const WCCHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/WCVCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/WCVCH/index.test.tsx
@@ -182,6 +182,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +203,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/WCVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCVCH/validation.ts
@@ -49,6 +49,7 @@ const WCVCHValidation = (data: FormData) => {
       PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/shared/globalValidations/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/index.ts
@@ -3,6 +3,7 @@ export * from "./omsValidator";
 export * as Types from "./types";
 
 export * from "./validateAtLeastOneDataSource";
+export * from "./validateAtLeastOneDefinitionOfPopulation";
 export * from "./validateAtLeastOneDeviationFieldFilled";
 export * from "./validateAtLeastOneRateComplete";
 export * from "./validateBothDatesInRange";

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDefinitionOfPopulation/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDefinitionOfPopulation/index.test.ts
@@ -1,0 +1,47 @@
+import { testFormData } from "../testHelpers/_testFormData";
+import * as DC from "dataConstants";
+import { validateAtLeastOneDefinitionOfPopulation } from ".";
+
+describe("validateAtLeastOneDefinitionOfPopulation", () => {
+  let formData: any;
+  let errorArray: FormError[];
+
+  const _check_errors = (data: any, numErrors: number) => {
+    errorArray = [...validateAtLeastOneDefinitionOfPopulation(data)];
+    expect(errorArray.length).toBe(numErrors);
+  };
+
+  beforeEach(() => {
+    formData = JSON.parse(JSON.stringify(testFormData)); // reset data
+    errorArray = [];
+  });
+
+  it("When no Definition of Population is Selected a validation warning shows", () => {
+    formData[DC.DEFINITION_OF_DENOMINATOR] = [];
+    _check_errors(formData, 1);
+  });
+
+  it("When a Definition of Population is Selected no validation warning shows", () => {
+    formData[DC.DEFINITION_OF_DENOMINATOR] = [DC.DENOMINATOR_INC_MEDICAID_POP];
+    _check_errors(formData, 0);
+  });
+
+  it("Error message text should match default errorMessage", () => {
+    formData[DC.DEFINITION_OF_DENOMINATOR] = [];
+    errorArray = [...validateAtLeastOneDefinitionOfPopulation(formData)];
+    expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe(
+      "You must select at least one definition of population option"
+    );
+  });
+
+  it("Error message text should match provided errorMessage", () => {
+    formData[DC.DEFINITION_OF_DENOMINATOR] = [];
+    const errorMessage = "Another one bites the dust.";
+    errorArray = [
+      ...validateAtLeastOneDefinitionOfPopulation(formData, errorMessage),
+    ];
+    expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe(errorMessage);
+  });
+});

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDefinitionOfPopulation/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDefinitionOfPopulation/index.ts
@@ -1,0 +1,21 @@
+import * as Types from "measures/2023/shared/CommonQuestions/types";
+
+export const validateAtLeastOneDefinitionOfPopulation = (
+  data: Types.DefinitionOfPopulation,
+  errorMessage?: string
+) => {
+  const errorArray: FormError[] = [];
+  if (
+    !data.DefinitionOfDenominator ||
+    data.DefinitionOfDenominator.length === 0
+  ) {
+    errorArray.push({
+      errorLocation: "Definition of Population",
+      errorMessage:
+        errorMessage ??
+        "You must select at least one definition of population option",
+    });
+  }
+
+  return errorArray;
+};

--- a/services/ui-src/src/measures/2023/shared/util/validationsMock.tsx
+++ b/services/ui-src/src/measures/2023/shared/util/validationsMock.tsx
@@ -1,4 +1,5 @@
 import * as validateAtLeastOneDataSource from "measures/2023/shared/globalValidations/validateAtLeastOneDataSource";
+import * as validateAtLeastOneDefinitionOfPopulation from "measures/2023/shared/globalValidations/validateAtLeastOneDefinitionOfPopulation";
 import * as validateAtLeastOneDeviationFieldFilled from "measures/2023/shared/globalValidations/validateAtLeastOneDeviationFieldFilled";
 import * as validateAtLeastOneRateComplete from "measures/2023/shared/globalValidations/validateAtLeastOneRateComplete";
 import * as validateBothDatesInRange from "measures/2023/shared/globalValidations/validateBothDatesInRange";
@@ -46,6 +47,10 @@ export const validationsMockObj: any = {
   validateAtLeastOneDataSource: jest.spyOn(
     validateAtLeastOneDataSource,
     "validateAtLeastOneDataSource"
+  ),
+  validateAtLeastOneDefinitionOfPopulation: jest.spyOn(
+    validateAtLeastOneDefinitionOfPopulation,
+    "validateAtLeastOneDefinitionOfPopulation"
   ),
   validateAtLeastOneDeviationFieldFilled: jest.spyOn(
     validateAtLeastOneDeviationFieldFilled,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adding a new validation for definition of population selection to FFY2023 measures

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2765

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as state user
- Navigate to FY2023
- Do not select a `Definition of Population Included in the Measure`, like so:

![Screenshot 2023-07-31 at 2 57 54 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/8bc8d2c6-8224-4368-b53d-f8cabd113fa0)

Validate the measure and you should see this error message:

![Screenshot 2023-07-31 at 2 58 34 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/c830b097-a45a-46be-88b5-bc1b61e95c0d)

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
