### PR TITLE
State Specific Comment Change

### DIFF
--- a/services/ui-src/src/components/Inputs/Checkbox/index.test.tsx
+++ b/services/ui-src/src/components/Inputs/Checkbox/index.test.tsx
@@ -20,7 +20,7 @@ const TestComponent = () => {
           value: "Other",
           children: [
             <Inputs.TextInput
-              label="Describe the data source (state-specific comment):"
+              label="Describe the data source (text in this field is included in publicly-reported state-specific comments):"
               formLabelProps={{
                 fontWeight: "normal",
                 fontSize: "normal",

--- a/services/ui-src/src/components/Inputs/RadioButton/index.test.tsx
+++ b/services/ui-src/src/components/Inputs/RadioButton/index.test.tsx
@@ -20,7 +20,7 @@ const TestComponent = () => {
           value: "Other",
           children: [
             <Inputs.TextInput
-              label="Describe the data source (state-specific comment):"
+              label="Describe the data source (text in this field is included in publicly-reported state-specific comments):"
               formLabelProps={{
                 fontWeight: "normal",
                 fontSize: "normal",
@@ -51,7 +51,7 @@ const TestComponent2 = () => {
           value: "Other",
           children: [
             <Inputs.TextInput
-              label="Describe the data source (state-specific comment):"
+              label="Describe the data source (text in this field is included in publicly-reported state-specific comments):"
               formLabelProps={{
                 fontWeight: "normal",
                 fontSize: "normal",

--- a/services/ui-src/src/measures/2023/CPAAD/questions/DataSource.tsx
+++ b/services/ui-src/src/measures/2023/CPAAD/questions/DataSource.tsx
@@ -20,7 +20,7 @@ export const DataSource = () => {
             value: "Other",
             children: [
               <QMR.TextArea
-                label="Describe the data source (state-specific comment):"
+                label="Describe the data source (text in this field is included in publicly-reported state-specific comments):"
                 {...register("DataSource-CAHPS-Version-Other")}
               />,
             ],

--- a/services/ui-src/src/measures/2023/MSCAD/questions/DataSource.tsx
+++ b/services/ui-src/src/measures/2023/MSCAD/questions/DataSource.tsx
@@ -19,7 +19,7 @@ export const DataSource = () => {
             value: "Other",
             children: [
               <QMR.TextArea
-                label="Describe the data source (state-specific comment):"
+                label="Describe the data source (text in this field is included in publicly-reported state-specific comments):"
                 {...register("DataSource-CAHPS-Version-Other")}
               />,
             ],

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/AdditionalNotes/index.test.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/AdditionalNotes/index.test.tsx
@@ -29,7 +29,7 @@ describe("Test AdditionalNotes component", () => {
 
   it("accepts input", async () => {
     const textArea = await screen.findByLabelText(
-      "Please add any additional notes or comments on the measure not otherwise captured above (state-specific comment):"
+      "Please add any additional notes or comments on the measure not otherwise captured above (text in this field is included in publicly-reported state-specific comments):"
     );
     fireEvent.type(textArea, "This is the test text");
     expect(textArea).toHaveDisplayValue("This is the test text");
@@ -41,7 +41,7 @@ describe("Test AdditionalNotes component", () => {
     );
 
     const textArea = await screen.findByLabelText(
-      "Please add any additional notes or comments on the measure not otherwise captured above (state-specific comment):"
+      "Please add any additional notes or comments on the measure not otherwise captured above (text in this field is included in publicly-reported state-specific comments):"
     );
 
     fireEvent.click(reportingNo);

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/AdditionalNotes/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/AdditionalNotes/index.tsx
@@ -22,7 +22,7 @@ export const AdditionalNotes = () => {
       label="Additional Notes/Comments on the measure (optional)"
     >
       <QMR.TextArea
-        label="Please add any additional notes or comments on the measure not otherwise captured above (state-specific comment):"
+        label="Please add any additional notes or comments on the measure not otherwise captured above (text in this field is included in publicly-reported state-specific comments):"
         {...register(DC.ADDITIONAL_NOTES)}
       />
       <CUI.Box marginTop={10}>

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/DataSource/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/DataSource/index.tsx
@@ -70,7 +70,8 @@ const buildDataSourceOptions: DSCBFunc = ({ data = [], parentName }) => {
     });
 
     if (node.description) {
-      let label = "Describe the data source (state-specific comment):";
+      let label =
+        "Describe the data source (text in this field is included in publicly-reported state-specific comments):";
       children.push(
         <QMR.TextArea
           label={

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/DataSourceCahps/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/DataSourceCahps/index.tsx
@@ -30,7 +30,7 @@ export const DataSourceRadio = ({ data = defaultData }: DataSourceProps) => {
             children: [
               <QMR.TextArea
                 name="describeTheDataSource"
-                label="Describe the data source (state-specific comment):"
+                label="Describe the data source (text in this field is included in publicly-reported state-specific comments):"
                 key="dataSourceOtherTextArea"
                 formLabelProps={{
                   fontWeight: "normal",

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/DefinitionsOfPopulation/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/DefinitionsOfPopulation/index.tsx
@@ -69,7 +69,7 @@ export const DefinitionOfPopulation = ({
                 children: [
                   <QMR.TextArea
                     formLabelProps={{ fontWeight: "400" }}
-                    label="Define the other denominator population (state-specific comment):"
+                    label="Define the other denominator population (text in this field is included in publicly-reported state-specific comments):"
                     {...register(DC.DEFINITION_DENOMINATOR_OTHER)}
                   />,
                 ],
@@ -133,7 +133,7 @@ export const DefinitionOfPopulation = ({
                   {...register(
                     DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN
                   )}
-                  label="Explain which populations are excluded and why (state-specific comment):"
+                  label="Explain which populations are excluded and why (text in this field is included in publicly-reported state-specific comments):"
                 />,
                 <CUI.Box mt="10" key="DenominatorDefineTotalTechSpec-No-Size">
                   <QMR.NumberInput
@@ -424,7 +424,7 @@ export const DefinitionOfPopulation = ({
                 <CUI.Box pb="5" key="DeliverySys-Other">
                   <QMR.TextArea
                     formLabelProps={{ fontWeight: "400" }}
-                    label="Describe the Other Delivery System represented in the denominator (state-specific comment):"
+                    label="Describe the Other Delivery System represented in the denominator (text in this field is included in publicly-reported state-specific comments):"
                     {...register(DC.DELIVERY_SYS_OTHER)}
                   />
                 </CUI.Box>,

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/DeviationFromMeasureSpecification/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/DeviationFromMeasureSpecification/index.tsx
@@ -25,7 +25,7 @@ export const DeviationFromMeasureSpec = () => {
             children: [
               <QMR.TextArea
                 {...register(DC.DEVIATION_REASON)}
-                label="Explain the deviation(s) (state-specific comment):"
+                label="Explain the deviation(s) (text in this field is included in publicly-reported state-specific comments):"
                 formLabelProps={{ fontWeight: 400 }}
               />,
             ],


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
BO wanted text to change from **(state-specific comment)** to **(text in this field is included in publicly-reported state-specific comments)**

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2782

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account
2) Go to any measure
3) Changes where you can see the text
- Data Source > Other 
- Additional Notes
- Definition of Population Included in the Measure
         - No, this denominator does not represent the total measure-eligible population as defined by the Technical Specifications for this measure.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
