### PR TITLE
[MDCT-2638] Use the custom param for the signout url

### DIFF
--- a/services/ui-src/serverless.yml
+++ b/services/ui-src/serverless.yml
@@ -37,7 +37,7 @@ custom:
   ui_s3_bucket_name: ${cf:ui-${self:custom.stage}.S3BucketName}
   ui_cloudfront_distribution_id: ${cf:ui-${self:custom.stage}.CloudFrontDistributionId}
   application_endpoint_url: ${cf:ui-${self:custom.stage}.ApplicationEndpointUrl}
-  application_signout_url: "${application_endpoint_url}/postLogout"
+  application_signout_url: "${self:custom.application_endpoint_url}/postLogout"
   signout_redirect_url: ${env:POST_SIGNOUT_REDIRECT, ssm:/configuration/${self:custom.stage}/cognito/redirectSignout, ssm:/configuration/default/cognito/redirectSignout}
   prod_url: ${ssm:/configuration/prodUrl, ""}
   s3Sync:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Fix a misconfigured value in the serverless file 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2638

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
