### PR TITLE
MDCT-2765 Pt. III: Add New Delivery Systems Validations

### DIFF
--- a/services/ui-src/src/measures/2023/AABAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AABAD/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -195,6 +197,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDataSourceType).toHaveBeenCalled();
     expect(V.validateAtLeastOneDeviationFieldFilled).toHaveBeenCalled();
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AABAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AABAD/validation.ts
@@ -48,6 +48,8 @@ const AABADValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/AABCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AABCH/index.test.tsx
@@ -181,6 +181,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(
       V.validateRequiredRadioButtonForCombinedRates
     ).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +202,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
     expect(V.validateRequiredRadioButtonForCombinedRates).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AABCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AABCH/validation.ts
@@ -47,6 +47,8 @@ const AABCHValidation = (data: FormData) => {
       PMD.qualifiers
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/ADDCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/ADDCH/index.test.tsx
@@ -185,6 +185,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     ).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOneQualDenomHigherThanOtherDenomOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/ADDCH/validation.ts
+++ b/services/ui-src/src/measures/2023/ADDCH/validation.ts
@@ -49,6 +49,8 @@ const ADDCHValidation = (data: FormData) => {
       didCalculationsDeviate,
       deviationReason
     ),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/AIFHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AIFHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it.skip("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -194,6 +196,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
     expect(V.validateAtLeastOneDataSourceType).toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AIFHH/validation.ts
+++ b/services/ui-src/src/measures/2023/AIFHH/validation.ts
@@ -55,6 +55,8 @@ const AIFHHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     ...GV.ComplexValidateDualPopInformation(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/AMBCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMBCH/index.test.tsx
@@ -184,6 +184,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -206,6 +208,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AMBCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBCH/validation.ts
@@ -32,6 +32,8 @@ const AMBCHValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/AMBHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMBHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AMBHH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMBHH/validation.ts
@@ -37,6 +37,9 @@ const AMBHHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
+
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/AMMAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMMAD/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +206,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/AMMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMMAD/validation.ts
@@ -72,6 +72,8 @@ const AMMADValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AMRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRAD/validation.ts
@@ -39,6 +39,8 @@ const AMRADValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/AMRCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMRCH/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +206,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/AMRCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AMRCH/validation.ts
@@ -39,6 +39,8 @@ const AMRCHValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/APMCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/APMCH/index.test.tsx
@@ -184,6 +184,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -206,6 +208,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/APMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APMCH/validation.ts
@@ -44,6 +44,8 @@ const APMCHValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/APPCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/APPCH/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +206,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/APPCH/validation.ts
+++ b/services/ui-src/src/measures/2023/APPCH/validation.ts
@@ -45,6 +45,8 @@ const APPCHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/BCSAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/BCSAD/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -199,6 +201,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/BCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/BCSAD/validation.ts
@@ -41,6 +41,8 @@ const BCSValidation = (data: FormData) => {
     ),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/CBPAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CBPAD/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -199,6 +201,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CBPAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPAD/validation.ts
@@ -49,6 +49,8 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CBPHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CBPHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CBPHH/validation.ts
+++ b/services/ui-src/src/measures/2023/CBPHH/validation.ts
@@ -50,6 +50,8 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateTotalNDR(performanceMeasureArray),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CCPAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCPAD/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCPAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCPAD/validation.ts
@@ -48,6 +48,8 @@ const CCPADValidation = (data: FormData) => {
     ),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD.data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // OMS Specific Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/CCPCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCPCH/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -206,6 +208,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCPCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CCPCH/validation.ts
@@ -34,6 +34,8 @@ const CCPCHValidation = (data: FormData) => {
     ...GV.validateEqualCategoryDenominatorsPM(data, PMD.categories),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/CCSAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCSAD/index.test.tsx
@@ -179,6 +179,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -196,6 +198,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCSAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCSAD/validation.ts
@@ -63,6 +63,8 @@ const CCSADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/CCWAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCWAD/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +206,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCWAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CCWAD/validation.ts
@@ -38,6 +38,8 @@ const CCWADValidation = (data: FormData) => {
     ...GV.validateEqualCategoryDenominatorsPM(data, PMD.categories, ageGroups),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),

--- a/services/ui-src/src/measures/2023/CCWCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CCWCH/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CCWCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CCWCH/validation.ts
@@ -36,6 +36,8 @@ const CCWCHValidation = (data: FormData) => {
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOneQualRateHigherThanOtherQualPM(data, PMD),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CDFAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CDFAD/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -199,6 +201,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CDFAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFAD/validation.ts
@@ -49,6 +49,8 @@ const CDFADValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CDFCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CDFCH/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CDFCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFCH/validation.ts
@@ -49,6 +49,8 @@ const CDFCHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/CDFHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CDFHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CDFHH/validation.ts
+++ b/services/ui-src/src/measures/2023/CDFHH/validation.ts
@@ -35,6 +35,8 @@ const CDFHHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(

--- a/services/ui-src/src/measures/2023/CHLAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CHLAD/index.test.tsx
@@ -179,6 +179,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +199,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/CHLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLAD/validation.ts
@@ -41,6 +41,8 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CHLCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CHLCH/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/CHLCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CHLCH/validation.ts
@@ -41,6 +41,8 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CISCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CISCH/index.test.tsx
@@ -185,6 +185,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -208,6 +210,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(44000);

--- a/services/ui-src/src/measures/2023/CISCH/validation.ts
+++ b/services/ui-src/src/measures/2023/CISCH/validation.ts
@@ -50,6 +50,8 @@ const CISCHValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/COBAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/COBAD/index.test.tsx
@@ -181,6 +181,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -201,6 +203,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/COBAD/validation.ts
+++ b/services/ui-src/src/measures/2023/COBAD/validation.ts
@@ -47,6 +47,8 @@ const COBADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),

--- a/services/ui-src/src/measures/2023/COLAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/COLAD/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -199,6 +201,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/COLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/COLAD/validation.ts
@@ -48,6 +48,8 @@ const COLADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),

--- a/services/ui-src/src/measures/2023/COLHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/COLHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/COLHH/validation.ts
+++ b/services/ui-src/src/measures/2023/COLHH/validation.ts
@@ -51,6 +51,8 @@ const COLHHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/CPUAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/CPUAD/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDeviationFieldFilled).not.toHaveBeenCalled();
     expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +199,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDeviationFieldFilled).toHaveBeenCalled();
     expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/CPUAD/validation.ts
+++ b/services/ui-src/src/measures/2023/CPUAD/validation.ts
@@ -36,7 +36,8 @@ const CPUADValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, carePlans, data),
     ...GV.validateEqualCategoryDenominatorsPM(data, PMD.categories, carePlans),
     ...GV.validateOneQualRateHigherThanOtherQualPM(data, PMD),
-
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),

--- a/services/ui-src/src/measures/2023/DEVCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/DEVCH/index.test.tsx
@@ -187,6 +187,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -212,6 +214,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/DEVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/DEVCH/validation.ts
@@ -51,6 +51,8 @@ const DEVCHValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/FUAAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUAAD/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAAD/validation.ts
@@ -51,6 +51,8 @@ const FUAADValidation = (data: FormData) => {
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD.data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),

--- a/services/ui-src/src/measures/2023/FUACH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUACH/index.test.tsx
@@ -187,6 +187,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -212,6 +214,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/FUACH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUACH/validation.ts
@@ -44,6 +44,8 @@ const FUACHValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/FUAHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUAHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUAHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUAHH/validation.ts
@@ -34,6 +34,8 @@ const FUAHHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/FUHAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUHAD/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUHAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHAD/validation.ts
@@ -63,6 +63,8 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),

--- a/services/ui-src/src/measures/2023/FUHCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUHCH/index.test.tsx
@@ -187,6 +187,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -212,6 +214,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/FUHCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHCH/validation.ts
@@ -63,6 +63,8 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/FUHHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUHHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUHHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUHHH/validation.ts
@@ -42,6 +42,8 @@ const FUHHHValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     // Performance Measure Validations
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/FUMAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUMAD/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUMAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMAD/validation.ts
@@ -54,6 +54,8 @@ const FUMADValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),

--- a/services/ui-src/src/measures/2023/FUMCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUMCH/index.test.tsx
@@ -187,6 +187,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -212,6 +214,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/FUMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMCH/validation.ts
@@ -62,6 +62,8 @@ const FUMCHValidation = (data: FormData) => {
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/FUMHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FUMHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FUMHH/validation.ts
+++ b/services/ui-src/src/measures/2023/FUMHH/validation.ts
@@ -38,6 +38,8 @@ const FUMHHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // Performance Measure Validations
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/FVAAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/FVAAD/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -203,6 +205,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/FVAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/FVAAD/validation.ts
@@ -40,6 +40,8 @@ const FVAADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),

--- a/services/ui-src/src/measures/2023/HBDAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/HBDAD/index.test.tsx
@@ -179,6 +179,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -197,6 +199,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/HBDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HBDAD/validation.ts
@@ -59,6 +59,8 @@ const HBDADValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/HPCMIAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/HPCMIAD/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateDualPopInformationPM).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -199,6 +201,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateDualPopInformationPM).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HPCMIAD/validation.ts
@@ -50,6 +50,8 @@ const HPCMIADValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/HVLAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/HVLAD/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/HVLAD/validation.ts
+++ b/services/ui-src/src/measures/2023/HVLAD/validation.ts
@@ -65,6 +65,8 @@ const HVLADValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/IETAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/IETAD/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -205,6 +207,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/IETAD/validation.ts
+++ b/services/ui-src/src/measures/2023/IETAD/validation.ts
@@ -100,6 +100,8 @@ const IETValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/IETHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/IETHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/IETHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IETHH/validation.ts
@@ -101,6 +101,8 @@ const IETValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/IMACH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/IMACH/index.test.tsx
@@ -187,6 +187,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -212,6 +214,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/IMACH/validation.ts
+++ b/services/ui-src/src/measures/2023/IMACH/validation.ts
@@ -52,6 +52,8 @@ const DEVCHValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/IUHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/IUHH/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -192,6 +194,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
     expect(V.validateAtLeastOneDataSourceType).toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/IUHH/validation.ts
+++ b/services/ui-src/src/measures/2023/IUHH/validation.ts
@@ -48,6 +48,8 @@ const IUHHValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),

--- a/services/ui-src/src/measures/2023/LSCCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/LSCCH/index.test.tsx
@@ -190,6 +190,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -215,6 +217,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/LSCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/LSCCH/validation.ts
@@ -26,6 +26,8 @@ const LSCCHValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/MSCAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/MSCAD/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -199,6 +201,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/MSCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/MSCAD/validation.ts
@@ -49,6 +49,8 @@ const MSCADValidation = (data: Types.DefaultFormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/OEVCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/OEVCH/index.test.tsx
@@ -187,6 +187,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -212,6 +214,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(33000);

--- a/services/ui-src/src/measures/2023/OEVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/OEVCH/validation.ts
@@ -31,6 +31,8 @@ const OEVCHValidation = (data: FormData) => {
       deviationReason
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(

--- a/services/ui-src/src/measures/2023/OHDAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/OHDAD/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/OHDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/OHDAD/validation.ts
@@ -48,6 +48,8 @@ const OHDValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/OUDAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/OUDAD/index.test.tsx
@@ -185,6 +185,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -208,6 +210,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/OUDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/OUDAD/validation.ts
@@ -44,6 +44,8 @@ const OUDValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateEqualCategoryDenominatorsPM(data, PMD.categories, ageGroups),
     ...GV.omsValidations({
       data,

--- a/services/ui-src/src/measures/2023/OUDHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/OUDHH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/OUDHH/validation.ts
+++ b/services/ui-src/src/measures/2023/OUDHH/validation.ts
@@ -43,6 +43,8 @@ const OUDValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateEqualCategoryDenominatorsPM(data, PMD.categories, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),

--- a/services/ui-src/src/measures/2023/PCRAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PCRAD/index.test.tsx
@@ -181,6 +181,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.PCRnoNonZeroNumOrDenom).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -200,6 +202,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.PCRnoNonZeroNumOrDenom).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PCRAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRAD/validation.ts
@@ -53,6 +53,8 @@ const PCRADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // Performance Measure Validations
     ...GV.PCRatLeastOneRateComplete(performanceMeasureArray, OPM, ageGroups),

--- a/services/ui-src/src/measures/2023/PCRHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PCRHH/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -192,6 +194,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
     expect(V.validateAtLeastOneDataSourceType).toHaveBeenCalled();
     expect(V.ComplexValidateNDRTotals).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PCRHH/validation.ts
+++ b/services/ui-src/src/measures/2023/PCRHH/validation.ts
@@ -53,6 +53,9 @@ const PCRHHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
+
     // Performance Measure Validations
     ...GV.PCRatLeastOneRateComplete(performanceMeasureArray, OPM, ageGroups),
     ...GV.PCRnoNonZeroNumOrDenom(performanceMeasureArray, OPM, ndrForumlas),

--- a/services/ui-src/src/measures/2023/PPCAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PPCAD/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PPCAD/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCAD/validation.ts
@@ -50,6 +50,8 @@ const PPCADValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/PPCCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PPCCH/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -206,6 +208,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PPCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/PPCCH/validation.ts
@@ -63,6 +63,8 @@ const PPCCHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2023/PQI01AD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI01AD/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI01AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI01AD/validation.ts
@@ -59,6 +59,8 @@ const PQI01Validation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/PQI05AD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI05AD/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI05AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI05AD/validation.ts
@@ -64,6 +64,8 @@ const PQI05Validation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,

--- a/services/ui-src/src/measures/2023/PQI08AD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI08AD/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI08AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI08AD/validation.ts
@@ -37,6 +37,8 @@ const PQI08Validation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateDualPopInformationPM(
       validateDualPopInformationArray,
       OPM,

--- a/services/ui-src/src/measures/2023/PQI15AD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI15AD/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI15AD/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI15AD/validation.ts
@@ -35,6 +35,8 @@ const PQI15Validation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/PQI92HH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/PQI92HH/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/PQI92HH/validation.ts
+++ b/services/ui-src/src/measures/2023/PQI92HH/validation.ts
@@ -35,6 +35,9 @@ const PQI92Validation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
+
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2023/SAAAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/SAAAD/index.test.tsx
@@ -182,6 +182,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -202,6 +204,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/SAAAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SAAAD/validation.ts
@@ -35,6 +35,8 @@ const SAAADValidation = (data: FormData) => {
     ),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/SFMCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/SFMCH/index.test.tsx
@@ -187,6 +187,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -212,6 +214,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateEqualCategoryDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
     expect(V.validateEqualCategoryDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/SFMCH/validation.ts
+++ b/services/ui-src/src/measures/2023/SFMCH/validation.ts
@@ -52,6 +52,8 @@ const SFMCHValidation = (data: FormData) => {
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),

--- a/services/ui-src/src/measures/2023/SSDAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/SSDAD/index.test.tsx
@@ -180,6 +180,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
     expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -199,6 +201,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
     expect(V.validateRateZeroOMS).toHaveBeenCalled();
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   jest.setTimeout(15000);

--- a/services/ui-src/src/measures/2023/SSDAD/validation.ts
+++ b/services/ui-src/src/measures/2023/SSDAD/validation.ts
@@ -34,6 +34,8 @@ const SSDValidation = (data: FormData) => {
     ),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/TFLCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/TFLCH/index.test.tsx
@@ -185,6 +185,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -208,6 +210,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/TFLCH/validation.ts
+++ b/services/ui-src/src/measures/2023/TFLCH/validation.ts
@@ -49,6 +49,8 @@ const TFLCHValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateTotalNDR(performanceMeasureArray),
     ...sameDenominatorError,
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2023/W30CH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/W30CH/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +206,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/W30CH/validation.ts
+++ b/services/ui-src/src/measures/2023/W30CH/validation.ts
@@ -57,6 +57,8 @@ const W30CHValidation = (data: FormData) => {
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2023/WCCCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/WCCCH/index.test.tsx
@@ -185,6 +185,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).not.toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -208,6 +210,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsPM).toHaveBeenCalled();
     expect(V.validateEqualQualifierDenominatorsOMS).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/WCCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCCCH/validation.ts
@@ -37,6 +37,8 @@ const WCCHValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),

--- a/services/ui-src/src/measures/2023/WCVCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/WCVCH/index.test.tsx
@@ -183,6 +183,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
     expect(V.validateTotalNDR).not.toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
   });
 
   it("(Completed) validationFunctions should call all expected validation functions", async () => {
@@ -204,6 +206,8 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
   });
 
   it("should not allow non state users to edit forms by disabling buttons", async () => {

--- a/services/ui-src/src/measures/2023/WCVCH/validation.ts
+++ b/services/ui-src/src/measures/2023/WCVCH/validation.ts
@@ -50,6 +50,8 @@ const WCVCHValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2023/shared/globalValidations/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/index.ts
@@ -4,6 +4,7 @@ export * as Types from "./types";
 
 export * from "./validateAtLeastOneDataSource";
 export * from "./validateAtLeastOneDataSourceType";
+export * from "./validateAtLeastOneDeliverySystem";
 export * from "./validateAtLeastOneDeviationFieldFilled";
 export * from "./validateAtLeastOneRateComplete";
 export * from "./validateBothDatesInRange";
@@ -11,6 +12,7 @@ export * from "./validateDateRangeRadioButtonCompletion";
 export * from "./validateDualPopInformation";
 export * from "./validateEqualCategoryDenominators";
 export * from "./validateEqualQualifierDenominators";
+export * from "./validateFfsRadioButtonCompletion";
 export * from "./validateRateNotZero";
 export * from "./validateRateZero";
 export * from "./validateNumeratorsLessThanDenominators";

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDeliverySystem/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDeliverySystem/index.test.ts
@@ -1,0 +1,47 @@
+import { testFormData } from "../testHelpers/_testFormData";
+import * as DC from "dataConstants";
+import { validateAtLeastOneDeliverySystem } from ".";
+
+describe("validateAtLeastOneDeliverySystem", () => {
+  let formData: any;
+  let errorArray: FormError[];
+
+  const _check_errors = (data: any, numErrors: number) => {
+    errorArray = [...validateAtLeastOneDeliverySystem(data)];
+    expect(errorArray.length).toBe(numErrors);
+  };
+
+  beforeEach(() => {
+    formData = JSON.parse(JSON.stringify(testFormData)); // reset data
+    errorArray = [];
+  });
+
+  it("When no Delivery System is Selected a validation warning shows", () => {
+    formData[DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR] = [];
+    _check_errors(formData, 1);
+  });
+
+  it("When a Delivery System is Selected no validation warning shows", () => {
+    formData[DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR] = [
+      DC.DELIVERY_SYS_FFS,
+    ];
+    _check_errors(formData, 0);
+  });
+
+  it("Error message text should match default errorMessage", () => {
+    formData[DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR] = [];
+    errorArray = [...validateAtLeastOneDeliverySystem(formData)];
+    expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe(
+      "You must select at least one delivery system option"
+    );
+  });
+
+  it("Error message text should match provided errorMessage", () => {
+    formData[DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR] = [];
+    const errorMessage = "Another one bites the dust.";
+    errorArray = [...validateAtLeastOneDeliverySystem(formData, errorMessage)];
+    expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe(errorMessage);
+  });
+});

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDeliverySystem/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDeliverySystem/index.ts
@@ -1,0 +1,20 @@
+import * as Types from "measures/2023/shared/CommonQuestions/types";
+
+export const validateAtLeastOneDeliverySystem = (
+  data: Types.DefinitionOfPopulation,
+  errorMessage?: string
+) => {
+  const errorArray: FormError[] = [];
+  if (
+    !data.DeliverySysRepresentationDenominator ||
+    data.DeliverySysRepresentationDenominator.length === 0
+  ) {
+    errorArray.push({
+      errorLocation: "Delivery Systems",
+      errorMessage:
+        errorMessage ?? "You must select at least one delivery system option",
+    });
+  }
+
+  return errorArray;
+};

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateFfsRadioButtonCompletion/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateFfsRadioButtonCompletion/index.test.ts
@@ -1,0 +1,49 @@
+import { testFormData } from "../testHelpers/_testFormData";
+import * as DC from "dataConstants";
+import { validateFfsRadioButtonCompletion } from ".";
+
+describe("validateFfsRadioButtonCompletion", () => {
+  let formData: any;
+  let errorArray: FormError[];
+
+  const _check_errors = (data: any, numErrors: number) => {
+    errorArray = [...validateFfsRadioButtonCompletion(data)];
+    expect(errorArray.length).toBe(numErrors);
+  };
+
+  beforeEach(() => {
+    formData = JSON.parse(JSON.stringify(testFormData)); // reset data
+    errorArray = [];
+  });
+
+  it("When no Delivery System nested question is checked a validation warning shows", () => {
+    formData[DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR] = [DC.FFS];
+    formData[DC.DELIVERY_SYS_FFS] = undefined;
+    _check_errors(formData, 1);
+  });
+
+  it("When a Delivery System nested question is checked no validation warning shows", () => {
+    formData[DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR] = [DC.FFS];
+    formData[DC.DELIVERY_SYS_FFS] = "yes";
+    _check_errors(formData, 0);
+  });
+
+  it("Error message text should match default errorMessage", () => {
+    formData[DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR] = [DC.FFS];
+    formData[DC.DELIVERY_SYS_FFS] = undefined;
+    errorArray = [...validateFfsRadioButtonCompletion(formData)];
+    expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe(
+      "You must indicate if the measure-eligible population is included"
+    );
+  });
+
+  it("Error message text should match provided errorMessage", () => {
+    formData[DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR] = [DC.FFS];
+    formData[DC.DELIVERY_SYS_FFS] = undefined;
+    const errorMessage = "Another one bites the dust.";
+    errorArray = [...validateFfsRadioButtonCompletion(formData, errorMessage)];
+    expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe(errorMessage);
+  });
+});

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateFfsRadioButtonCompletion/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateFfsRadioButtonCompletion/index.ts
@@ -1,0 +1,37 @@
+import * as Types from "measures/2023/shared/CommonQuestions/types";
+import * as DC from "dataConstants";
+
+export const validateFfsRadioButtonCompletion = (
+  data: Types.DefinitionOfPopulation,
+  errorMessage?: string
+) => {
+  const errorArray: FormError[] = [];
+
+  // map the delivery systems to their respective nested selections
+  const deliverySystemsMap = {
+    [DC.FFS]: DC.DELIVERY_SYS_FFS,
+    [DC.ICM]: DC.DELIVERY_SYS_ICM,
+    [DC.PCCM]: DC.DELIVERY_SYS_PCCM,
+    [DC.MCO_PIHP]: DC.DELIVERY_SYS_MCO_PIHP,
+    [DC.OTHER]: DC.DELIVERY_SYS_OTHER,
+  };
+
+  const selectedDeliverySystems = data.DeliverySysRepresentationDenominator;
+  if (selectedDeliverySystems) {
+    selectedDeliverySystems.forEach((system) => {
+      Object.entries(data).forEach((selection) => {
+        // check if user has actually checked the nested radio button selection
+        if (selection[0] === deliverySystemsMap[system] && !selection[1]) {
+          errorArray.push({
+            errorLocation: "Delivery System",
+            errorMessage:
+              errorMessage ??
+              "You must indicate if the measure-eligible population is included",
+          });
+        }
+      });
+    });
+  }
+
+  return errorArray;
+};

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateFfsRadioButtonCompletion/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateFfsRadioButtonCompletion/index.ts
@@ -23,7 +23,7 @@ export const validateFfsRadioButtonCompletion = (
         // check if user has actually checked the nested radio button selection
         if (selection[0] === deliverySystemsMap[system] && !selection[1]) {
           errorArray.push({
-            errorLocation: "Delivery System",
+            errorLocation: "Delivery Systems",
             errorMessage:
               errorMessage ??
               "You must indicate if the measure-eligible population is included",

--- a/services/ui-src/src/measures/2023/shared/util/validationsMock.tsx
+++ b/services/ui-src/src/measures/2023/shared/util/validationsMock.tsx
@@ -1,11 +1,13 @@
 import * as validateAtLeastOneDataSource from "measures/2023/shared/globalValidations/validateAtLeastOneDataSource";
 import * as validateAtLeastOneDataSourceType from "measures/2023/shared/globalValidations/validateAtLeastOneDataSourceType";
+import * as validateAtLeastOneDeliverySystem from "measures/2023/shared/globalValidations/validateAtLeastOneDeliverySystem";
 import * as validateAtLeastOneDeviationFieldFilled from "measures/2023/shared/globalValidations/validateAtLeastOneDeviationFieldFilled";
 import * as validateAtLeastOneRateComplete from "measures/2023/shared/globalValidations/validateAtLeastOneRateComplete";
 import * as validateBothDatesInRange from "measures/2023/shared/globalValidations/validateBothDatesInRange";
 import * as validateDualPopInformation from "measures/2023/shared/globalValidations/validateDualPopInformation";
 import * as validateEqualCategoryDenominators from "measures/2023/shared/globalValidations/validateEqualCategoryDenominators";
 import * as validateEqualQualifierDenominators from "measures/2023/shared/globalValidations/validateEqualQualifierDenominators";
+import * as validateFfsRadioButtonCompletion from "measures/2023/shared/globalValidations/validateFfsRadioButtonCompletion";
 import * as validateRateNotZero from "measures/2023/shared/globalValidations/validateRateNotZero";
 import * as validateRateZero from "measures/2023/shared/globalValidations/validateRateZero";
 import * as validateNumeratorsLessThanDenominators from "measures/2023/shared/globalValidations/validateNumeratorsLessThanDenominators";
@@ -52,6 +54,10 @@ export const validationsMockObj: any = {
     validateAtLeastOneDataSourceType,
     "validateAtLeastOneDataSourceType"
   ),
+  validateAtLeastOneDeliverySystem: jest.spyOn(
+    validateAtLeastOneDeliverySystem,
+    "validateAtLeastOneDeliverySystem"
+  ),
   validateAtLeastOneDeviationFieldFilled: jest.spyOn(
     validateAtLeastOneDeviationFieldFilled,
     "validateAtLeastOneDeviationFieldFilled"
@@ -83,6 +89,10 @@ export const validationsMockObj: any = {
   validateEqualQualifierDenominatorsOMS: jest.spyOn(
     validateEqualQualifierDenominators,
     "validateEqualQualifierDenominatorsOMS"
+  ),
+  validateFfsRadioButtonCompletion: jest.spyOn(
+    validateFfsRadioButtonCompletion,
+    "validateFfsRadioButtonCompletion"
   ),
   validateRateNotZeroPM: jest.spyOn(
     validateRateNotZero,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adding two (2) new validations for delivery systems and their nested selections to FFY2023 measures

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2765

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as state user
- Navigate to FY2023
- Do not select an option for `Which delivery systems are represented in the denominator?`, like so:
 
![Screenshot 2023-08-01 at 10 36 07 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/450b917e-c4e0-4954-b593-d7c621bf9c6d)

Validate the measure and you should see this error message:

![Screenshot 2023-08-01 at 10 36 30 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/b34fc94f-89af-41e5-8ccd-2ab3925abec1)

- Next, select an option for that same question but don't select anything for the nested responses, like so:

![Screenshot 2023-08-01 at 10 36 16 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/1a7b2033-d18a-4633-ab00-a943feeb63f1)

Validate the measure and you should see this other error message:

![Screenshot 2023-08-01 at 10 37 18 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/3ca7d83d-22c3-46f0-914c-9d87be24d573)

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
