### PR TITLE
MDCT-2779: Add Missing Validation to AAB-AD, AAB-CH, LSC-CH

### DIFF
--- a/services/ui-src/src/measures/2023/AABAD/validation.ts
+++ b/services/ui-src/src/measures/2023/AABAD/validation.ts
@@ -55,6 +55,7 @@ const AABADValidation = (data: FormData) => {
       deviationReason
     ),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+    ...GV.validateOPMRates(OPM),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/AABCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AABCH/validation.ts
@@ -50,6 +50,7 @@ const AABCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+    ...GV.validateOPMRates(OPM),
 
     // OMS Validations
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2023/LSCCH/validation.ts
+++ b/services/ui-src/src/measures/2023/LSCCH/validation.ts
@@ -33,6 +33,7 @@ const LSCCHValidation = (data: FormData) => {
       deviationReason
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateOPMRates(OPM),
 
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
AAB-AD, AAB-CH, and LSC-CH measures were missing a validation to check if a state user creates identical data labels for multiple Other Performance Section rates. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2779

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Navigate to either of those (AAB-AD, AAB-CH, LSC-CH)
- Under `Measurement specification`, pick `Other` and type in any description
- Scroll down to `Other performance measure` and click `Add another`
- Type in identical fields in `Describe the rate` like so:

![Screenshot 2023-08-04 at 4 14 54 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/923acceb-549a-4894-8114-faf5e0c2a2c1)

Validate measure and you should see this error:

![Screenshot 2023-08-04 at 4 15 01 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/ac787862-886c-4c2c-a3d9-74ce392c74b5)


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
