### PR TITLE
Add UID to IU-HH & AIF-HH Field Data

### DIFF
--- a/services/ui-src/src/components/ComplexRate/index.tsx
+++ b/services/ui-src/src/components/ComplexRate/index.tsx
@@ -1,6 +1,6 @@
 import * as CUI from "@chakra-ui/react";
 import { useController, useFormContext } from "react-hook-form";
-import { allNumbers, xNumbersYDecimals } from "utils";
+import { allNumbers, LabelData, xNumbersYDecimals } from "utils";
 import * as QMR from "components";
 import objectPath from "object-path";
 import { useEffect, useLayoutEffect } from "react";
@@ -19,7 +19,7 @@ interface Props extends QMR.InputWrapperProps {
   calcTotal?: boolean;
   allowNumeratorGreaterThanDenominator?: boolean;
   categoryName?: string;
-  inputFieldNames?: any[];
+  inputFieldNames?: string[] | LabelData[];
   measureName?: string;
   ndrFormulas?: ndrFormula[];
 }
@@ -120,15 +120,18 @@ export const ComplexRate = ({
 
   // Quick reference list of all rate indices
   const rateLocations = ndrFormulas.map((ndr) => ndr.rate);
-  let inputFields: any[] = [];
 
-  //because this is a shared component, data pre-2023 will need to be slightly formatted to work
+  // We need every input field to have a label
+  let inputFields: LabelData[] | { label: string; id?: never }[] = [];
   if (inputFieldNames.length > 0) {
-    if (typeof inputFieldNames[0] === "string")
-      inputFields = inputFieldNames.map((field) => {
+    // Pre-2023 input field names are strings
+    if (typeof inputFieldNames[0] === "string") {
+      inputFields = (inputFieldNames as string[]).map((field) => {
         return { label: field };
       });
-    else inputFields = inputFieldNames;
+    }
+    // Post-2023 input field names are LabelData
+    else inputFields = inputFieldNames as LabelData[];
   }
 
   const { field } = useController({
@@ -155,7 +158,9 @@ export const ComplexRate = ({
           uid: rate.uid,
           fields: inputFields.map((field) => {
             const label = field.label;
-            const uid = field.id ?? undefined; //undefined values do not get saved to the database
+            // Pre-2023 fields do not have an id, so uid is undefined.
+            // Undefined values are not saved to the database
+            const uid = field.id ?? undefined;
             return {
               label,
               uid,

--- a/services/ui-src/src/components/ComplexRate/index.tsx
+++ b/services/ui-src/src/components/ComplexRate/index.tsx
@@ -19,7 +19,7 @@ interface Props extends QMR.InputWrapperProps {
   calcTotal?: boolean;
   allowNumeratorGreaterThanDenominator?: boolean;
   categoryName?: string;
-  inputFieldNames?: string[];
+  inputFieldNames?: any[];
   measureName?: string;
   ndrFormulas?: ndrFormula[];
 }
@@ -120,6 +120,16 @@ export const ComplexRate = ({
 
   // Quick reference list of all rate indices
   const rateLocations = ndrFormulas.map((ndr) => ndr.rate);
+  let inputFields: any[] = [];
+
+  //because this is a shared component, data pre-2023 will need to be slightly formatted to work
+  if (inputFieldNames.length > 0) {
+    if (typeof inputFieldNames[0] === "string")
+      inputFields = inputFieldNames.map((field) => {
+        return { label: field };
+      });
+    else inputFields = inputFieldNames;
+  }
 
   const { field } = useController({
     name,
@@ -143,9 +153,12 @@ export const ComplexRate = ({
         prevRate[index] = {
           label: rate.label,
           uid: rate.uid,
-          fields: inputFieldNames.map((label) => {
+          fields: inputFields.map((field) => {
+            const label = field.label;
+            const uid = field.id ?? undefined; //undefined values do not get saved to the database
             return {
               label,
+              uid,
               value: undefined,
             };
           }),
@@ -240,15 +253,15 @@ export const ComplexRate = ({
               className={`${lowerCaseMeasureName}-field-stack`}
               key={`${lowerCaseMeasureName}-field-stack-${qualIndex}`}
             >
-              {inputFieldNames.map((inputFieldName, fieldIndex) => {
+              {inputFields.map((inputFieldName, fieldIndex) => {
                 return (
                   <QMR.InputWrapper
                     isInvalid={
                       !!objectPath.get(errors, `${name}.${fieldIndex}.value`)
                         ?.message
                     }
-                    key={`input-wrapper-${inputFieldName}-${fieldIndex}`}
-                    label={inputFieldName}
+                    key={`input-wrapper-${inputFieldName.label}-${fieldIndex}`}
+                    label={inputFieldName.label}
                     formLabelProps={{
                       minH: "50px",
                       h: "100px",

--- a/services/ui-src/src/measures/2023/AIFHH/data.ts
+++ b/services/ui-src/src/measures/2023/AIFHH/data.ts
@@ -6,13 +6,41 @@ export const { categories, qualifiers } = getCatQualLabels("AIF-HH");
 const measureName = "AIFHH";
 
 const inputFieldNames = [
-  "Number of Enrollee Months",
-  "Number of Short-Term Admissions",
-  "Short-Term Admissions per 1,000 Enrollee Months",
-  "Number of Medium-Term Admissions",
-  "Medium-Term Admissions per 1,000 Enrollee Months",
-  "Number of Long-Term Admissions",
-  "Long-Term Admissions per 1,000 Enrollee Months",
+  {
+    label: "Number of Enrollee Months",
+    text: "Number of Enrollee Months",
+    id: "QFSYON",
+  },
+  {
+    label: "Number of Short-Term Admissions",
+    text: "Number of Short-Term Admissions",
+    id: "tMeLfq",
+  },
+  {
+    label: "Short-Term Admissions per 1,000 Enrollee Months",
+    text: "Short-Term Admissions per 1,000 Enrollee Months",
+    id: "bxkVCC",
+  },
+  {
+    label: "Number of Medium-Term Admissions",
+    text: "Number of Medium-Term Admissions",
+    id: "KBOnkQ",
+  },
+  {
+    label: "Medium-Term Admissions per 1,000 Enrollee Months",
+    text: "Medium-Term Admissions per 1,000 Enrollee Months",
+    id: "5RO62J",
+  },
+  {
+    label: "Number of Long-Term Admissions",
+    text: "Number of Long-Term Admissions",
+    id: "m3HvMS",
+  },
+  {
+    label: "Long-Term Admissions per 1,000 Enrollee Months",
+    text: "Long-Term Admissions per 1,000 Enrollee Months",
+    id: "dFMGFi",
+  },
 ];
 
 // Rate structure by index in row

--- a/services/ui-src/src/measures/2023/IUHH/data.ts
+++ b/services/ui-src/src/measures/2023/IUHH/data.ts
@@ -6,12 +6,28 @@ export const { categories, qualifiers } = getCatQualLabels("IU-HH");
 const measureName = "IUHH";
 
 const inputFieldNames = [
-  "Number of Enrollee Months",
-  "Discharges",
-  "Discharges per 1,000 Enrollee Months",
-  "Days",
-  "Days per 1,000 Enrollee Months",
-  "Average Length of Stay",
+  {
+    label: "Number of Enrollee Months",
+    text: "Number of Enrollee Months",
+    id: "G3AVs1",
+  },
+  { label: "Discharges", text: "Discharges", id: "MwGkaA" },
+  {
+    label: "Discharges per 1,000 Enrollee Months",
+    text: "Discharges per 1,000 Enrollee Months",
+    id: "CGEK9m",
+  },
+  { label: "Days", text: "Days", id: "jSSEHA" },
+  {
+    label: "Days per 1,000 Enrollee Months",
+    text: "Days per 1,000 Enrollee Months",
+    id: "qjHhDk",
+  },
+  {
+    label: "Average Length of Stay",
+    text: "Average Length of Stay",
+    id: "coDyWU",
+  },
 ];
 
 // Rate structure by index in row

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/context.ts
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/context.ts
@@ -15,7 +15,7 @@ interface ContextProps {
   categories: LabelData[];
   qualifiers: LabelData[];
   measureName?: string;
-  inputFieldNames?: string[];
+  inputFieldNames?: LabelData[];
   ndrFormulas?: ndrFormula[];
   rateMultiplicationValue?: number;
   customMask?: RegExp;

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/index.tsx
@@ -9,6 +9,7 @@ import { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import { cleanString } from "utils/cleanString";
 import { ndrFormula } from "types";
+import { LabelData } from "utils";
 
 interface OmsCheckboxProps {
   /** name for react-hook-form registration */
@@ -51,7 +52,7 @@ export const buildOmsCheckboxes = ({
 
 interface BaseProps extends Types.Qualifiers, Types.Categories {
   measureName?: string;
-  inputFieldNames?: string[];
+  inputFieldNames?: LabelData[];
   ndrFormulas?: ndrFormula[];
   /** string array for perfromance measure descriptions */
   performanceMeasureArray?: Types.RateFields[][];

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/data.ts
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/data.ts
@@ -5,7 +5,7 @@ export interface PerformanceMeasureData {
   qualifiers?: LabelData[]; // age ranges, etc
   categories?: LabelData[]; //performance measure descriptions
   measureName?: string;
-  inputFieldNames?: string[];
+  inputFieldNames?: LabelData[];
   ndrFormulas?: ndrFormula[];
   customPrompt?: string; // Default: "Enter a number for the numerator and the denominator. Rate will auto-calculate:"
   questionText?: string[];

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -29,7 +29,7 @@ interface NdrSetProps {
   categories?: LabelData[];
   qualifiers?: LabelData[];
   measureName?: string;
-  inputFieldNames?: string[];
+  inputFieldNames?: LabelData[];
   ndrFormulas?: ndrFormula[];
   rateReadOnly: boolean;
   calcTotal: boolean;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
IU-HH & AIF-HH have unique fields compare to the other measures. So the chain is Category -> Qualifier -> Fields. 

The ask is to add an id for the field as to prevent any issues if the field label changes. 

We have checked, and they don't require us to do chaining of the id name, so we're going with just the short id for the uid. 

So the data should look like the image below, in the database.
<img width="690" alt="uid" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/5020edc5-62a2-4b39-8b62-971b601896eb">

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2770

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, one with Health Home (i.e. [stateuserWA@test.com](mailto:stateuserDC@test.com))
2) Go to AIF-HH
3) Select the first radio button for the first 3 questions, this will open up performance measures
4) Fill out data for performance measures & OMS
5) Spin up local dynamo db
6) Find AIF-HH 2023 data in local dynamo db, there should now be uid keys in the data

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
