### PR TITLE
Add Rate Label to LSC-CH

### DIFF
--- a/services/ui-src/src/measures/2023/rateLabelText.ts
+++ b/services/ui-src/src/measures/2023/rateLabelText.ts
@@ -1226,7 +1226,13 @@ export const data = {
     },
 
     "LSC-CH": {
-        "qualifiers": [{"label": "", "text": "", "id": "AtXKXx"}],
+        "qualifiers": [
+            {
+                "label": "At least one lead capillary or venous blood test on or before the child's second birthday.", 
+                "text": "At least one lead capillary or venous blood test on or before the child's second birthday.", 
+                "id": "AtXKXx"
+            }
+        ],
         "categories": [{"id":"HOiTVZ", "label": "", "text":""}]
     },
     "MSC-AD": {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
LSC-CH now has a rate label and a very long one at that,
At least one lead capillary or venous blood test on or before the child’s second birthday.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2780

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account
2) Create new child measure
3) Go to LSC-CH
4) Select first radio button in first 3 questions to open the Performance Measure section
5) Scroll down to Performance Measure section and there should be a rate label 
- "At least one lead capillary or venous blood test on or before the child’s second birthday."

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
