### PR TITLE
OPM Null Issue in DB

### DIFF
--- a/services/ui-src/src/dataConstants.ts
+++ b/services/ui-src/src/dataConstants.ts
@@ -152,6 +152,7 @@ export const OHSU = "OHSU";
 export const OMS = "OptionalMeasureStratification";
 export const OPA = "OPA";
 export const OPM_EXPLAINATION = "OtherPerformanceMeasure-Explanation";
+export const OPM_KEY = "OPM_"; //used for fixing id keys for other performance measures
 export const OPM_HYBRID_EXPLANATION =
   "OtherPerformanceMeasure-HybridExplanation";
 export const OPM_NOTES = "OtherPerformanceMeasure-Notes";

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/ndrSets.tsx
@@ -521,7 +521,7 @@ const useRenderOPMCheckboxOptions = (name: string) => {
 
   OPM?.forEach(({ description }, idx) => {
     if (description) {
-      const cleanedFieldName = cleanString(description);
+      const cleanedFieldName = `${DC.OPM_KEY}${cleanString(description)}`;
 
       const RateComponent = (
         <QMR.Rate

--- a/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/omsValidator/index.ts
@@ -1,3 +1,4 @@
+import * as DC from "dataConstants";
 import {
   OmsValidationCallback,
   locationDictionaryFunction,
@@ -41,7 +42,7 @@ export const omsValidations = ({
     opmQuals.push(
       ...data["OtherPerformanceMeasure-Rates"].map((rate) => ({
         id: rate.description
-          ? cleanString(rate.description)
+          ? `${DC.OPM_KEY}${cleanString(rate.description)}`
           : "Fill out description",
         label: rate.description ?? "Fill out description",
         text: "",
@@ -249,10 +250,11 @@ const validateNDRs = (
         //array key order is determined in component useQualRateArray, cleanedName variable
         if (rateData.rates?.[cat.id]?.[qual.id]) {
           const temp = rateData.rates[cat.id][qual.id][0];
+          let cleanQual = isOPM ? qual.label : qual.id;
           if (temp && temp.denominator && temp.numerator && temp.rate) {
-            isDeepFilled[`${location}-${qual.id}`] ??= true;
+            isDeepFilled[`${location}-${cleanQual}`] ??= true;
           } else {
-            isDeepFilled[`${location}-${qual.id}`] = false;
+            isDeepFilled[`${location}-${cleanQual}`] = false;
           }
         }
       }

--- a/tests/cypress/cypress/integration/measures/adult/HBDAD.spec.ts
+++ b/tests/cypress/cypress/integration/measures/adult/HBDAD.spec.ts
@@ -287,7 +287,7 @@ describe("Measure: HBD-AD", () => {
       '[data-cy="OptionalMeasureStratification.selections.Race.selections.AmericanIndianorAlaskaNative.rateData.options0"] > .chakra-checkbox__control'
     ).click();
     cy.get(
-      '[data-cy="OptionalMeasureStratification.selections.Race.selections.AmericanIndianorAlaskaNative.rateData.rates.OPM.example1.0.numerator"]'
+      '[data-cy="OptionalMeasureStratification.selections.Race.selections.AmericanIndianorAlaskaNative.rateData.rates.OPM.OPM_example1.0.numerator"]'
     ).type("3");
   });
 });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
When saving other performance measure, if the user enters a rate name that is a number, that number ends being using as the length of the array instead of as a object key in the OMS OPM. Only happens if N/D/R is not filled out but option is selected.
<img width="1201" alt="Screenshot 2023-08-21 at 11 06 39 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/a966bad1-dd71-4e36-b869-3d7b4df07808">



<img width="450" alt="Screenshot 2023-08-18 at 1 00 58 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/20663eb9-6b9b-443b-b68b-0f454664ab48">


I could not find any indication that it was done by QMR itself, it might be a rendering issue from the database. My solution was to add a variable (OPM_) in front on the string key to keep it from being a pure number.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2828

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account
2) Select a measure that has an Other performance measure, i.e. AAB-AD
3) In Measurement Specification, select "Other"
4) Scroll down to "Other Performance Measure"
5) Enter "12" in "Describe the Rate"
6) Select classification checkboxes in "Optional Measure Stratification" but DO NOT fill out the N/D/R
7) It should look like this in local dynamodb

<img width="347" alt="Screenshot 2023-08-21 at 11 03 26 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/d512ec1f-c54b-4ec9-8ceb-9bcf8bfc59b8">

If trigger a validation error, it should not show the extra key name
<img width="1129" alt="Screenshot 2023-08-21 at 10 55 22 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/c2fa6724-c688-4b0c-b991-4a63e1c2ccfe">


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
