### PR TITLE
OMS Other Validation Error

### DIFF
--- a/services/ui-src/src/measures/2023/PCRAD/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2023/PCRAD/questions/PerformanceMeasure.tsx
@@ -37,10 +37,10 @@ const CategoryNdrSets = ({
 
   return (
     <>
-      {categories.map((item) => {
-        let rates: QMR.IRate[] | undefined = qualifiers?.map((cat, idx) => ({
-          label: cat.label,
-          uid: `${item.id}.${cat.id}`,
+      {categories.map((cat) => {
+        let rates: QMR.IRate[] | undefined = qualifiers?.map((qual, idx) => ({
+          label: qual.label,
+          uid: `${cat.id}.${qual.id}`,
           id: idx,
         }));
 
@@ -48,15 +48,15 @@ const CategoryNdrSets = ({
 
         return (
           <>
-            <CUI.Text key={item.id} fontWeight="bold" my="5">
-              {item.label}
+            <CUI.Text key={cat.id} fontWeight="bold" my="5">
+              {cat.label}
             </CUI.Text>
             <QMR.Rate
               readOnly={rateReadOnly}
               rates={rates}
               rateMultiplicationValue={rateScale}
               customMask={customMask}
-              {...register(`PerformanceMeasure.rates.${item.id}`)}
+              {...register(`PerformanceMeasure.rates.${cat.id}`)}
             />
           </>
         );

--- a/services/ui-src/src/measures/2023/PCRHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2023/PCRHH/questions/PerformanceMeasure.tsx
@@ -37,10 +37,10 @@ const CategoryNdrSets = ({
 
   return (
     <>
-      {categories.map((item) => {
-        let rates: QMR.IRate[] | undefined = qualifiers?.map((cat, idx) => ({
-          label: cat.label,
-          uid: `${item.id}.${cat.id}`,
+      {categories.map((cat) => {
+        let rates: QMR.IRate[] | undefined = qualifiers?.map((qual, idx) => ({
+          label: qual.label,
+          uid: `${cat.id}.${qual.id}`,
           id: idx,
         }));
 
@@ -48,15 +48,15 @@ const CategoryNdrSets = ({
 
         return (
           <>
-            <CUI.Text key={item.id} fontWeight="bold" my="5">
-              {item.label}
+            <CUI.Text key={cat.id} fontWeight="bold" my="5">
+              {cat.label}
             </CUI.Text>
             <QMR.Rate
               readOnly={rateReadOnly}
               rates={rates}
               rateMultiplicationValue={rateScale}
               customMask={customMask}
-              {...register(`PerformanceMeasure.rates.${item.id}`)}
+              {...register(`PerformanceMeasure.rates.${cat.id}`)}
             />
           </>
         );

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
@@ -530,8 +530,8 @@ const useRenderOPMCheckboxOptions = (name: string) => {
               id: 0,
             },
           ]}
-          name={`${name}.rates.${cleanedFieldName}.OPM`}
-          key={`${name}.rates.${cleanedFieldName}.OPM`}
+          name={`${name}.rates.OPM.${cleanedFieldName}`}
+          key={`${name}.rates.OPM.${cleanedFieldName}`}
           readOnly={rateReadOnly}
           rateMultiplicationValue={rateMultiplicationValue}
           customMask={customMask}

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -66,19 +66,19 @@ const CategoryNdrSets = ({
 
   return (
     <>
-      {categories.map((item) => {
-        let rates: QMR.IRate[] | undefined = qualifiers?.map((cat, idx) => ({
-          label: cat.label,
-          uid: item.id + "." + cat.id,
+      {categories.map((cat) => {
+        let rates: QMR.IRate[] | undefined = qualifiers?.map((qual, idx) => ({
+          label: qual.label,
+          uid: cat.id + "." + qual.id,
           id: idx,
         }));
 
         rates = rates?.length ? rates : [{ id: 0 }];
 
         return (
-          <CUI.Box key={item.id}>
+          <CUI.Box key={cat.id}>
             <CUI.Text fontWeight="bold" my="5">
-              {labelText[item.label] ?? item.label}
+              {labelText[cat.label] ?? cat.label}
             </CUI.Text>
             <RateComponent
               readOnly={rateReadOnly}
@@ -88,14 +88,14 @@ const CategoryNdrSets = ({
               ndrFormulas={ndrFormulas}
               rateMultiplicationValue={rateScale}
               calcTotal={calcTotal}
-              categoryName={item.label}
+              categoryName={cat.label}
               categories={categories}
               customMask={customMask}
               customNumeratorLabel={customNumeratorLabel}
               customDenominatorLabel={customDenominatorLabel}
               customRateLabel={customRateLabel}
               rateCalc={rateCalc}
-              {...register(`${DC.PERFORMANCE_MEASURE}.${DC.RATES}.${item.id}`)}
+              {...register(`${DC.PERFORMANCE_MEASURE}.${DC.RATES}.${cat.id}`)}
               allowNumeratorGreaterThanDenominator={
                 allowNumeratorGreaterThanDenominator
               }

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
@@ -8,7 +8,7 @@ import {
   DefaultFormData,
 } from "measures/2023/shared/CommonQuestions/types";
 import { validatePartialRateCompletionOMS } from "../validatePartialRateCompletion";
-import { LabelData } from "utils";
+import { LabelData, cleanString } from "utils";
 
 interface OmsValidationProps {
   data: DefaultFormData;
@@ -40,7 +40,9 @@ export const omsValidations = ({
     isOPM = true;
     opmQuals.push(
       ...data["OtherPerformanceMeasure-Rates"].map((rate) => ({
-        id: "",
+        id: rate.description
+          ? cleanString(rate.description)
+          : "Fill out description",
         label: rate.description ?? "Fill out description",
         text: "",
       }))


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
There is a validation error when checking OMS Other performance measure types. When a user selects “other performance measure” at the beginning of the measure, the oms section will show a validation error even if the data is entered. 

Note: Also renamed some bad variable names i did previously.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2777

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account
2) Select any measure that has the option of other
3) Under Measure specification, select Other
4) Fill out Describe the Rate
5) Go to the Optional Measure Stratification section
6) Pick any and fill out N/D/R set
7) Validate.
     - You should **NOT** see this, "Must fill out at least one NDR set."


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
