### PR TITLE
Measure Text Updates

### DIFF
--- a/services/ui-src/src/measures/2023/AABAD/data.ts
+++ b/services/ui-src/src/measures/2023/AABAD/data.ts
@@ -5,7 +5,7 @@ export const { categories, qualifiers } = getCatQualLabels("AAB-AD");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   customPrompt:
-    "Enter a number for the numerator and the denominator. The measure is reported as an inverted rate. <br/> The formula for the Rate = (1 - (Numerator/Denominator)) x 100",
+    "Enter a number for the numerator and the denominator. The measure is reported as an inverted rate. The formula for the Rate = (1 - (Numerator/Denominator)) x 100",
   questionText: [
     "The percentage of episodes for beneficiaries age 18 and older with a diagnosis of acute bronchitis/bronchiolitis that did not result in an antibiotic dispensing event.",
   ],

--- a/services/ui-src/src/measures/2023/AABCH/data.ts
+++ b/services/ui-src/src/measures/2023/AABCH/data.ts
@@ -5,7 +5,7 @@ export const { categories, qualifiers } = getCatQualLabels("AAB-CH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   customPrompt:
-    "Enter a number for the numerator and the denominator. The measure is reported as an inverted rate. <br/> The formula for the Rate = 1 - (Numerator/Denominator) x 100",
+    "Enter a number for the numerator and the denominator. The measure is reported as an inverted rate. The formula for the Rate = (1 - (Numerator/Denominator)) x 100",
   questionText: [
     "The percentage of episodes for beneficiaries ages 3 months to 17 years with a diagnosis of acute bronchitis/bronchiolitis that did not result in an antibiotic dispensing event.",
   ],

--- a/services/ui-src/src/measures/2023/IUHH/data.ts
+++ b/services/ui-src/src/measures/2023/IUHH/data.ts
@@ -59,7 +59,7 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
   customPrompt:
     "Enter the appropriate data below. Completion of at least one set of Numerator/Denominator/Rate (numeric entry, other than zero) is required.",
   questionText: [
-    "Rate of acute inpatient care and services (total, maternity, mental and behavioral disorders, surgery, and medicine) per 1,000 enrollee months among health home enrollees.",
+    "Rate of acute inpatient care and services (total, mental and behavioral disorders, surgery, and medicine) per 1,000 enrollee months among health home enrollees.",
   ],
   questionListItems: [],
   measureName,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
IU-HH
- Removed the word "maternity" from performance measure description

AAB-AD, AAB-CH
- Remore stray '/br' tag

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2783
MDCT-2789

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

MDCT-2783
- Sign into QMR with an account with HH, (i.e. [stateuserWA@test.com](mailto:stateuserDC@test.com))
- Go to IU-HH
- Select the first radio button in the first 3 questions to trigger the Performance Measure
- Scroll down to Performance Measure, the description text should read "(total, mental and behavioral disorders, surgery, and medicine)

MDCT-2789
- Go to AAB-AD
- Trigger the Performance Measure
- Scroll to Performance Measure, the bolded text should read "Enter a number for the numerator and the denominator. The measure is reported as an inverted rate. The formula for the Rate = (1 - (Numerator/Denominator)) x 100"
- The 'br/' tag should be removed

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
