### PR TITLE
OMS Classification ID and Labels

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/data.ts
@@ -1,6 +1,8 @@
 export interface OmsNode {
-  /** displayName value for option */
+  /** id value for option */
   id: string;
+  /** displayName value for option*/
+  label: string;
   /** should additional category render? */
   addMore?: boolean;
   /** should this node have a subCatOption? */
@@ -9,81 +11,125 @@ export interface OmsNode {
   options?: OmsNode[];
   /** should additional category values have subCatOptions? */
   addMoreSubCatFlag?: boolean;
-  /** should the aggregate question have a diffrent title than id? */
+  /** should the aggregate question have a diffrent title than label? */
   aggregateTitle?: string;
 }
 
 export const OMSData = (): OmsNode[] => {
   const data: OmsNode[] = [
     {
-      id: "Race",
+      id: "3dpUZu",
+      label: "Race",
       options: [
-        { id: "American Indian or Alaska Native", flagSubCat: false },
         {
-          id: "Asian",
+          id: "ll9YP8",
+          flagSubCat: false,
+          label: "American Indian or Alaska Native",
+        },
+        {
+          id: "RKWD6S",
+          label: "Asian",
           options: [
-            { id: "Asian Indian", flagSubCat: false },
-            { id: "Chinese", flagSubCat: false },
-            { id: "Filipino", flagSubCat: false },
-            { id: "Japanese", flagSubCat: false },
-            { id: "Korean", flagSubCat: false },
-            { id: "Vietnamese", flagSubCat: false },
-            { id: "Other Asian", flagSubCat: false },
+            { id: "e68Cj8", flagSubCat: false, label: "Asian Indian" },
+            { id: "gCxXhf", flagSubCat: false, label: "Chinese" },
+            { id: "i2fIgY", flagSubCat: false, label: "Filipino" },
+            { id: "WxWvJ8", flagSubCat: false, label: "Japanese" },
+            { id: "78IBC7", flagSubCat: false, label: "Korean" },
+            { id: "GPgIYd", flagSubCat: false, label: "Vietnamese" },
+            { id: "5v7GMy", flagSubCat: false, label: "Other Asian" },
           ],
           flagSubCat: true,
         },
-        { id: "Black or African American", flagSubCat: false },
         {
-          id: "Native Hawaiian or Other Pacific Islander",
+          id: "6NrBa5",
+          flagSubCat: false,
+          label: "Black or African American",
+        },
+        {
+          id: "Qu4kZK",
+          label: "Native Hawaiian or Other Pacific Islander",
           options: [
-            { id: "Native Hawaiian", flagSubCat: false },
-            { id: "Guamanian or Chamorro", flagSubCat: false },
-            { id: "Samoan", flagSubCat: false },
-            { id: "Other Pacific Islander", flagSubCat: false },
+            {
+              id: "GDJJx4",
+              flagSubCat: false,
+              label: "Native Hawaiian",
+            },
+            {
+              id: "LgwPP1",
+              flagSubCat: false,
+              label: "Guamanian or Chamorro",
+            },
+            { id: "LTJcrA", flagSubCat: false, label: "Samoan" },
+            {
+              id: "Ri1PWc",
+              flagSubCat: false,
+              label: "Other Pacific Islander",
+            },
           ],
           flagSubCat: true,
         },
-        { id: "White", flagSubCat: false },
-        { id: "Two or More Races", flagSubCat: false },
-        { id: "Some Other Race", flagSubCat: false },
-        { id: "Missing or not reported", flagSubCat: false },
+        { id: "szjphG", flagSubCat: false, label: "White" },
+        {
+          id: "OmjSBa",
+          flagSubCat: false,
+          label: "Two or More Races",
+        },
+        { id: "uZTnKi", flagSubCat: false, label: "Some Other Race" },
+        {
+          id: "nN7fNs",
+          flagSubCat: false,
+          label: "Missing or not reported",
+        },
       ],
       addMore: true,
       addMoreSubCatFlag: false,
     },
     {
-      id: "Ethnicity",
+      id: "elakUl",
+      label: "Ethnicity",
       options: [
-        { id: "Not of Hispanic, Latino/a, or Spanish origin" },
         {
-          id: "Hispanic, Latino/a, or Spanish origin",
+          id: "51ZZEh",
+          label: "Not of Hispanic, Latino/a, or Spanish origin",
+        },
+        {
+          id: "BFeF4k",
+          label: "Hispanic, Latino/a, or Spanish origin",
           aggregateTitle: "Hispanic, Latino/a, or Spanish origin",
           options: [
-            { id: "Mexican, Mexican American, Chicano/a" },
-            { id: "Puerto Rican" },
-            { id: "Cuban" },
-            { id: "Another Hispanic, Latino/a or Spanish origin" },
+            {
+              id: "ZP5n08",
+              label: "Mexican, Mexican American, Chicano/a",
+            },
+            { id: "4cq5P4", label: "Puerto Rican" },
+            { id: "XCzK5D", label: "Cuban" },
+            {
+              id: "kHsTcd",
+              label: "Another Hispanic, Latino/a or Spanish origin",
+            },
           ],
         },
-        { id: "Missing or not reported" },
+        { id: "WBIqgU", label: "Missing or not reported" },
       ],
       addMore: true,
     },
     {
-      id: "Sex",
+      id: "O8BrOa",
+      label: "Sex",
       options: [
-        { id: "Male" },
-        { id: "Female" },
-        { id: "Missing or not reported" },
+        { id: "KRwFRN", label: "Male" },
+        { id: "8M0aAo", label: "Female" },
+        { id: "BnVURC", label: "Missing or not reported" },
       ],
       addMore: true,
     },
     {
-      id: "Geography",
+      id: "afMbTr",
+      label: "Geography",
       options: [
-        { id: "Urban" },
-        { id: "Rural" },
-        { id: "Missing or not reported" },
+        { id: "r07WKZ", label: "Urban" },
+        { id: "bbaSzG", label: "Rural" },
+        { id: "i11ZUj", label: "Missing or not reported" },
       ],
       addMore: true,
     },

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/index.tsx
@@ -7,7 +7,6 @@ import { TopLevelOmsChildren } from "./omsNodeBuilder";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
-import { cleanString } from "utils/cleanString";
 import { ndrFormula } from "types";
 import { LabelData } from "utils";
 
@@ -29,10 +28,10 @@ export const buildOmsCheckboxes = ({
   isSingleSex,
 }: OmsCheckboxProps) => {
   return data
-    .filter((d) => !isSingleSex || d.id !== "Sex") // remove sex as a top level option if isSingleSex
+    .filter((d) => !isSingleSex || d.id !== "O8BrOa") // remove sex as a top level option if isSingleSex
     .map((lvlOneOption) => {
-      const displayValue = lvlOneOption.id;
-      const value = cleanString(lvlOneOption.id);
+      const displayValue = lvlOneOption.label;
+      const value = lvlOneOption.id;
 
       const children = [
         <TopLevelOmsChildren
@@ -42,7 +41,8 @@ export const buildOmsCheckboxes = ({
           addMoreSubCatFlag={!!lvlOneOption.addMoreSubCatFlag}
           name={`${name}.selections.${value}`}
           key={`${name}.selections.${value}`}
-          id={displayValue}
+          id={value}
+          label={displayValue}
         />,
       ];
 

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -4,7 +4,6 @@ import * as CUI from "@chakra-ui/react";
 import { OmsNode } from "./data";
 
 import { AddAnotherSection } from "./additionalCategory";
-import { cleanString } from "utils/cleanString";
 import { SubCatSection } from "./subCatClassification";
 import { NDRSets } from "./ndrSets";
 
@@ -44,7 +43,7 @@ const renderRadioButtonOptions = ({
   return [
     {
       displayValue: `Yes, we are reporting aggregate data for the ${
-        omsNode?.aggregateTitle || omsNode?.id
+        omsNode?.aggregateTitle || omsNode?.label
       } categories.`,
       value: "YesAggregateData",
       children: [
@@ -53,7 +52,7 @@ const renderRadioButtonOptions = ({
     },
     {
       displayValue: `No, we are reporting disaggregated data for ${
-        omsNode?.aggregateTitle || omsNode?.id
+        omsNode?.aggregateTitle || omsNode?.label
       } sub-categories`,
       value: "NoIndependentData",
       children: [
@@ -64,9 +63,7 @@ const renderRadioButtonOptions = ({
             omsNode?.options!.map((node) => {
               return buildChildCheckboxOption({
                 omsNode: node,
-                name: `${name}.selections.${
-                  cleanString(node.id) ?? "ID_NOT_SET"
-                }`,
+                name: `${name}.selections.${node.id ?? "ID_NOT_SET"}`,
               });
             }) || []
           }
@@ -86,7 +83,7 @@ const buildChildCheckboxOption = ({
   name,
 }: ChildCheckBoxOptionProps) => {
   let children = [];
-  const cleanedName = omsNode?.id ? cleanString(omsNode.id) : "ID_NOT_SET";
+  const id = omsNode?.id ? omsNode.id : "ID_NOT_SET";
 
   if (!omsNode?.options) {
     children = [
@@ -101,14 +98,14 @@ const buildChildCheckboxOption = ({
         key={`${name}.aggregate`}
         options={renderRadioButtonOptions({ omsNode, name })}
         label={`Are you reporting aggregate data for the ${
-          omsNode.aggregateTitle || omsNode.id
+          omsNode.aggregateTitle || omsNode.label
         } category?`}
       />,
     ];
   }
   return {
-    value: cleanedName,
-    displayValue: omsNode?.id ?? "DISPLAY_ID_NOT_SET",
+    value: id,
+    displayValue: omsNode?.label ?? "DISPLAY_ID_NOT_SET",
     children,
   };
 };
@@ -129,8 +126,7 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
         key={`${props.name}.options`}
         options={[
           ...props.options.map((lvlTwoOption) => {
-            const cleanedId =
-              cleanString(lvlTwoOption?.id) ?? "LVL_TWO_ID_NOT_SET";
+            const cleanedId = lvlTwoOption?.id ?? "LVL_TWO_ID_NOT_SET";
 
             return buildChildCheckboxOption({
               omsNode: lvlTwoOption,

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/types.ts
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/types.ts
@@ -233,6 +233,7 @@ export namespace OmsNodes {
   export interface MidLevelOMSNode extends LowLevelOmsNode {
     // if sub-options
     [DC.AGGREGATE]?: string;
+    [DC.LABEL]?: string;
     [DC.OPTIONS]?: string[];
     [DC.SELECTIONS]?: {
       [option: string]: LowLevelOmsNode;
@@ -241,6 +242,7 @@ export namespace OmsNodes {
 
   export interface TopLevelOmsNode {
     // top level child, ex: Race, Sex, Ethnicity
+    [DC.LABEL]?: string;
     [DC.OPTIONS]?: string[]; // checkbox
     [DC.ADDITIONAL_CATS]?: string[]; // add another section
     [DC.SELECTIONS]?: {

--- a/services/ui-src/src/measures/2023/shared/globalValidations/dataDrivenTools.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/dataDrivenTools.ts
@@ -1,7 +1,7 @@
 import * as DC from "dataConstants";
 import * as Types from "measures/2023/shared/CommonQuestions/types";
 import { DataDrivenTypes as DDT } from "measures/2023/shared/CommonQuestions/types";
-import { LabelData, cleanString } from "utils";
+import { LabelData } from "utils";
 import { FormRateField as PM, RateData } from "./types";
 
 /**
@@ -99,7 +99,7 @@ export const omsLocationDictionary = (
     for (const option of node.options ?? []) {
       checkNode(option);
     }
-    dictionary[cleanString(node.id)] = node.id;
+    dictionary[node.id] = node.label;
   };
 
   for (const node of renderData) {

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
@@ -89,6 +89,13 @@ const validateNDRs = (
   const errorArray: FormError[] = [];
   // validates top levels, ex: Race, Geography, Sex
   const validateTopLevelNode = (node: OMS.TopLevelOmsNode, label: string[]) => {
+    //add label for db data
+    if (!node.label) {
+      const cleanString = locationDictionary(label);
+      node.label = cleanString
+        .substring(cleanString.lastIndexOf("-") + 1)
+        .trim();
+    }
     // validate children if exist
     if (node.options?.length) {
       for (const option of node.options) {
@@ -109,6 +116,13 @@ const validateNDRs = (
   };
   // validate mid level, ex: White, African American, etc
   const validateChildNodes = (node: OMS.MidLevelOMSNode, label: string[]) => {
+    //add label for db data
+    if (!node.label) {
+      const cleanString = locationDictionary(label);
+      node.label = cleanString
+        .substring(cleanString.lastIndexOf("-") + 1)
+        .trim();
+    }
     // validate sub categories
     if (node.additionalSubCategories?.length) {
       for (const subCat of node.additionalSubCategories) {

--- a/services/ui-src/src/utils/testUtils/2023/validationHelpers.ts
+++ b/services/ui-src/src/utils/testUtils/2023/validationHelpers.ts
@@ -254,6 +254,7 @@ export const generateOmsFormData = (
       midNode.aggregate = "NoIndependentData";
       for (const opt of node.options) {
         midNode.options ??= [];
+        midNode.label ??= "";
         midNode.selections ??= {};
         addToSelections && midNode.options.push(opt.id);
         midNode.selections[opt.id] = {
@@ -280,6 +281,7 @@ export const generateOmsFormData = (
     if (!!node.options?.length) {
       for (const opt of node.options) {
         topNode.options ??= [];
+        topNode.label ??= "";
         topNode.selections ??= {};
         addToSelections && topNode.options.push(opt.id);
         topNode.selections[opt.id] = createMidLevelNode(opt);

--- a/services/ui-src/src/utils/testUtils/2023/validationHelpers.ts
+++ b/services/ui-src/src/utils/testUtils/2023/validationHelpers.ts
@@ -9,7 +9,7 @@ import {
   OMSData,
   OmsNode,
 } from "measures/2023/shared/CommonQuestions/OptionalMeasureStrat/data";
-import { LabelData, cleanString } from "utils";
+import { LabelData } from "utils";
 import {
   RateFields,
   OmsNodes as OMS,
@@ -255,8 +255,8 @@ export const generateOmsFormData = (
       for (const opt of node.options) {
         midNode.options ??= [];
         midNode.selections ??= {};
-        addToSelections && midNode.options.push(cleanString(opt.id));
-        midNode.selections[cleanString(opt.id)] = {
+        addToSelections && midNode.options.push(opt.id);
+        midNode.selections[opt.id] = {
           rateData,
           additionalSubCategories: [{ description, rateData }],
         };
@@ -281,8 +281,8 @@ export const generateOmsFormData = (
       for (const opt of node.options) {
         topNode.options ??= [];
         topNode.selections ??= {};
-        addToSelections && topNode.options.push(cleanString(opt.id));
-        topNode.selections[cleanString(opt.id)] = createMidLevelNode(opt);
+        addToSelections && topNode.options.push(opt.id);
+        topNode.selections[opt.id] = createMidLevelNode(opt);
       }
     }
     if (node.addMore) {
@@ -298,11 +298,10 @@ export const generateOmsFormData = (
 
   // makes top level node for each omsnode
   const createBaseOMS = (node: OmsNode) => {
-    const cleanLabel = cleanString(node.id);
     addToSelections &&
-      omsData.OptionalMeasureStratification.options.push(cleanLabel);
+      omsData.OptionalMeasureStratification.options.push(node.id);
     omsData.OptionalMeasureStratification.selections ??= {};
-    omsData.OptionalMeasureStratification.selections[cleanLabel] =
+    omsData.OptionalMeasureStratification.selections[node.id] =
       createTopLevelNode(node);
   };
 

--- a/tests/cypress/cypress/integration/measures/adult/HBDAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/HBDAD.spec.ts
@@ -278,16 +278,16 @@ describe("Measure: HBD-AD", () => {
       '[data-cy="OptionalMeasureStratification.options0"] > .chakra-checkbox__control'
     ).click();
     cy.get(
-      '[data-cy="OptionalMeasureStratification.selections.Race.options0"] > .chakra-checkbox__control'
+      '[data-cy="OptionalMeasureStratification.selections.3dpUZu.options0"] > .chakra-checkbox__control'
     ).click();
     cy.get(
-      '[data-cy="OptionalMeasureStratification.selections.Race.selections.AmericanIndianorAlaskaNative.rateData.options0"] > .chakra-checkbox__label > .chakra-text'
+      '[data-cy="OptionalMeasureStratification.selections.3dpUZu.selections.ll9YP8.rateData.options0"] > .chakra-checkbox__label > .chakra-text'
     ).should("have.text", "example 1");
     cy.get(
-      '[data-cy="OptionalMeasureStratification.selections.Race.selections.AmericanIndianorAlaskaNative.rateData.options0"] > .chakra-checkbox__control'
+      '[data-cy="OptionalMeasureStratification.selections.3dpUZu.selections.ll9YP8.rateData.options0"] > .chakra-checkbox__control'
     ).click();
     cy.get(
-      '[data-cy="OptionalMeasureStratification.selections.Race.selections.AmericanIndianorAlaskaNative.rateData.rates.OPM.example1.0.numerator"]'
+      '[data-cy="OptionalMeasureStratification.selections.3dpUZu.selections.ll9YP8.rateData.rates.OPM.example1.0.numerator"]'
     ).type("3");
   });
 });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The OMS classifications are using the label text as id, similar to how rateLabelText used label as both id and text. 

Added  a label key for each and replace the current id values to unique id values. A couple of components were updated to reflect this change.

Old
<img width="421" alt="Screenshot 2023-08-18 at 5 02 54 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/9341fa45-89a0-4f47-bcf1-ec8d041b08a1">



New
<img width="459" alt="Screenshot 2023-08-18 at 12 41 50 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/b1011584-0af6-42f7-9f4b-47e8f96e7f39">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2831

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account
2) Pick any measure that has OMS, i.e. AAB-AD
3) Trigger Performance Measure section by selecting the first radio button in Measure Specification section
4) Scroll Down and fill our Performance Measure, this will enable OMS
5) Scroll Down to OMS
6) Fill out N/D/R and validate
7) Open local dynamodb
8) Check to make sure that the data is using 6 character ids and not words

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
