### PR TITLE
Global OMS Validation

### DIFF
--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
@@ -84,6 +84,7 @@ const validateNDRs = (
 ) => {
   const isFilled: { [key: string]: boolean } = {};
   const isDeepFilled: { [key: string]: boolean } = {};
+  const isClassFilled: { [key: string]: boolean } = {};
   const errorArray: FormError[] = [];
   // validates top levels, ex: Race, Geography, Sex
   const validateTopLevelNode = (node: OMS.TopLevelOmsNode, label: string[]) => {
@@ -173,6 +174,7 @@ const validateNDRs = (
       ""
     );
     checkIsDeepFilled(locationReduced, rateData);
+    checkIsClassFilled(locationReduced, rateData);
   };
   //checks at least one ndr filled
   const checkNdrsFilled = (rateData: RateData) => {
@@ -253,6 +255,10 @@ const validateNDRs = (
     }
   };
 
+  const checkIsClassFilled = (location: string, rateData: RateData) => {
+    isClassFilled[location] = rateData?.rates != undefined;
+  };
+
   // Loop through top level nodes for validation
   for (const key of data.OptionalMeasureStratification?.options ?? []) {
     isFilled[key] = false;
@@ -284,6 +290,19 @@ const validateNDRs = (
           errorMessage:
             "For any category selected, all NDR sets must be filled.",
         });
+      }
+    }
+
+    if (!Object.values(isClassFilled).every((v) => v === false)) {
+      for (const classKey in isClassFilled) {
+        if (!isClassFilled[classKey]) {
+          errorArray.push({
+            errorLocation: `Optional Measure Stratification: ${locationDictionary(
+              classKey.split("-")
+            )}`,
+            errorMessage: "Must fill out at least one NDR set.",
+          });
+        }
       }
     }
   }

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
@@ -256,7 +256,7 @@ const validateNDRs = (
   };
 
   const checkIsClassFilled = (location: string, rateData: RateData) => {
-    isClassFilled[location] = rateData?.rates != undefined;
+    isClassFilled[location] = rateData?.rates !== undefined;
   };
 
   // Loop through top level nodes for validation

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
@@ -269,7 +269,6 @@ const validateNDRs = (
 
   //if selection is empty, it means that no sub classification was selected
   const checkIsDisaggregateFilled = (locations: string[], selection: any) => {
-    //only check if there's at least 1
     isDisaggregateFilled[locations[1]] = selection !== undefined;
   };
   // Loop through top level nodes for validation

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
@@ -255,6 +255,7 @@ const validateNDRs = (
     }
   };
 
+  //check if sub-classifications have rateData entered
   const checkIsClassFilled = (location: string, rateData: RateData) => {
     isClassFilled[location] = rateData?.rates !== undefined;
   };
@@ -293,6 +294,8 @@ const validateNDRs = (
       }
     }
 
+    //if at least one sub-classifications qualifiers is false (no rate data entered), we want to generate an error message,
+    //else if all is false, we will ignore it as another error message would already be there
     if (!Object.values(isClassFilled).every((v) => v === false)) {
       for (const classKey in isClassFilled) {
         if (!isClassFilled[classKey]) {

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
@@ -84,7 +84,8 @@ const validateNDRs = (
 ) => {
   const isFilled: { [key: string]: boolean } = {};
   const isDeepFilled: { [key: string]: boolean } = {};
-  const isClassFilled: { [key: string]: boolean } = {};
+  const isClassificationFilled: { [key: string]: boolean } = {};
+  const isDisaggregateFilled: { [key: string]: boolean } = {};
   const errorArray: FormError[] = [];
   // validates top levels, ex: Race, Geography, Sex
   const validateTopLevelNode = (node: OMS.TopLevelOmsNode, label: string[]) => {
@@ -118,10 +119,13 @@ const validateNDRs = (
       }
     }
     // validate sub type, ex: Asian -> Korean, Chinese, etc
-    if (node.aggregate?.includes("No")) {
+    if (node.aggregate?.includes("NoIndependentData")) {
+      //if options are empty but there's a no
       for (const key of node.options ?? []) {
         validateChildNodes(node.selections?.[key] ?? {}, [...label, key]);
       }
+      //check if disaggregate has sub-categories selected
+      checkIsDisaggregateFilled(label, node.selections);
     }
     //validate rates
     if (node.rateData) {
@@ -174,7 +178,7 @@ const validateNDRs = (
       ""
     );
     checkIsDeepFilled(locationReduced, rateData);
-    checkIsClassFilled(locationReduced, rateData);
+    checkIsClassificationFilled(locationReduced, rateData);
   };
   //checks at least one ndr filled
   const checkNdrsFilled = (rateData: RateData) => {
@@ -256,10 +260,18 @@ const validateNDRs = (
   };
 
   //check if sub-classifications have rateData entered
-  const checkIsClassFilled = (location: string, rateData: RateData) => {
-    isClassFilled[location] = rateData?.rates !== undefined;
+  const checkIsClassificationFilled = (
+    location: string,
+    rateData: RateData
+  ) => {
+    isClassificationFilled[location] = rateData?.rates !== undefined;
   };
 
+  //if selection is empty, it means that no sub classification was selected
+  const checkIsDisaggregateFilled = (locations: string[], selection: any) => {
+    //only check if there's at least 1
+    isDisaggregateFilled[locations[1]] = selection !== undefined;
+  };
   // Loop through top level nodes for validation
   for (const key of data.OptionalMeasureStratification?.options ?? []) {
     isFilled[key] = false;
@@ -296,9 +308,9 @@ const validateNDRs = (
 
     //if at least one sub-classifications qualifiers is false (no rate data entered), we want to generate an error message,
     //else if all is false, we will ignore it as another error message would already be there
-    if (!Object.values(isClassFilled).every((v) => v === false)) {
-      for (const classKey in isClassFilled) {
-        if (!isClassFilled[classKey]) {
+    if (!Object.values(isClassificationFilled).every((v) => v === false)) {
+      for (const classKey in isClassificationFilled) {
+        if (!isClassificationFilled[classKey]) {
           errorArray.push({
             errorLocation: `Optional Measure Stratification: ${locationDictionary(
               classKey.split("-")
@@ -306,6 +318,19 @@ const validateNDRs = (
             errorMessage: "Must fill out at least one NDR set.",
           });
         }
+      }
+    }
+
+    //checking if the user has selected no to aggregate data for certain classifictions (i.e. asian, native hawaiian or pacific islanders)
+    //keeping the error message seperate in case we want to have unique messages in the future
+    for (const classKey in isDisaggregateFilled) {
+      if (!isDisaggregateFilled[classKey]) {
+        errorArray.push({
+          errorLocation: `Optional Measure Stratification: ${locationDictionary(
+            classKey.split("-")
+          )}`,
+          errorMessage: "Must fill out at least one NDR set.",
+        });
       }
     }
   }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently for OMS, when selecting a sub-category and not selecting a label, it will generate a validation error. This is correct and expected.

The issue is when you have two sub-classification selected and only one of them is filled out. This causes the system to think both sub-classification had its N/D/R filled out, so no validation error is shown. 

This branch should fix that and will generate a validation error for the non-filled out sub-classification.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2791

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account
2) Go to AAB-AD
3) Select the first radio button for the first 3 questions, this will open up the Performance Measures
4) Go to Performance Measure, fill out the N/D/R set, every N/D/R filled will generate an equivalent check box for the OMS
5) The OMS section should be available now
6) Select the 'Race' checkbox
7) Check any two sub classification
8) Only fill out 1 sub-classification N/D/R set
9) Click Validate
10) There should be a validation error for the non-filled out N/D/R set.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
