### PR TITLE
Calculate to Zero

### DIFF
--- a/services/ui-src/src/components/IETRate/index.tsx
+++ b/services/ui-src/src/components/IETRate/index.tsx
@@ -150,7 +150,7 @@ export const IETRate = ({
     }
 
     if (
-      parseInt(editRate.denominator) &&
+      editRate.denominator &&
       editRate.numerator &&
       (parseFloat(editRate.numerator) <= parseFloat(editRate.denominator) ||
         allowNumeratorGreaterThanDenominator)

--- a/services/ui-src/src/components/Rate/index.tsx
+++ b/services/ui-src/src/components/Rate/index.tsx
@@ -138,7 +138,7 @@ export const Rate = ({
     }
 
     if (
-      parseInt(editRate.denominator) &&
+      editRate.denominator &&
       editRate.numerator &&
       (parseFloat(editRate.numerator) <= parseFloat(editRate.denominator) ||
         allowNumeratorGreaterThanDenominator)

--- a/services/ui-src/src/utils/rateFormulas/index.ts
+++ b/services/ui-src/src/utils/rateFormulas/index.ts
@@ -13,7 +13,9 @@ export const defaultRateCalculation: RateFormula = (
 ) => {
   const floatNumerator = parseFloat(numerator);
   const floatDenominator = parseFloat(denominator);
-  const floatRate = floatNumerator / floatDenominator;
+  let floatRate = floatNumerator / floatDenominator;
+  //zero dividing by zero becomes a NaN when dividing, converting it back to zero. only numbers are entered in so no issues otherwise
+  floatRate = isNaN(floatRate) ? 0 : floatRate;
   const roundedRate = fixRounding(
     floatRate * rateMultiplicationValue,
     numbersAfterDecimal
@@ -29,7 +31,10 @@ export const AABRateCalculation: RateFormula = (
 ) => {
   const floatNumerator = parseFloat(numerator);
   const floatDenominator = parseFloat(denominator);
-  const floatRate = 1 - floatNumerator / floatDenominator;
+  let remainder = floatNumerator / floatDenominator;
+  //zero dividing by zero becomes a NaN when dividing, converting it back to zero. only numbers are entered in so no issues otherwise
+  remainder = isNaN(remainder) ? 0 : remainder;
+  const floatRate = 1 - remainder;
   const roundedRate = fixRounding(
     floatRate * rateMultiplicationValue,
     numbersAfterDecimal

--- a/services/ui-src/src/utils/rateFormulas/index.ts
+++ b/services/ui-src/src/utils/rateFormulas/index.ts
@@ -13,9 +13,13 @@ export const defaultRateCalculation: RateFormula = (
 ) => {
   const floatNumerator = parseFloat(numerator);
   const floatDenominator = parseFloat(denominator);
+
+  //return 0 if the denominator is 0, provides a rate for when numerator = 0 & denominator = 0
+  if (floatDenominator === 0) {
+    return (0).toFixed(numbersAfterDecimal);
+  }
+
   let floatRate = floatNumerator / floatDenominator;
-  //zero dividing by zero becomes a NaN when dividing, converting it back to zero. only numbers are entered in so no issues otherwise
-  floatRate = isNaN(floatRate) ? 0 : floatRate;
   const roundedRate = fixRounding(
     floatRate * rateMultiplicationValue,
     numbersAfterDecimal


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
When entering data into N/D/R if numerator and denominator is 0, the rate does not auto calculate. and leaves an empty input field. 

<img width="1107" alt="Screenshot 2023-08-22 at 11 18 10 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/c6f3a32d-1a4c-4fc1-8f93-1c9f61746e56">


This change will have it fill the rate out with a zero

<img width="1117" alt="Screenshot 2023-08-22 at 11 19 02 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/a913e4c0-af23-4eb5-981a-cd05659e002e">

---

**Note:** AAB-AD & AAB-CH calculates a little differently, so the rate value would be 100%.

![Screenshot 2023-08-22 at 10 14 22 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/e3d87272-e814-4eb6-91c1-6ca685b0e9ff)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2838

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account
2) Select any measure that has a Performance Measure, i.e. AMR-AD
3) In the **Measurement Specification** section, select the first radio button to enable the **Performance Measure** section
4) In the Performance Measure section, enter 0 for Numerator and Denominator. Rate should now auto calculate to 0.0.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
