### PR TITLE
MDCT-2789: Fix custom HTML rendering for AAB-AD and AAB-CH (OMS)

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
@@ -101,12 +101,14 @@ export const OtherPerformanceMeasure = ({
                 <CUI.Text
                   fontWeight="bold"
                   mt={5}
+                  dangerouslySetInnerHTML={{
+                    __html:
+                      data.customPrompt ??
+                      `Enter a number for the numerator and the denominator. Rate will
+            auto-calculate:`,
+                  }}
                   data-cy="Enter a number for the numerator and the denominator"
-                >
-                  {data.customPrompt ??
-                    `Enter a number for the numerator and the denominator. Rate will
-        auto-calculate:`}
-                </CUI.Text>
+                />
                 {(dataSourceWatch?.[0] !== "AdministrativeData" ||
                   dataSourceWatch?.length !== 1) && (
                   <CUI.Heading pt="5" size={"sm"}>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently, there is a `<br/>` rendering on the OMS section of AAB-AD and AAB-CH. This is a fix for it!

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2789

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Navigate to AAB-AD or AAB-CH
- Click `Other` under `Measurement specification`

You should not see any HTML tags out in the wild, stay safe out there.

![Screenshot 2023-08-07 at 3 33 13 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/bbf8fe92-36df-4f22-93f5-5605fbf3e3cb)


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
