### PR TITLE
Fix OMS Add More Label

### DIFF
--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OptionalMeasureStrat/index.tsx
@@ -37,7 +37,7 @@ export const buildOmsCheckboxes = ({
         <TopLevelOmsChildren
           options={lvlOneOption.options}
           addMore={!!lvlOneOption.addMore}
-          parentDisplayName={lvlOneOption.aggregateTitle || lvlOneOption.id}
+          parentDisplayName={lvlOneOption.aggregateTitle || lvlOneOption.label}
           addMoreSubCatFlag={!!lvlOneOption.addMoreSubCatFlag}
           name={`${name}.selections.${value}`}
           key={`${name}.selections.${value}`}


### PR DESCRIPTION
### Description
Fixed button text issue, was showing classification id instead of the text label

<img width="364" alt="Screenshot 2023-08-23 at 5 27 04 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/7b761020-b600-481e-83f9-4a0d9133e5a7">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any account
2) Select a measure with OMS, i.e. AAB-AD
3) On Measurement Specification, select the first radio button, this will trigger the Performance Measure section
4) Scroll down and fill out an N/D/R set in Performance Measure
5) Scroll down again to the OMS section
6) Checkbox any classification
7) Make sure the Add button is using reading labels 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
