### PR TITLE
Remove Extra Comma and ID changes

### DIFF
--- a/services/ui-src/src/measures/2023/rateLabelText.ts
+++ b/services/ui-src/src/measures/2023/rateLabelText.ts
@@ -217,7 +217,7 @@ export const data = {
                 "id": "Total"
             }
         ],
-        "categories": [{"id":"AMR-CH-CAT-A", "label": "", "text":""}]
+        "categories": [{"id":"tMt8gW", "label": "", "text":""}]
     },
     "APM-CH": {
         "qualifiers": [
@@ -436,7 +436,7 @@ export const data = {
                 "id": "tJ0j8E"
             }
         ],
-        "categories": [{"id":"CDF-AD-CAT-A", "label": "", "text":""}]
+        "categories": [{"id":"fUqwlh", "label": "", "text":""}]
     },
     "CDF-CH": {
         "qualifiers": [
@@ -484,7 +484,7 @@ export const data = {
                 "id": "eV26mN"
             }
         ],
-        "categories": [{"id":"CHL-AD-CAT-A", "label": "", "text":""}]
+        "categories": [{"id":"cvc5jQ", "label": "", "text":""}]
     },
     "CHL-CH": {
         "qualifiers": [
@@ -1566,7 +1566,7 @@ export const data = {
                 "id": "usIZvV"
             }
         ],
-        "categories": [{"id":"PQI05-AD-CAT-A", "label": "", "text":""}]
+        "categories": [{"id":"CzBbvv", "label": "", "text":""}]
     },
     "PQI08-AD": {
         "qualifiers": [

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validatePartialRateCompletion/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validatePartialRateCompletion/index.ts
@@ -49,7 +49,7 @@ const _validation = ({
         (!rate.denominator || !rate.numerator || !rate.rate)
       ) {
         const multipleQuals: boolean = !!qualifiers?.length;
-        const multipleCats: boolean = !!categories?.length;
+        const multipleCats: boolean = !!categories?.some((item) => item.label);
         errors.push({
           errorLocation: location,
           errorMessage: errorMessageFunc(


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
There is an extra comma being generated in a validator error for partial filled N/D/R sets. This only shows up in non category performance measure validation.

Also, tossed in some id changes to rateLabelText to the standard 6 character format that were missed

<img width="1120" alt="Screenshot 2023-08-22 at 9 12 53 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/27f48687-2e5d-4ea9-80ed-e2d3d0e6d692">

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2837

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account
2) Select a measure with no category, i.e. AMR-AD
3) In **Measurement Specification** section, select the first radio button, that will open up **Performance Measure**
4) Scroll down to **Performance Measure**, only fill out only the numerator.
5) Validate
There should not be a comma in this validation error. 

<img width="1126" alt="Screenshot 2023-08-22 at 9 12 21 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/f14de0d8-6ec7-49a5-8a01-acaa0ed2da57">


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
