### PR TITLE
Fix roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tests_output
 *.log
 tests/cypress/videos
 tests/cypress/screenshots
+tests/cypress/downloads
 tests/cypress/package-lock.json
 package-lock.json
 tests/cypress/.env

--- a/services/app-api/handlers/banners/create.ts
+++ b/services/app-api/handlers/banners/create.ts
@@ -32,4 +32,4 @@ export const createBanner = handler(async (event, _context) => {
     await dynamoDb.put(params);
     return { status: StatusCodes.CREATED };
   }
-}, true);
+});

--- a/services/app-api/handlers/banners/create.ts
+++ b/services/app-api/handlers/banners/create.ts
@@ -12,6 +12,7 @@ export const createBanner = handler(async (event, _context) => {
       body: Errors.UNAUTHORIZED,
     };
   }
+
   const validPayload = (payload: any) => {
     return (
       payload.title &&

--- a/services/app-api/handlers/banners/create.ts
+++ b/services/app-api/handlers/banners/create.ts
@@ -1,9 +1,17 @@
 import handler from "../../libs/handler-lib";
 import dynamoDb from "../../libs/dynamodb-lib";
-
+import { hasRolePermissions } from "../../libs/authorization";
+import { UserRoles } from "../../types";
 import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const createBanner = handler(async (event, _context) => {
+  // action limited to admin users
+  if (!hasRolePermissions(event, [UserRoles.ADMIN])) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: Errors.UNAUTHORIZED,
+    };
+  }
   const validPayload = (payload: any) => {
     return (
       payload.title &&

--- a/services/app-api/handlers/banners/delete.ts
+++ b/services/app-api/handlers/banners/delete.ts
@@ -1,8 +1,17 @@
 import handler from "../../libs/handler-lib";
 import dynamoDb from "../../libs/dynamodb-lib";
+import { hasRolePermissions } from "../../libs/authorization";
+import { UserRoles } from "../../types";
 import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const deleteBanner = handler(async (event, _context) => {
+  // action limited to admin users
+  if (!hasRolePermissions(event, [UserRoles.ADMIN])) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: Errors.UNAUTHORIZED,
+    };
+  }
   if (!event?.pathParameters?.bannerId!) {
     throw new Error(Errors.NO_KEY);
   } else {

--- a/services/app-api/handlers/banners/delete.ts
+++ b/services/app-api/handlers/banners/delete.ts
@@ -15,4 +15,4 @@ export const deleteBanner = handler(async (event, _context) => {
     await dynamoDb.delete(params);
     return { status: StatusCodes.SUCCESS, body: params };
   }
-}, true);
+});

--- a/services/app-api/handlers/banners/delete.ts
+++ b/services/app-api/handlers/banners/delete.ts
@@ -12,6 +12,7 @@ export const deleteBanner = handler(async (event, _context) => {
       body: Errors.UNAUTHORIZED,
     };
   }
+
   if (!event?.pathParameters?.bannerId!) {
     throw new Error(Errors.NO_KEY);
   } else {

--- a/services/app-api/handlers/banners/tests/create.test.ts
+++ b/services/app-api/handlers/banners/tests/create.test.ts
@@ -40,15 +40,11 @@ jest.spyOn(dynamoDb, "put").mockImplementation(
 
 describe("Test createBanner API method", () => {
   beforeEach(() => {
-    mockHasRolePermissions.mockImplementation(() => {
-      return true;
-    });
+    mockHasRolePermissions.mockImplementation(() => true);
   });
 
   test("Test unauthorized user attempt", async () => {
-    mockHasRolePermissions.mockImplementation(() => {
-      return false;
-    });
+    mockHasRolePermissions.mockImplementation(() => false);
     const res = await createBanner(testEvent, null);
     expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
     expect(res.body).toContain(Errors.UNAUTHORIZED);

--- a/services/app-api/handlers/banners/tests/create.test.ts
+++ b/services/app-api/handlers/banners/tests/create.test.ts
@@ -7,7 +7,7 @@ import { mockDocumentClient } from "../../../utils/testing/setupJest";
 
 const mockHasRolePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasRolePermissions: () => mockHasRolePermissions(),
 }));
 

--- a/services/app-api/handlers/banners/tests/create.test.ts
+++ b/services/app-api/handlers/banners/tests/create.test.ts
@@ -5,9 +5,10 @@ import dynamoDb from "../../../libs/dynamodb-lib";
 import { Errors, StatusCodes } from "../../../utils/constants/constants";
 import { mockDocumentClient } from "../../../utils/testing/setupJest";
 
+const mockHasRolePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
   isAuthorized: jest.fn().mockReturnValue(true),
-  hasPermissions: jest.fn().mockReturnValue(true),
+  hasRolePermissions: () => mockHasRolePermissions(),
 }));
 
 jest.mock("../../../libs/debug-lib", () => ({
@@ -37,11 +38,25 @@ jest.spyOn(dynamoDb, "put").mockImplementation(
   })
 );
 
-describe("Test createBanner API method", () => {
+describe("brax Test createBanner API method", () => {
+  beforeEach(() => {
+    mockHasRolePermissions.mockImplementation(() => {
+      return true;
+    });
+  });
+
+  test("Test unauthorized user attempt", async () => {
+    mockHasRolePermissions.mockImplementation(() => {
+      return false;
+    });
+    const res = await createBanner(testEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
+  });
+
   test("Test Successful Run of Banner Creation", async () => {
     const res = await createBanner(testEvent, null);
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-    expect(JSON.parse(res.body).status).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.CREATED);
   });
 
   test("Test invalid banner data", async () => {

--- a/services/app-api/handlers/banners/tests/create.test.ts
+++ b/services/app-api/handlers/banners/tests/create.test.ts
@@ -38,7 +38,7 @@ jest.spyOn(dynamoDb, "put").mockImplementation(
   })
 );
 
-describe("brax Test createBanner API method", () => {
+describe("Test createBanner API method", () => {
   beforeEach(() => {
     mockHasRolePermissions.mockImplementation(() => {
       return true;

--- a/services/app-api/handlers/banners/tests/delete.test.ts
+++ b/services/app-api/handlers/banners/tests/delete.test.ts
@@ -7,7 +7,7 @@ import { mockDocumentClient } from "../../../utils/testing/setupJest";
 
 const mockHasRolePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasRolePermissions: () => mockHasRolePermissions(),
 }));
 

--- a/services/app-api/handlers/banners/tests/delete.test.ts
+++ b/services/app-api/handlers/banners/tests/delete.test.ts
@@ -5,9 +5,10 @@ import dynamoDb from "../../../libs/dynamodb-lib";
 import { Errors, StatusCodes } from "../../../utils/constants/constants";
 import { mockDocumentClient } from "../../../utils/testing/setupJest";
 
+const mockHasRolePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
   isAuthorized: jest.fn().mockReturnValue(true),
-  hasPermissions: jest.fn().mockReturnValue(true),
+  hasRolePermissions: () => mockHasRolePermissions(),
 }));
 
 jest.mock("../../../libs/debug-lib", () => ({
@@ -29,10 +30,24 @@ jest.spyOn(dynamoDb, "delete").mockImplementation(
 );
 
 describe("Test deleteBanner API method", () => {
+  beforeEach(() => {
+    mockHasRolePermissions.mockImplementation(() => {
+      return true;
+    });
+  });
+
   test("Test Successful Banner Deletion", async () => {
     const res = await deleteBanner(testEvent, null);
     expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-    expect(JSON.parse(res.body).status).toBe(StatusCodes.SUCCESS);
+  });
+
+  test("Test unauthorized user attempt", async () => {
+    mockHasRolePermissions.mockImplementation(() => {
+      return false;
+    });
+    const res = await deleteBanner(testEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
   });
 
   test("Test bannerKey not provided throws 500 error", async () => {

--- a/services/app-api/handlers/banners/tests/delete.test.ts
+++ b/services/app-api/handlers/banners/tests/delete.test.ts
@@ -31,9 +31,7 @@ jest.spyOn(dynamoDb, "delete").mockImplementation(
 
 describe("Test deleteBanner API method", () => {
   beforeEach(() => {
-    mockHasRolePermissions.mockImplementation(() => {
-      return true;
-    });
+    mockHasRolePermissions.mockImplementation(() => true);
   });
 
   test("Test Successful Banner Deletion", async () => {
@@ -42,9 +40,7 @@ describe("Test deleteBanner API method", () => {
   });
 
   test("Test unauthorized user attempt", async () => {
-    mockHasRolePermissions.mockImplementation(() => {
-      return false;
-    });
+    mockHasRolePermissions.mockImplementation(() => false);
     const res = await deleteBanner(testEvent, null);
     expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
     expect(res.body).toContain(Errors.UNAUTHORIZED);

--- a/services/app-api/handlers/banners/tests/fetch.test.ts
+++ b/services/app-api/handlers/banners/tests/fetch.test.ts
@@ -6,7 +6,7 @@ import { Errors, StatusCodes } from "../../../utils/constants/constants";
 import { mockDocumentClient } from "../../../utils/testing/setupJest";
 
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasPermissions: jest.fn().mockReturnValue(true),
 }));
 

--- a/services/app-api/handlers/banners/tests/fetch.test.ts
+++ b/services/app-api/handlers/banners/tests/fetch.test.ts
@@ -39,20 +39,18 @@ describe("Test fetchBanner API method", () => {
       })
     );
     const res = await fetchBanner(testEvent, null);
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-    expect(JSON.parse(res.body).status).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
   });
 
   test("Test Successful Banner Fetch", async () => {
     const res = await fetchBanner(testEvent, null);
-    const parsedBody = JSON.parse(res.body);
     expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-    expect(parsedBody.status).toBe(StatusCodes.SUCCESS);
-    expect(parsedBody.body.Item.title).toEqual(testBanner.title);
-    expect(parsedBody.body.Item.description).toEqual(testBanner.description);
-    expect(parsedBody.body.Item.startDate).toEqual(testBanner.startDate);
-    expect(parsedBody.body.Item.endDate).toEqual(testBanner.endDate);
-    expect(parsedBody.body.Item.link).toEqual(testBanner.link);
+    const parsedBody = JSON.parse(res.body);
+    expect(parsedBody.Item.title).toEqual(testBanner.title);
+    expect(parsedBody.Item.description).toEqual(testBanner.description);
+    expect(parsedBody.Item.startDate).toEqual(testBanner.startDate);
+    expect(parsedBody.Item.endDate).toEqual(testBanner.endDate);
+    expect(parsedBody.Item.link).toEqual(testBanner.link);
   });
 
   test("Test bannerKey not provided throws 500 error", async () => {

--- a/services/app-api/handlers/banners/tests/unauth.test.ts
+++ b/services/app-api/handlers/banners/tests/unauth.test.ts
@@ -4,7 +4,7 @@ import { testBanner, proxyEvent } from "./proxyEvent";
 import { Errors, StatusCodes } from "../../../utils/constants/constants";
 
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(false),
+  isAuthenticated: jest.fn().mockReturnValue(false),
   hasPermissions: jest.fn().mockReturnValue(true),
 }));
 

--- a/services/app-api/handlers/coreSets/create.ts
+++ b/services/app-api/handlers/coreSets/create.ts
@@ -32,10 +32,8 @@ export const createCoreSet = handler(async (event, context) => {
 
   if (coreSetExists) {
     return {
-      statusCode: 400,
-      body: JSON.stringify({
-        error: "Failure to create coreset. Coreset already exists.",
-      }),
+      status: StatusCodes.BAD_REQUEST,
+      body: Errors.CORESET_ALREADY_EXISTS,
     };
   }
   const dynamoKey = createCompoundKey(event);
@@ -77,7 +75,7 @@ export const createCoreSet = handler(async (event, context) => {
   };
 
   await dynamoDb.post(params);
-  return params;
+  return { status: StatusCodes.SUCCESS };
 });
 
 const createDependentMeasures = async (

--- a/services/app-api/handlers/coreSets/create.ts
+++ b/services/app-api/handlers/coreSets/create.ts
@@ -11,15 +11,17 @@ import * as Types from "../../types";
 import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const createCoreSet = handler(async (event, context) => {
-  // action limited to state users from corresponding state
+  // action limited to any admin type user and state users from corresponding state
   const isStateUser = hasRolePermissions(event, [Types.UserRoles.STATE_USER]);
-  const isFromCorrespondingState = hasStatePermissions(event);
-  if (!isStateUser || !isFromCorrespondingState) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: Errors.UNAUTHORIZED,
-    };
-  }
+  if (isStateUser) {
+    const isFromCorrespondingState = hasStatePermissions(event);
+    if (!isFromCorrespondingState) {
+      return {
+        status: StatusCodes.UNAUTHORIZED,
+        body: Errors.UNAUTHORIZED,
+      };
+    }
+  } // if not state user, can safely assume admin type user due to baseline handler protections
 
   // The State Year and ID are all part of the path
   const state = event!.pathParameters!.state!;

--- a/services/app-api/handlers/coreSets/create.ts
+++ b/services/app-api/handlers/coreSets/create.ts
@@ -75,7 +75,7 @@ export const createCoreSet = handler(async (event, context) => {
   };
 
   await dynamoDb.post(params);
-  return { status: StatusCodes.SUCCESS };
+  return { status: StatusCodes.SUCCESS, body: params };
 });
 
 const createDependentMeasures = async (

--- a/services/app-api/handlers/coreSets/delete.ts
+++ b/services/app-api/handlers/coreSets/delete.ts
@@ -31,7 +31,10 @@ export const deleteCoreSet = handler(async (event, context) => {
   await dynamoDb.delete(params);
   await deleteDependentMeasures(state, year, coreSet);
 
-  return params;
+  return {
+    status: StatusCodes.SUCCESS,
+    body: params,
+  };
 });
 
 const deleteDependentMeasures = async (

--- a/services/app-api/handlers/coreSets/delete.ts
+++ b/services/app-api/handlers/coreSets/delete.ts
@@ -2,18 +2,13 @@ import handler from "../../libs/handler-lib";
 import dynamoDb from "../../libs/dynamodb-lib";
 import { createCompoundKey } from "../dynamoUtils/createCompoundKey";
 import { convertToDynamoExpression } from "../dynamoUtils/convertToDynamoExpressionVars";
-import {
-  hasRolePermissions,
-  hasStatePermissions,
-} from "../../libs/authorization";
-import { Measure, UserRoles } from "../../types";
+import { hasStatePermissions } from "../../libs/authorization";
+import { Measure } from "../../types";
 import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const deleteCoreSet = handler(async (event, context) => {
   // action limited to state users from corresponding state
-  const isStateUser = hasRolePermissions(event, [UserRoles.STATE_USER]);
-  const isFromCorrespondingState = hasStatePermissions(event);
-  if (!isStateUser || !isFromCorrespondingState) {
+  if (!hasStatePermissions(event)) {
     return {
       status: StatusCodes.UNAUTHORIZED,
       body: Errors.UNAUTHORIZED,

--- a/services/app-api/handlers/coreSets/get.ts
+++ b/services/app-api/handlers/coreSets/get.ts
@@ -94,5 +94,8 @@ export const getCoreSet = handler(async (event, context) => {
     },
   };
   const queryValue = await dynamoDb.get(params);
-  return queryValue;
+  return {
+    status: StatusCodes.SUCCESS,
+    body: queryValue,
+  };
 });

--- a/services/app-api/handlers/coreSets/get.ts
+++ b/services/app-api/handlers/coreSets/get.ts
@@ -53,7 +53,10 @@ export const coreSetList = handler(async (event, context) => {
       );
       if (createCoreSetResult.statusCode === 200) {
         const res = await dynamoDb.scan(params);
-        return res;
+        return {
+          status: StatusCodes.SUCCESS,
+          body: res,
+        };
       } else {
         throw new Error("Creation failed");
       }

--- a/services/app-api/handlers/coreSets/get.ts
+++ b/services/app-api/handlers/coreSets/get.ts
@@ -4,9 +4,26 @@ import { updateCoreSetProgress } from "../../libs/updateCoreProgress";
 import { convertToDynamoExpression } from "../dynamoUtils/convertToDynamoExpressionVars";
 import { createCompoundKey } from "../dynamoUtils/createCompoundKey";
 import { createCoreSet } from "./create";
+import {
+  hasRolePermissions,
+  hasStatePermissions,
+} from "../../libs/authorization";
 import * as Types from "../../types";
+import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const coreSetList = handler(async (event, context) => {
+  // action limited to any admin type user and state users from corresponding state
+  const isStateUser = hasRolePermissions(event, [Types.UserRoles.STATE_USER]);
+  if (isStateUser) {
+    const isFromCorrespondingState = hasStatePermissions(event);
+    if (!isFromCorrespondingState) {
+      return {
+        status: StatusCodes.UNAUTHORIZED,
+        body: Errors.UNAUTHORIZED,
+      };
+    }
+  } // if not state user, can safely assume admin type user due to baseline handler protections
+
   const params = {
     TableName: process.env.coreSetTableName!,
     ...convertToDynamoExpression(
@@ -54,6 +71,18 @@ export const coreSetList = handler(async (event, context) => {
 });
 
 export const getCoreSet = handler(async (event, context) => {
+  // action limited to any admin type user and state users from corresponding state
+  const isStateUser = hasRolePermissions(event, [Types.UserRoles.STATE_USER]);
+  if (isStateUser) {
+    const isFromCorrespondingState = hasStatePermissions(event);
+    if (!isFromCorrespondingState) {
+      return {
+        status: StatusCodes.UNAUTHORIZED,
+        body: Errors.UNAUTHORIZED,
+      };
+    }
+  } // if not state user, can safely assume admin type user due to baseline handler protections
+
   const dynamoKey = createCompoundKey(event);
   const params = {
     TableName: process.env.coreSetTableName!,

--- a/services/app-api/handlers/coreSets/get.ts
+++ b/services/app-api/handlers/coreSets/get.ts
@@ -36,7 +36,6 @@ export const coreSetList = handler(async (event, context) => {
   };
 
   const results = await dynamoDb.scan<Types.CoreSet>(params);
-
   // if the query value contains no results
   if (results.Count === 0) {
     // add an adult coreset and requery the db
@@ -66,7 +65,10 @@ export const coreSetList = handler(async (event, context) => {
     // Update the progress measure numComplete
     const updatedCoreSetProgressResults =
       (await updateCoreSetProgress(results, event, context)) || results;
-    return updatedCoreSetProgressResults;
+    return {
+      status: StatusCodes.SUCCESS,
+      body: updatedCoreSetProgressResults,
+    };
   }
 });
 

--- a/services/app-api/handlers/coreSets/tests/create.test.ts
+++ b/services/app-api/handlers/coreSets/tests/create.test.ts
@@ -18,7 +18,7 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
 const mockHasRolePermissions = jest.fn();
 const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasRolePermissions: () => mockHasRolePermissions(),
   hasStatePermissions: () => mockHasStatePermissions(),
 }));

--- a/services/app-api/handlers/coreSets/tests/create.test.ts
+++ b/services/app-api/handlers/coreSets/tests/create.test.ts
@@ -5,6 +5,7 @@ import dynamoDb from "../../../libs/dynamodb-lib";
 import { measures } from "../../dynamoUtils/measureList";
 import { CoreSetAbbr } from "../../../types";
 import { getCoreSet } from "../get";
+import { Errors, StatusCodes } from "../../../utils/constants/constants";
 
 jest.mock("../../../libs/dynamodb-lib", () => ({
   __esModule: true,
@@ -14,9 +15,12 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
   },
 }));
 
+const mockHasRolePermissions = jest.fn();
+const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  __esModule: true,
   isAuthorized: jest.fn().mockReturnValue(true),
+  hasRolePermissions: () => mockHasRolePermissions(),
+  hasStatePermissions: () => mockHasStatePermissions(),
 }));
 
 jest.mock("../../../libs/debug-lib", () => ({
@@ -35,9 +39,45 @@ jest.mock("../get", () => ({
   getCoreSet: jest.fn(),
 }));
 
-describe("Testing the Create CoreSet Functions", () => {
+describe("brax Testing the Create CoreSet Functions", () => {
   beforeEach(() => {
     (getCoreSet as jest.Mock).mockReset();
+    mockHasRolePermissions.mockImplementation(() => true);
+    mockHasStatePermissions.mockImplementation(() => true);
+  });
+
+  test("Test unauthorized user attempt (incorrect role)", async () => {
+    mockHasRolePermissions.mockImplementation(() => false);
+    (getCoreSet as jest.Mock).mockReturnValue({ body: JSON.stringify({}) });
+    const list = measures[2021].filter((measure) => measure.type === "A");
+    const res = await createCoreSet(
+      {
+        ...testEvent,
+        pathParameters: { state: "FL", year: "2021", coreSet: CoreSetAbbr.ACS },
+      },
+      null
+    );
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
+  });
+
+  test("Test unauthorized user attempt (incorrect state)", async () => {
+    mockHasStatePermissions.mockImplementation(() => false);
+    (getCoreSet as jest.Mock).mockReturnValue({ body: JSON.stringify({}) });
+    const list = measures[2021].filter((measure) => measure.type === "A");
+    const res = await createCoreSet(
+      {
+        ...testEvent,
+        pathParameters: {
+          state: "FL",
+          year: "2021",
+          coreSet: CoreSetAbbr.ACS,
+        },
+      },
+      null
+    );
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
   });
 
   test("Test createCoreSet but coreSet exists", async () => {
@@ -52,12 +92,8 @@ describe("Testing the Create CoreSet Functions", () => {
       null
     );
 
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toContain("statusCode");
-    expect(res.body).toContain("400");
-    expect(res.body).toContain(
-      "Failure to create coreset. Coreset already exists."
-    );
+    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.body).toContain(Errors.CORESET_ALREADY_EXISTS);
   });
 
   test("Test createCoreSet", async () => {
@@ -71,10 +107,7 @@ describe("Testing the Create CoreSet Functions", () => {
       null
     );
 
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toContain("Item");
-    expect(res.body).toContain("coreSet");
-    expect(res.body).toContain("submitted");
+    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
     expect(dynamoDb.post).toHaveBeenCalledTimes(list.length + 1);
   });
 });

--- a/services/app-api/handlers/coreSets/tests/create.test.ts
+++ b/services/app-api/handlers/coreSets/tests/create.test.ts
@@ -39,7 +39,7 @@ jest.mock("../get", () => ({
   getCoreSet: jest.fn(),
 }));
 
-describe("brax Testing the Create CoreSet Functions", () => {
+describe("Testing the Create CoreSet Functions", () => {
   beforeEach(() => {
     (getCoreSet as jest.Mock).mockReset();
     mockHasRolePermissions.mockImplementation(() => true);

--- a/services/app-api/handlers/coreSets/tests/create.test.ts
+++ b/services/app-api/handlers/coreSets/tests/create.test.ts
@@ -42,26 +42,11 @@ jest.mock("../get", () => ({
 describe("Testing the Create CoreSet Functions", () => {
   beforeEach(() => {
     (getCoreSet as jest.Mock).mockReset();
-    mockHasRolePermissions.mockImplementation(() => true);
-    mockHasStatePermissions.mockImplementation(() => true);
-  });
-
-  test("Test unauthorized user attempt (incorrect role)", async () => {
     mockHasRolePermissions.mockImplementation(() => false);
-    (getCoreSet as jest.Mock).mockReturnValue({ body: JSON.stringify({}) });
-    const list = measures[2021].filter((measure) => measure.type === "A");
-    const res = await createCoreSet(
-      {
-        ...testEvent,
-        pathParameters: { state: "FL", year: "2021", coreSet: CoreSetAbbr.ACS },
-      },
-      null
-    );
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-    expect(res.body).toContain(Errors.UNAUTHORIZED);
   });
 
   test("Test unauthorized user attempt (incorrect state)", async () => {
+    mockHasRolePermissions.mockImplementation(() => true);
     mockHasStatePermissions.mockImplementation(() => false);
     (getCoreSet as jest.Mock).mockReturnValue({ body: JSON.stringify({}) });
     const list = measures[2021].filter((measure) => measure.type === "A");

--- a/services/app-api/handlers/coreSets/tests/delete.test.ts
+++ b/services/app-api/handlers/coreSets/tests/delete.test.ts
@@ -41,7 +41,7 @@ jest.mock("../../dynamoUtils/createCompoundKey", () => ({
   createCompoundKey: jest.fn().mockReturnValue("FL2020ACSFUA-AD"),
 }));
 
-describe("brax Testing Delete Core Set Functions", () => {
+describe("Testing Delete Core Set Functions", () => {
   beforeEach(() => {
     (db.scan as jest.Mock).mockReset();
     (db.delete as jest.Mock).mockReset();

--- a/services/app-api/handlers/coreSets/tests/delete.test.ts
+++ b/services/app-api/handlers/coreSets/tests/delete.test.ts
@@ -1,6 +1,5 @@
 import { deleteCoreSet } from "../delete";
 import db from "../../../libs/dynamodb-lib";
-import { env } from "yargs";
 import { testEvent, testMeasure } from "../../../test-util/testEvents";
 import { Errors, StatusCodes } from "../../../utils/constants/constants";
 
@@ -12,11 +11,9 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
   },
 }));
 
-const mockHasRolePermissions = jest.fn();
 const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
-  hasRolePermissions: () => mockHasRolePermissions(),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasStatePermissions: () => mockHasStatePermissions(),
 }));
 
@@ -45,21 +42,7 @@ describe("Testing Delete Core Set Functions", () => {
   beforeEach(() => {
     (db.scan as jest.Mock).mockReset();
     (db.delete as jest.Mock).mockReset();
-    mockHasRolePermissions.mockImplementation(() => true);
     mockHasStatePermissions.mockImplementation(() => true);
-  });
-
-  test("Test unauthorized user attempt (incorrect role)", async () => {
-    mockHasRolePermissions.mockImplementation(() => false);
-    const res = await deleteCoreSet(
-      {
-        ...testEvent,
-        pathParameters: { state: "FL", year: "2020", coreSet: "ACS" },
-      },
-      null
-    );
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-    expect(res.body).toContain(Errors.UNAUTHORIZED);
   });
 
   test("Test unauthorized user attempt (incorrect state)", async () => {

--- a/services/app-api/handlers/coreSets/tests/get.test.ts
+++ b/services/app-api/handlers/coreSets/tests/get.test.ts
@@ -25,7 +25,7 @@ jest.mock("../create", () => ({
 const mockHasRolePermissions = jest.fn();
 const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasRolePermissions: () => mockHasRolePermissions(),
   hasStatePermissions: () => mockHasStatePermissions(),
 }));

--- a/services/app-api/handlers/coreSets/tests/get.test.ts
+++ b/services/app-api/handlers/coreSets/tests/get.test.ts
@@ -7,6 +7,7 @@ import { updateCoreSetProgress } from "../../../libs/updateCoreProgress";
 import { createCompoundKey } from "../../dynamoUtils/createCompoundKey";
 import { CoreSetAbbr } from "../../../types";
 import { createCoreSet } from "../create";
+import { Errors, StatusCodes } from "../../../utils/constants/constants";
 
 jest.mock("../../../libs/dynamodb-lib", () => ({
   __esModule: true,
@@ -21,9 +22,12 @@ jest.mock("../create", () => ({
   createCoreSet: jest.fn(),
 }));
 
+const mockHasRolePermissions = jest.fn();
+const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  __esModule: true,
   isAuthorized: jest.fn().mockReturnValue(true),
+  hasRolePermissions: () => mockHasRolePermissions(),
+  hasStatePermissions: () => mockHasStatePermissions(),
 }));
 
 jest.mock("../../../libs/debug-lib", () => ({
@@ -47,7 +51,7 @@ jest.mock("../../dynamoUtils/convertToDynamoExpressionVars", () => ({
   convertToDynamoExpression: jest.fn().mockReturnValue({ testValue: "test" }),
 }));
 
-describe("Test Get Core Set Functions", () => {
+describe("braxy Test Get Core Set Functions", () => {
   beforeAll(() => {
     process.env.coreSetTableName = "EXAMPLE TABLE";
   });
@@ -56,6 +60,18 @@ describe("Test Get Core Set Functions", () => {
     (createCoreSet as jest.Mock).mockReset();
     (dynamodbLib.scan as jest.Mock).mockReset();
     (updateCoreSetProgress as jest.Mock).mockReset();
+    mockHasRolePermissions.mockImplementation(() => false);
+  });
+
+  test("Test getCoreSet unauthorized user attempt (incorrect state)", async () => {
+    mockHasRolePermissions.mockImplementation(() => true);
+    mockHasStatePermissions.mockImplementation(() => false);
+    const res = await getCoreSet(
+      { ...testEvent, pathParameters: { coreSet: "ACS" } },
+      null
+    );
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
   });
 
   test("Test getCoreSet", async () => {
@@ -70,6 +86,22 @@ describe("Test Get Core Set Functions", () => {
       ...testEvent,
       pathParameters: { coreSet: "ACS" },
     });
+  });
+
+  test("Test coreSetList unauthorized user attempt (incorrect state)", async () => {
+    mockHasRolePermissions.mockImplementation(() => true);
+    mockHasStatePermissions.mockImplementation(() => false);
+    (dynamodbLib.scan as jest.Mock).mockReturnValue({ Count: 0 });
+    (createCoreSet as jest.Mock).mockReturnValue({ statusCode: 200 });
+    const res = await coreSetList(
+      {
+        ...testEvent,
+        pathParameters: { coreSet: CoreSetAbbr.ACS, year: "2021", state: "FL" },
+      },
+      null
+    );
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
   });
 
   test("Test coreSetList with results.Count being 0 and statusCode 200", async () => {
@@ -153,7 +185,6 @@ describe("Test Get Core Set Functions", () => {
       },
       null
     );
-
     expect(res.body).toContain('"Count":1');
   });
 });

--- a/services/app-api/handlers/coreSets/tests/get.test.ts
+++ b/services/app-api/handlers/coreSets/tests/get.test.ts
@@ -51,7 +51,7 @@ jest.mock("../../dynamoUtils/convertToDynamoExpressionVars", () => ({
   convertToDynamoExpression: jest.fn().mockReturnValue({ testValue: "test" }),
 }));
 
-describe("braxy Test Get Core Set Functions", () => {
+describe("Test Get Core Set Functions", () => {
   beforeAll(() => {
     process.env.coreSetTableName = "EXAMPLE TABLE";
   });

--- a/services/app-api/handlers/coreSets/tests/update.test.ts
+++ b/services/app-api/handlers/coreSets/tests/update.test.ts
@@ -12,12 +12,10 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
   },
 }));
 
-const mockHasRolePermissions = jest.fn();
 const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   getUserNameFromJwt: jest.fn().mockReturnValue("branchUser"),
-  hasRolePermissions: () => mockHasRolePermissions(),
   hasStatePermissions: () => mockHasStatePermissions(),
 }));
 
@@ -39,23 +37,7 @@ jest.mock("../../dynamoUtils/convertToDynamoExpressionVars", () => ({
 
 describe("Testing Updating Core Set Functions", () => {
   beforeEach(() => {
-    mockHasRolePermissions.mockImplementation(() => true);
     mockHasStatePermissions.mockImplementation(() => true);
-  });
-
-  test("Test unauthorized user attempt (incorrect role)", async () => {
-    mockHasRolePermissions.mockImplementation(() => false);
-    const res = await editCoreSet(
-      {
-        ...testEvent,
-        headers: { "cognito-identity-id": "branchUser" },
-        pathParameters: { coreSet: "ACS" },
-        body: "{}",
-      },
-      null
-    );
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-    expect(res.body).toContain(Errors.UNAUTHORIZED);
   });
 
   test("Test unauthorized user attempt (incorrect state)", async () => {

--- a/services/app-api/handlers/coreSets/tests/update.test.ts
+++ b/services/app-api/handlers/coreSets/tests/update.test.ts
@@ -37,7 +37,7 @@ jest.mock("../../dynamoUtils/convertToDynamoExpressionVars", () => ({
   convertToDynamoExpression: jest.fn().mockReturnValue({ testValue: "test" }),
 }));
 
-describe("brax Testing Updating Core Set Functions", () => {
+describe("Testing Updating Core Set Functions", () => {
   beforeEach(() => {
     mockHasRolePermissions.mockImplementation(() => true);
     mockHasStatePermissions.mockImplementation(() => true);

--- a/services/app-api/handlers/coreSets/update.ts
+++ b/services/app-api/handlers/coreSets/update.ts
@@ -41,6 +41,5 @@ export const editCoreSet = handler(async (event, context) => {
     ),
   };
   await dynamoDb.update(params);
-
-  return params;
+  return { status: StatusCodes.SUCCESS, body: params };
 });

--- a/services/app-api/handlers/coreSets/update.ts
+++ b/services/app-api/handlers/coreSets/update.ts
@@ -2,9 +2,25 @@ import handler from "../../libs/handler-lib";
 import dynamoDb from "../../libs/dynamodb-lib";
 import { convertToDynamoExpression } from "../dynamoUtils/convertToDynamoExpressionVars";
 import { createCompoundKey } from "../dynamoUtils/createCompoundKey";
-import { getUserNameFromJwt } from "../../libs/authorization";
+import {
+  getUserNameFromJwt,
+  hasRolePermissions,
+  hasStatePermissions,
+} from "../../libs/authorization";
+import { UserRoles } from "../../types";
+import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const editCoreSet = handler(async (event, context) => {
+  // action limited to state users from corresponding state
+  const isStateUser = hasRolePermissions(event, [UserRoles.STATE_USER]);
+  const isFromCorrespondingState = hasStatePermissions(event);
+  if (!isStateUser || !isFromCorrespondingState) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: Errors.UNAUTHORIZED,
+    };
+  }
+
   const { submitted, status } = JSON.parse(event!.body!);
   const dynamoKey = createCompoundKey(event);
   const lastAlteredBy = getUserNameFromJwt(event);

--- a/services/app-api/handlers/coreSets/update.ts
+++ b/services/app-api/handlers/coreSets/update.ts
@@ -4,17 +4,13 @@ import { convertToDynamoExpression } from "../dynamoUtils/convertToDynamoExpress
 import { createCompoundKey } from "../dynamoUtils/createCompoundKey";
 import {
   getUserNameFromJwt,
-  hasRolePermissions,
   hasStatePermissions,
 } from "../../libs/authorization";
-import { UserRoles } from "../../types";
 import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const editCoreSet = handler(async (event, context) => {
   // action limited to state users from corresponding state
-  const isStateUser = hasRolePermissions(event, [UserRoles.STATE_USER]);
-  const isFromCorrespondingState = hasStatePermissions(event);
-  if (!isStateUser || !isFromCorrespondingState) {
+  if (!hasStatePermissions(event)) {
     return {
       status: StatusCodes.UNAUTHORIZED,
       body: Errors.UNAUTHORIZED,

--- a/services/app-api/handlers/measures/create.ts
+++ b/services/app-api/handlers/measures/create.ts
@@ -9,15 +9,17 @@ import { MeasureStatus, CoreSetAbbr, UserRoles } from "../../types";
 import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const createMeasure = handler(async (event, context) => {
-  // action limited to state users from corresponding state
+  // action limited to any admin type user and state users from corresponding state
   const isStateUser = hasRolePermissions(event, [UserRoles.STATE_USER]);
-  const isFromCorrespondingState = hasStatePermissions(event);
-  if (!isStateUser || !isFromCorrespondingState) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: Errors.UNAUTHORIZED,
-    };
-  }
+  if (isStateUser) {
+    const isFromCorrespondingState = hasStatePermissions(event);
+    if (!isFromCorrespondingState) {
+      return {
+        status: StatusCodes.UNAUTHORIZED,
+        body: Errors.UNAUTHORIZED,
+      };
+    }
+  } // if not state user, can safely assume admin type user due to baseline handler protections
 
   const body = JSON.parse(event!.body!);
   const dynamoKey = createCompoundKey(event);

--- a/services/app-api/handlers/measures/create.ts
+++ b/services/app-api/handlers/measures/create.ts
@@ -43,5 +43,5 @@ export const createMeasure = handler(async (event, context) => {
 
   await dynamoDb.put(params);
 
-  return params;
+  return { status: StatusCodes.SUCCESS, body: params };
 });

--- a/services/app-api/handlers/measures/create.ts
+++ b/services/app-api/handlers/measures/create.ts
@@ -1,9 +1,24 @@
 import handler from "../../libs/handler-lib";
 import dynamoDb from "../../libs/dynamodb-lib";
 import { createCompoundKey } from "../dynamoUtils/createCompoundKey";
-import { MeasureStatus, CoreSetAbbr } from "../../types";
+import {
+  hasRolePermissions,
+  hasStatePermissions,
+} from "../../libs/authorization";
+import { MeasureStatus, CoreSetAbbr, UserRoles } from "../../types";
+import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const createMeasure = handler(async (event, context) => {
+  // action limited to state users from corresponding state
+  const isStateUser = hasRolePermissions(event, [UserRoles.STATE_USER]);
+  const isFromCorrespondingState = hasStatePermissions(event);
+  if (!isStateUser || !isFromCorrespondingState) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: Errors.UNAUTHORIZED,
+    };
+  }
+
   const body = JSON.parse(event!.body!);
   const dynamoKey = createCompoundKey(event);
   const params = {

--- a/services/app-api/handlers/measures/delete.ts
+++ b/services/app-api/handlers/measures/delete.ts
@@ -1,18 +1,12 @@
 import handler from "../../libs/handler-lib";
 import dynamoDb from "../../libs/dynamodb-lib";
 import { createCompoundKey } from "../dynamoUtils/createCompoundKey";
-import {
-  hasRolePermissions,
-  hasStatePermissions,
-} from "../../libs/authorization";
-import { UserRoles } from "../../types";
+import { hasStatePermissions } from "../../libs/authorization";
 import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const deleteMeasure = handler(async (event, context) => {
   // action limited to state users from corresponding state
-  const isStateUser = hasRolePermissions(event, [UserRoles.STATE_USER]);
-  const isFromCorrespondingState = hasStatePermissions(event);
-  if (!isStateUser || !isFromCorrespondingState) {
+  if (!hasStatePermissions(event)) {
     return {
       status: StatusCodes.UNAUTHORIZED,
       body: Errors.UNAUTHORIZED,

--- a/services/app-api/handlers/measures/delete.ts
+++ b/services/app-api/handlers/measures/delete.ts
@@ -1,8 +1,24 @@
 import handler from "../../libs/handler-lib";
 import dynamoDb from "../../libs/dynamodb-lib";
 import { createCompoundKey } from "../dynamoUtils/createCompoundKey";
+import {
+  hasRolePermissions,
+  hasStatePermissions,
+} from "../../libs/authorization";
+import { UserRoles } from "../../types";
+import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const deleteMeasure = handler(async (event, context) => {
+  // action limited to state users from corresponding state
+  const isStateUser = hasRolePermissions(event, [UserRoles.STATE_USER]);
+  const isFromCorrespondingState = hasStatePermissions(event);
+  if (!isStateUser || !isFromCorrespondingState) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: Errors.UNAUTHORIZED,
+    };
+  }
+
   const dynamoKey = createCompoundKey(event);
   const params = {
     TableName: process.env.measureTableName!,

--- a/services/app-api/handlers/measures/delete.ts
+++ b/services/app-api/handlers/measures/delete.ts
@@ -30,5 +30,5 @@ export const deleteMeasure = handler(async (event, context) => {
 
   await dynamoDb.delete(params);
 
-  return params;
+  return { status: StatusCodes.SUCCESS, body: params };
 });

--- a/services/app-api/handlers/measures/get.ts
+++ b/services/app-api/handlers/measures/get.ts
@@ -86,9 +86,15 @@ export const getMeasure = handler(async (event, context) => {
 
 export const getReportingYears = handler(async () => {
   const reportingYears = Object.keys(measures);
-  return reportingYears;
+  return {
+    status: StatusCodes.SUCCESS,
+    body: reportingYears,
+  };
 });
 
 export const getMeasureListInfo = handler(async () => {
-  return measures;
+  return {
+    status: StatusCodes.SUCCESS,
+    body: measures,
+  };
 });

--- a/services/app-api/handlers/measures/get.ts
+++ b/services/app-api/handlers/measures/get.ts
@@ -83,3 +83,12 @@ export const getMeasure = handler(async (event, context) => {
     body: queryValue,
   };
 });
+
+export const getReportingYears = handler(async () => {
+  const reportingYears = Object.keys(measures);
+  return reportingYears;
+});
+
+export const getMeasureListInfo = handler(async () => {
+  return measures;
+});

--- a/services/app-api/handlers/measures/get.ts
+++ b/services/app-api/handlers/measures/get.ts
@@ -50,7 +50,10 @@ export const listMeasures = handler(async (event, context) => {
     });
   });
   queryValue.Items = scannedResults;
-  return queryValue;
+  return {
+    status: StatusCodes.SUCCESS,
+    body: queryValue,
+  };
 });
 
 export const getMeasure = handler(async (event, context) => {
@@ -75,5 +78,8 @@ export const getMeasure = handler(async (event, context) => {
     },
   };
   const queryValue = await dynamoDb.get(params);
-  return queryValue;
+  return {
+    status: StatusCodes.SUCCESS,
+    body: queryValue,
+  };
 });

--- a/services/app-api/handlers/measures/tests/create.test.ts
+++ b/services/app-api/handlers/measures/tests/create.test.ts
@@ -53,7 +53,7 @@ describe("Test Create Measure Handler", () => {
   test("Test Successful Run of Measure Creation with description", async () => {
     const event: APIGatewayProxyEvent = {
       ...testEvent,
-      body: `{"data": {}, "description": "sample desc"}`,
+      body: `{"data": {}, "description": "sample desc", "detailedDescription": "sample detailed desc"}`,
       headers: { "cognito-identity-id": "test" },
     };
 
@@ -61,6 +61,7 @@ describe("Test Create Measure Handler", () => {
 
     expect(res.statusCode).toBe(StatusCodes.SUCCESS);
     expect(res.body).toContain("sample desc");
+    expect(res.body).toContain("sample detailed desc");
     expect(res.body).toContain("FL2020ACSFUA-AD");
   });
 

--- a/services/app-api/handlers/measures/tests/create.test.ts
+++ b/services/app-api/handlers/measures/tests/create.test.ts
@@ -33,24 +33,11 @@ jest.mock("../../dynamoUtils/createCompoundKey", () => ({
 
 describe("Test Create Measure Handler", () => {
   beforeEach(() => {
-    mockHasRolePermissions.mockImplementation(() => true);
-    mockHasStatePermissions.mockImplementation(() => true);
-  });
-
-  test("Test unauthorized user attempt (incorrect role)", async () => {
     mockHasRolePermissions.mockImplementation(() => false);
-    const event: APIGatewayProxyEvent = {
-      ...testEvent,
-      body: `{"data": {}, "description": "sample desc"}`,
-      headers: { "cognito-identity-id": "test" },
-    };
-    const res = await createMeasure(event, null);
-
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-    expect(res.body).toContain(Errors.UNAUTHORIZED);
   });
 
   test("Test unauthorized user attempt (incorrect state)", async () => {
+    mockHasRolePermissions.mockImplementation(() => true);
     mockHasStatePermissions.mockImplementation(() => false);
     const event: APIGatewayProxyEvent = {
       ...testEvent,

--- a/services/app-api/handlers/measures/tests/create.test.ts
+++ b/services/app-api/handlers/measures/tests/create.test.ts
@@ -15,7 +15,7 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
 const mockHasRolePermissions = jest.fn();
 const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasRolePermissions: () => mockHasRolePermissions(),
   hasStatePermissions: () => mockHasStatePermissions(),
 }));

--- a/services/app-api/handlers/measures/tests/create.test.ts
+++ b/services/app-api/handlers/measures/tests/create.test.ts
@@ -2,6 +2,7 @@ import { createMeasure } from "../create";
 
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { testEvent } from "../../../test-util/testEvents";
+import { StatusCodes, Errors } from "../../../utils/constants/constants";
 
 jest.mock("../../../libs/dynamodb-lib", () => ({
   __esModule: true,
@@ -11,9 +12,12 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
   },
 }));
 
+const mockHasRolePermissions = jest.fn();
+const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  __esModule: true,
   isAuthorized: jest.fn().mockReturnValue(true),
+  hasRolePermissions: () => mockHasRolePermissions(),
+  hasStatePermissions: () => mockHasStatePermissions(),
 }));
 
 jest.mock("../../../libs/debug-lib", () => ({
@@ -28,6 +32,37 @@ jest.mock("../../dynamoUtils/createCompoundKey", () => ({
 }));
 
 describe("Test Create Measure Handler", () => {
+  beforeEach(() => {
+    mockHasRolePermissions.mockImplementation(() => true);
+    mockHasStatePermissions.mockImplementation(() => true);
+  });
+
+  test("Test unauthorized user attempt (incorrect role)", async () => {
+    mockHasRolePermissions.mockImplementation(() => false);
+    const event: APIGatewayProxyEvent = {
+      ...testEvent,
+      body: `{"data": {}, "description": "sample desc"}`,
+      headers: { "cognito-identity-id": "test" },
+    };
+    const res = await createMeasure(event, null);
+
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
+  });
+
+  test("Test unauthorized user attempt (incorrect state)", async () => {
+    mockHasStatePermissions.mockImplementation(() => false);
+    const event: APIGatewayProxyEvent = {
+      ...testEvent,
+      body: `{"data": {}, "description": "sample desc"}`,
+      headers: { "cognito-identity-id": "test" },
+    };
+    const res = await createMeasure(event, null);
+
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
+  });
+
   test("Test Successful Run of Measure Creation with description", async () => {
     const event: APIGatewayProxyEvent = {
       ...testEvent,
@@ -37,7 +72,7 @@ describe("Test Create Measure Handler", () => {
 
     const res = await createMeasure(event, null);
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
     expect(res.body).toContain("sample desc");
     expect(res.body).toContain("FL2020ACSFUA-AD");
   });
@@ -51,7 +86,7 @@ describe("Test Create Measure Handler", () => {
 
     const res = await createMeasure(event, null);
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
     expect(res.body).toContain("test");
     expect(res.body).toContain("FL2020ACSFUA-AD");
   });

--- a/services/app-api/handlers/measures/tests/delete.test.ts
+++ b/services/app-api/handlers/measures/tests/delete.test.ts
@@ -13,11 +13,9 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
   },
 }));
 
-const mockHasRolePermissions = jest.fn();
 const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
-  hasRolePermissions: () => mockHasRolePermissions(),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasStatePermissions: () => mockHasStatePermissions(),
 }));
 
@@ -42,15 +40,7 @@ process.env.measureTableName = "SAMPLE TABLE";
 
 describe("Test Delete Measure Handler", () => {
   beforeEach(() => {
-    mockHasRolePermissions.mockImplementation(() => true);
     mockHasStatePermissions.mockImplementation(() => true);
-  });
-
-  test("Test unauthorized user attempt (incorrect role)", async () => {
-    mockHasRolePermissions.mockImplementation(() => false);
-    const res = await deleteMeasure(event, null);
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-    expect(res.body).toContain(Errors.UNAUTHORIZED);
   });
 
   test("Test unauthorized user attempt (incorrect state)", async () => {

--- a/services/app-api/handlers/measures/tests/get.test.ts
+++ b/services/app-api/handlers/measures/tests/get.test.ts
@@ -18,7 +18,7 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
 const mockHasRolePermissions = jest.fn();
 const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasRolePermissions: () => mockHasRolePermissions(),
   hasStatePermissions: () => mockHasStatePermissions(),
 }));

--- a/services/app-api/handlers/measures/tests/get.test.ts
+++ b/services/app-api/handlers/measures/tests/get.test.ts
@@ -5,6 +5,7 @@ import dbLib from "../../../libs/dynamodb-lib";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { testEvent } from "../../../test-util/testEvents";
 import { convertToDynamoExpression } from "../../dynamoUtils/convertToDynamoExpressionVars";
+import { Errors, StatusCodes } from "../../../utils/constants/constants";
 
 jest.mock("../../../libs/dynamodb-lib", () => ({
   __esModule: true,
@@ -14,9 +15,12 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
   },
 }));
 
+const mockHasRolePermissions = jest.fn();
+const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  __esModule: true,
   isAuthorized: jest.fn().mockReturnValue(true),
+  hasRolePermissions: () => mockHasRolePermissions(),
+  hasStatePermissions: () => mockHasStatePermissions(),
 }));
 
 jest.mock("../../../libs/debug-lib", () => ({
@@ -36,6 +40,26 @@ jest.mock("../../dynamoUtils/convertToDynamoExpressionVars", () => ({
 }));
 
 describe("Test Get Measure Handlers", () => {
+  beforeEach(() => {
+    mockHasRolePermissions.mockImplementation(() => false);
+  });
+
+  test("Test getMeasure unauthorized user attempt (incorrect state)", async () => {
+    mockHasRolePermissions.mockImplementation(() => true);
+    mockHasStatePermissions.mockImplementation(() => false);
+    const event: APIGatewayProxyEvent = {
+      ...testEvent,
+      body: `{"data": {}, "description": "sample desc"}`,
+      headers: { "cognito-identity-id": "test" },
+      pathParameters: { coreSet: "ACS" },
+    };
+    process.env.measureTableName = "SAMPLE TABLE";
+
+    const res = await getMeasure(event, null);
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
+  });
+
   test("Test Fetching a Measure", async () => {
     const event: APIGatewayProxyEvent = {
       ...testEvent,
@@ -58,6 +82,22 @@ describe("Test Get Measure Handlers", () => {
     });
   });
 
+  test("Test listMeasures unauthorized user attempt (incorrect state)", async () => {
+    mockHasRolePermissions.mockImplementation(() => true);
+    mockHasStatePermissions.mockImplementation(() => false);
+    const event: APIGatewayProxyEvent = {
+      ...testEvent,
+      body: `{"data": {}, "description": "sample desc"}`,
+      headers: { "cognito-identity-id": "test" },
+      pathParameters: { coreSet: "ACS" },
+    };
+    process.env.measureTableName = "SAMPLE TABLE";
+
+    const res = await listMeasures(event, null);
+    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.body).toContain(Errors.UNAUTHORIZED);
+  });
+
   test("Test Successfully Fetching a List of Measures", async () => {
     const event: APIGatewayProxyEvent = {
       ...testEvent,
@@ -69,7 +109,7 @@ describe("Test Get Measure Handlers", () => {
 
     const res = await listMeasures(event, null);
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
     expect(res.body).toContain("array");
     expect(res.body).toContain("of");
     expect(res.body).toContain("measures");
@@ -90,7 +130,7 @@ describe("Test Get Measure Handlers", () => {
 
     const res = await listMeasures(event, null);
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
     expect(convertToDynamoExpression).toHaveBeenCalledWith(
       { state: undefined, year: NaN, coreSet: undefined },
       "list"

--- a/services/app-api/handlers/measures/tests/get.test.ts
+++ b/services/app-api/handlers/measures/tests/get.test.ts
@@ -1,4 +1,9 @@
-import { getMeasure, listMeasures } from "../get";
+import {
+  getMeasure,
+  listMeasures,
+  getMeasureListInfo,
+  getReportingYears,
+} from "../get";
 
 import dbLib from "../../../libs/dynamodb-lib";
 
@@ -135,5 +140,26 @@ describe("Test Get Measure Handlers", () => {
       { state: undefined, year: NaN, coreSet: undefined },
       "list"
     );
+  });
+
+  test("Test getReportingYears", async () => {
+    const event: APIGatewayProxyEvent = {
+      ...testEvent,
+      body: `{ "year1": true, "year2": true, "year3": true }`,
+      headers: { "cognito-identity-id": "test" },
+    };
+    const res = await getReportingYears(event, null);
+    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.body).toBe('["2021","2022","2023"]');
+  });
+
+  test("Test getMeasureListInfo works when called with an empty object", async () => {
+    const event: APIGatewayProxyEvent = {
+      ...testEvent,
+      body: `{{}}`,
+      headers: { "cognito-identity-id": "test" },
+    };
+    const res = await getMeasureListInfo(event, null);
+    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
   });
 });

--- a/services/app-api/handlers/measures/tests/update.test.ts
+++ b/services/app-api/handlers/measures/tests/update.test.ts
@@ -39,7 +39,6 @@ jest.mock("../../dynamoUtils/convertToDynamoExpressionVars", () => ({
 
 const event: APIGatewayProxyEvent = {
   ...testEvent,
-  body: `{"data": {}, "status": "status"}`,
   pathParameters: { coreSet: "ACS" },
 };
 process.env.measureTableName = "SAMPLE TABLE";
@@ -48,6 +47,7 @@ describe("Test Update Measure Handler", () => {
   beforeEach(() => {
     mockHasStatePermissions.mockImplementation(() => true);
     event.headers = { "cognito-identity-id": "test" };
+    event.body = `{"data": {}, "status": "status"}`;
   });
 
   test("Test unauthorized user attempt (incorrect state)", async () => {
@@ -112,5 +112,26 @@ describe("Test Update Measure Handler", () => {
       },
       testValue: "test",
     });
+  });
+
+  test("Test param creation for convertToDynamoExpression", async () => {
+    event.headers = {};
+    event.body = `{"data": {}, "status": "status", "reporting": "yes", "description": "sample desc", "detailedDescription": "sample detailed desc"}`;
+    Date.now = jest.fn(() => 20);
+
+    const res = await editMeasure(event, null);
+
+    expect(convertToDynamoExpression).toHaveBeenCalledWith(
+      {
+        status: "status",
+        lastAltered: 20,
+        lastAlteredBy: "branchUser",
+        reporting: "yes",
+        description: "sample desc",
+        detailedDescription: "sample detailed desc",
+        data: {},
+      },
+      "post"
+    );
   });
 });

--- a/services/app-api/handlers/measures/tests/update.test.ts
+++ b/services/app-api/handlers/measures/tests/update.test.ts
@@ -14,12 +14,10 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
   },
 }));
 
-const mockHasRolePermissions = jest.fn();
 const mockHasStatePermissions = jest.fn();
 jest.mock("../../../libs/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   getUserNameFromJwt: jest.fn().mockReturnValue("branchUser"),
-  hasRolePermissions: () => mockHasRolePermissions(),
   hasStatePermissions: () => mockHasStatePermissions(),
 }));
 
@@ -42,22 +40,14 @@ jest.mock("../../dynamoUtils/convertToDynamoExpressionVars", () => ({
 const event: APIGatewayProxyEvent = {
   ...testEvent,
   body: `{"data": {}, "status": "status"}`,
-  headers: { "cognito-identity-id": "test" },
   pathParameters: { coreSet: "ACS" },
 };
 process.env.measureTableName = "SAMPLE TABLE";
 
 describe("Test Update Measure Handler", () => {
   beforeEach(() => {
-    mockHasRolePermissions.mockImplementation(() => true);
     mockHasStatePermissions.mockImplementation(() => true);
-  });
-
-  test("Test unauthorized user attempt (incorrect role)", async () => {
-    mockHasRolePermissions.mockImplementation(() => false);
-    const res = await editMeasure(event, null);
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-    expect(res.body).toContain(Errors.UNAUTHORIZED);
+    event.headers = { "cognito-identity-id": "test" };
   });
 
   test("Test unauthorized user attempt (incorrect state)", async () => {

--- a/services/app-api/handlers/measures/update.ts
+++ b/services/app-api/handlers/measures/update.ts
@@ -4,17 +4,13 @@ import { convertToDynamoExpression } from "../dynamoUtils/convertToDynamoExpress
 import { createCompoundKey } from "../dynamoUtils/createCompoundKey";
 import {
   getUserNameFromJwt,
-  hasRolePermissions,
   hasStatePermissions,
 } from "../../libs/authorization";
-import { UserRoles } from "../../types";
 import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const editMeasure = handler(async (event, context) => {
   // action limited to state users from corresponding state
-  const isStateUser = hasRolePermissions(event, [UserRoles.STATE_USER]);
-  const isFromCorrespondingState = hasStatePermissions(event);
-  if (!isStateUser || !isFromCorrespondingState) {
+  if (!hasStatePermissions(event)) {
     return {
       status: StatusCodes.UNAUTHORIZED,
       body: Errors.UNAUTHORIZED,

--- a/services/app-api/handlers/measures/update.ts
+++ b/services/app-api/handlers/measures/update.ts
@@ -59,5 +59,5 @@ export const editMeasure = handler(async (event, context) => {
   };
   await dynamoDb.update(params);
 
-  return params;
+  return { status: StatusCodes.SUCCESS, body: params };
 });

--- a/services/app-api/handlers/measures/update.ts
+++ b/services/app-api/handlers/measures/update.ts
@@ -2,9 +2,25 @@ import handler from "../../libs/handler-lib";
 import dynamoDb from "../../libs/dynamodb-lib";
 import { convertToDynamoExpression } from "../dynamoUtils/convertToDynamoExpressionVars";
 import { createCompoundKey } from "../dynamoUtils/createCompoundKey";
-import { getUserNameFromJwt } from "../../libs/authorization";
+import {
+  getUserNameFromJwt,
+  hasRolePermissions,
+  hasStatePermissions,
+} from "../../libs/authorization";
+import { UserRoles } from "../../types";
+import { Errors, StatusCodes } from "../../utils/constants/constants";
 
 export const editMeasure = handler(async (event, context) => {
+  // action limited to state users from corresponding state
+  const isStateUser = hasRolePermissions(event, [UserRoles.STATE_USER]);
+  const isFromCorrespondingState = hasStatePermissions(event);
+  if (!isStateUser || !isFromCorrespondingState) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: Errors.UNAUTHORIZED,
+    };
+  }
+
   const {
     data,
     status,

--- a/services/app-api/handlers/prince/pdf.ts
+++ b/services/app-api/handlers/prince/pdf.ts
@@ -16,4 +16,4 @@ export const getPDF = handler(async (event, _context) => {
   } catch (err) {
     console.log(err);
   }
-}, true);
+});

--- a/services/app-api/handlers/prince/pdf.ts
+++ b/services/app-api/handlers/prince/pdf.ts
@@ -1,6 +1,7 @@
 import handler from "../../libs/handler-lib";
 import { aws4Interceptor } from "aws4-axios";
 import axios from "axios";
+import { StatusCodes } from "../../utils/constants/constants";
 
 export const getPDF = handler(async (event, _context) => {
   const interceptor = aws4Interceptor({
@@ -12,7 +13,10 @@ export const getPDF = handler(async (event, _context) => {
 
   try {
     const pdf = await axios.post(process.env.princeUrl!, event.body!);
-    return pdf.data;
+    return {
+      status: StatusCodes.SUCCESS,
+      body: pdf.data,
+    };
   } catch (err) {
     console.log(err);
   }

--- a/services/app-api/libs/authorization.ts
+++ b/services/app-api/libs/authorization.ts
@@ -28,7 +28,7 @@ export const isAuthorized = (
   const userState = decoded["custom:cms_state"];
 
   // if user is a state user - check they are requesting a resource from their state
-  if (userState && requestState && userRoles.includes(UserRoles.STATE)) {
+  if (userState && requestState && userRoles.includes(UserRoles.STATE_USER)) {
     return userState.toLowerCase() === requestState.toLowerCase();
   }
 

--- a/services/app-api/libs/authorization.ts
+++ b/services/app-api/libs/authorization.ts
@@ -11,12 +11,12 @@ interface DecodedToken {
   identities?: [{ userId?: string }];
 }
 
-export const isAuthorized = (event: APIGatewayProxyEvent) => {
-  let isAuthorized;
+export const isAuthenticated = (event: APIGatewayProxyEvent) => {
+  let authed;
   if (event?.headers?.["x-api-key"]) {
-    isAuthorized = jwt_decode(event.headers["x-api-key"]) as DecodedToken;
+    authed = jwt_decode(event.headers["x-api-key"]) as DecodedToken;
   }
-  return !!isAuthorized;
+  return !!authed;
 };
 
 export const hasRolePermissions = (

--- a/services/app-api/libs/authorization.ts
+++ b/services/app-api/libs/authorization.ts
@@ -24,6 +24,26 @@ export const isAuthorized = (event: APIGatewayProxyEvent) => {
   return !!isAuthorized;
 };
 
+export const hasPermissions = (
+  event: APIGatewayProxyEvent,
+  allowedRoles: UserRoles[]
+) => {
+  let isAllowed = false;
+  // decode the idToken
+  if (event?.headers["x-api-key"]) {
+    const decoded = jwt_decode(event.headers["x-api-key"]) as DecodedToken;
+    const idmUserRoles = decoded["custom:cms_roles"];
+    const qmrUserRole = idmUserRoles
+      ?.split(",")
+      .find((role) => role.includes("mdctqmr")) as UserRoles;
+    // determine if role has permissions
+    if (allowedRoles.includes(qmrUserRole)) {
+      isAllowed = true;
+    }
+  }
+  return isAllowed;
+};
+
 export const getUserNameFromJwt = (event: APIGatewayProxyEvent) => {
   let userName = "branchUser";
   if (!event?.headers || !event.headers?.["x-api-key"]) return userName;

--- a/services/app-api/libs/authorization.ts
+++ b/services/app-api/libs/authorization.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
 import jwt_decode from "jwt-decode";
 import { UserRoles, RequestMethods } from "../types";
+import { clearLogs } from "./debug-lib";
 
 interface DecodedToken {
   "custom:cms_roles": string;
@@ -13,13 +14,7 @@ interface DecodedToken {
 export const isAuthorized = (event: APIGatewayProxyEvent) => {
   let isAuthorized;
   if (event?.headers?.["x-api-key"]) {
-    try {
-      // decode the idToken
-      isAuthorized = jwt_decode(event.headers["x-api-key"]) as DecodedToken;
-    } catch {
-      // verification failed - unauthorized
-      isAuthorized = false;
-    }
+    isAuthorized = jwt_decode(event.headers["x-api-key"]) as DecodedToken;
   }
   return !!isAuthorized;
 };

--- a/services/app-api/libs/handler-lib.ts
+++ b/services/app-api/libs/handler-lib.ts
@@ -1,7 +1,8 @@
 import * as debug from "./debug-lib";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { isAuthorized } from "./authorization";
-import { failure, success, buildResponse } from "./response-lib";
+import { failure, buildResponse } from "./response-lib";
+import { Errors, StatusCodes } from "../utils/constants/constants";
 
 type LambdaFunction = (
   event: APIGatewayProxyEvent,
@@ -16,8 +17,8 @@ export default function handler(lambda: LambdaFunction) {
     if (isAuthorized(event)) {
       try {
         // Run the Lambda
-        const body = await lambda(event, context);
-        return success(body);
+        const { status, body } = await lambda(event, context);
+        return buildResponse(status, body);
       } catch (e: any) {
         // Print debug messages
         debug.flush(e);
@@ -26,8 +27,8 @@ export default function handler(lambda: LambdaFunction) {
         return failure(body);
       }
     } else {
-      const body = { error: "User is not authorized to access this resource." };
-      return buildResponse(403, body);
+      const body = { error: Errors.UNAUTHORIZED };
+      return buildResponse(StatusCodes.UNAUTHORIZED, body);
     }
   };
 }

--- a/services/app-api/libs/handler-lib.ts
+++ b/services/app-api/libs/handler-lib.ts
@@ -8,12 +8,12 @@ type LambdaFunction = (
   context: any
 ) => Promise<any>;
 
-export default function handler(lambda: LambdaFunction, postOverride = false) {
+export default function handler(lambda: LambdaFunction) {
   return async function (event: APIGatewayProxyEvent, context: any) {
     // Start debugger
     debug.init(event, context);
 
-    if (isAuthorized(event, postOverride)) {
+    if (isAuthorized(event)) {
       try {
         // Run the Lambda
         const body = await lambda(event, context);

--- a/services/app-api/libs/handler-lib.ts
+++ b/services/app-api/libs/handler-lib.ts
@@ -1,6 +1,6 @@
 import * as debug from "./debug-lib";
 import { APIGatewayProxyEvent } from "aws-lambda";
-import { isAuthorized } from "./authorization";
+import { isAuthenticated } from "./authorization";
 import { failure, buildResponse } from "./response-lib";
 import { Errors, StatusCodes } from "../utils/constants/constants";
 
@@ -14,7 +14,7 @@ export default function handler(lambda: LambdaFunction) {
     // Start debugger
     debug.init(event, context);
 
-    if (isAuthorized(event)) {
+    if (isAuthenticated(event)) {
       try {
         // Run the Lambda
         const { status, body } = await lambda(event, context);

--- a/services/app-api/libs/response-lib.ts
+++ b/services/app-api/libs/response-lib.ts
@@ -1,7 +1,3 @@
-export function success(body: any) {
-  return buildResponse(200, body);
-}
-
 export function failure(body: any) {
   return buildResponse(500, body);
 }

--- a/services/app-api/libs/tests/authorization.test.ts
+++ b/services/app-api/libs/tests/authorization.test.ts
@@ -1,6 +1,6 @@
 import { testEvent } from "../../test-util/testEvents";
 import {
-  isAuthorized,
+  isAuthenticated,
   hasStatePermissions,
   hasRolePermissions,
 } from "../authorization";
@@ -15,10 +15,7 @@ jest.mock("jwt-decode", () => ({
   },
 }));
 
-describe("isAuthorized checks if user is authenticated", () => {
-  const event = { ...testEvent };
-  event.headers = { "x-api-key": "test" };
-
+describe("isAuthenticated checks if user is authenticated", () => {
   beforeEach(() => {
     mockedDecode.mockReturnValue({
       "custom:cms_roles": UserRoles.ADMIN,
@@ -26,12 +23,15 @@ describe("isAuthorized checks if user is authenticated", () => {
   });
 
   test("returns true with correctly formatted jwt key", () => {
-    expect(isAuthorized(event)).toEqual(true);
+    const event = { ...testEvent };
+    event.headers = { "x-api-key": "test" };
+    expect(isAuthenticated(event)).toEqual(true);
   });
 
   test("returns false if missing jwt key", () => {
+    const event = { ...testEvent };
     event.headers = {};
-    expect(isAuthorized(event)).toEqual(false);
+    expect(isAuthenticated(event)).toEqual(false);
   });
 });
 

--- a/services/app-api/libs/tests/authorization.test.ts
+++ b/services/app-api/libs/tests/authorization.test.ts
@@ -20,7 +20,7 @@ describe("Authorization Lib Function", () => {
       event.headers = { "x-api-key": "test" };
       event.pathParameters = { state: "AL" };
       mockedDecode.mockReturnValue({
-        "custom:cms_roles": UserRoles.STATE,
+        "custom:cms_roles": UserRoles.STATE_USER,
         "custom:cms_state": "AL",
       });
     });
@@ -59,7 +59,7 @@ describe("Authorization Lib Function", () => {
       event.headers = { "x-api-key": "test" };
       event.pathParameters = { state: "AL" };
       mockedDecode.mockReturnValue({
-        "custom:cms_roles": UserRoles.ADMIN,
+        "custom:cms_roles": UserRoles.APPROVER,
         "custom:cms_state": "AL",
       });
     });

--- a/services/app-api/libs/tests/authorization.test.ts
+++ b/services/app-api/libs/tests/authorization.test.ts
@@ -1,5 +1,9 @@
 import { testEvent } from "../../test-util/testEvents";
-import { isAuthorized } from "../authorization";
+import {
+  isAuthorized,
+  hasStatePermissions,
+  hasRolePermissions,
+} from "../authorization";
 import { UserRoles } from "../../types";
 
 const mockedDecode = jest.fn();
@@ -11,81 +15,96 @@ jest.mock("jwt-decode", () => ({
   },
 }));
 
-describe("Authorization Lib Function", () => {
-  describe("State User Tests", () => {
-    const event = { ...testEvent };
+describe("isAuthorized checks if user is authenticated", () => {
+  const event = { ...testEvent };
+  event.headers = { "x-api-key": "test" };
 
-    beforeEach(() => {
-      event.httpMethod = "GET";
-      event.headers = { "x-api-key": "test" };
-      event.pathParameters = { state: "AL" };
-      mockedDecode.mockReturnValue({
-        "custom:cms_roles": UserRoles.STATE_USER,
-        "custom:cms_state": "AL",
-      });
-    });
-
-    test("authorizaiton should fail from missing jwt key", () => {
-      event.headers = {};
-      expect(isAuthorized(event)).toBeFalsy();
-    });
-
-    test("authorization should pass", () => {
-      expect(isAuthorized(event)).toBeTruthy();
-    });
-
-    test("authorization should fail from mismatched states", () => {
-      event.pathParameters = { state: "FL" };
-      expect(isAuthorized(event)).toBeFalsy();
-    });
-
-    test("authorization should pass for GET, but skip if check from missing requestState", () => {
-      event.pathParameters = null;
-      expect(isAuthorized(event)).toBeTruthy();
-    });
-
-    test("authorization should fail from missing requestState and non-GET call", () => {
-      event.pathParameters = null;
-      event.httpMethod = "POST";
-      expect(isAuthorized(event)).toBeFalsy();
+  beforeEach(() => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.ADMIN,
     });
   });
 
-  describe("Non-State User Tests", () => {
-    const event = { ...testEvent };
+  test("returns true with correctly formatted jwt key", () => {
+    expect(isAuthorized(event)).toEqual(true);
+  });
 
-    beforeEach(() => {
-      event.httpMethod = "GET";
-      event.headers = { "x-api-key": "test" };
-      event.pathParameters = { state: "AL" };
-      mockedDecode.mockReturnValue({
-        "custom:cms_roles": UserRoles.APPROVER,
-        "custom:cms_state": "AL",
-      });
+  test("returns false if missing jwt key", () => {
+    event.headers = {};
+    expect(isAuthorized(event)).toEqual(false);
+  });
+});
+
+describe("hasRolePermissions checks if the user has one of a given set of roles", () => {
+  const event = { ...testEvent };
+  event.headers = { "x-api-key": "test" };
+
+  beforeEach(() => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.ADMIN,
     });
+  });
 
-    test("authorization should pass", () => {
-      expect(isAuthorized(event)).toBeTruthy();
+  test("returns true when user role matches single given role", () => {
+    expect(hasRolePermissions(event, [UserRoles.ADMIN])).toEqual(true);
+  });
+
+  test("returns true when user role is one of a set of given roles", () => {
+    expect(
+      hasRolePermissions(event, [UserRoles.ADMIN, UserRoles.STATE_USER])
+    ).toEqual(true);
+  });
+
+  test("returns false when the asked for role is the given role", () => {
+    expect(hasRolePermissions(event, [UserRoles.STATE_USER])).toEqual(false);
+  });
+});
+
+describe("hasStatePermissions checks if the user's state matches event's state", () => {
+  const event = { ...testEvent };
+  event.headers = { "x-api-key": "test" };
+
+  beforeEach(() => {
+    event.pathParameters = { ...event.pathParameters, state: "MN" };
+  });
+
+  test("returns true when user's state matches event's state", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+      "custom:cms_state": "MN",
     });
+    expect(hasStatePermissions(event)).toEqual(true);
+  });
 
-    test("authorization should fail from unauthorized http method", () => {
-      event.httpMethod = "POST";
-      expect(isAuthorized(event)).toBeFalsy();
+  test("returns false if no state parameter is passed", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+      "custom:cms_state": "MN",
     });
+    delete event.pathParameters!.state;
+    expect(hasStatePermissions(event)).toEqual(false);
+  });
 
-    // test("authorization should pass with POST override", () => {
-    //   event.httpMethod = "POST";
-    //   expect(isAuthorized(event)).toBeTruthy();
-    // });
-
-    test("authorization should fail from unauthorized http method", () => {
-      event.httpMethod = "DELETE";
-      expect(isAuthorized(event)).toBeFalsy();
+  test("returns false if user role is not state user", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.INTERNAL,
+      "custom:cms_state": "MN",
     });
+    expect(hasStatePermissions(event)).toEqual(false);
+  });
 
-    // test("authorization should pass with DELETE override", () => {
-    //   event.httpMethod = "DELETE";
-    //   expect(isAuthorized(event)).toBeTruthy();
-    // });
+  test("returns false if user doesn't have a state", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+    });
+    expect(hasStatePermissions(event)).toEqual(false);
+  });
+
+  test("returns false if user's state doesn't match event's state", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+      "custom:cms_state": "PA",
+    });
+    expect(hasStatePermissions(event)).toEqual(false);
   });
 });

--- a/services/app-api/libs/tests/authorization.test.ts
+++ b/services/app-api/libs/tests/authorization.test.ts
@@ -27,27 +27,27 @@ describe("Authorization Lib Function", () => {
 
     test("authorizaiton should fail from missing jwt key", () => {
       event.headers = {};
-      expect(isAuthorized(event, false)).toBeFalsy();
+      expect(isAuthorized(event)).toBeFalsy();
     });
 
     test("authorization should pass", () => {
-      expect(isAuthorized(event, false)).toBeTruthy();
+      expect(isAuthorized(event)).toBeTruthy();
     });
 
     test("authorization should fail from mismatched states", () => {
       event.pathParameters = { state: "FL" };
-      expect(isAuthorized(event, false)).toBeFalsy();
+      expect(isAuthorized(event)).toBeFalsy();
     });
 
     test("authorization should pass for GET, but skip if check from missing requestState", () => {
       event.pathParameters = null;
-      expect(isAuthorized(event, false)).toBeTruthy();
+      expect(isAuthorized(event)).toBeTruthy();
     });
 
     test("authorization should fail from missing requestState and non-GET call", () => {
       event.pathParameters = null;
       event.httpMethod = "POST";
-      expect(isAuthorized(event, false)).toBeFalsy();
+      expect(isAuthorized(event)).toBeFalsy();
     });
   });
 
@@ -65,27 +65,27 @@ describe("Authorization Lib Function", () => {
     });
 
     test("authorization should pass", () => {
-      expect(isAuthorized(event, false)).toBeTruthy();
+      expect(isAuthorized(event)).toBeTruthy();
     });
 
     test("authorization should fail from unauthorized http method", () => {
       event.httpMethod = "POST";
-      expect(isAuthorized(event, false)).toBeFalsy();
+      expect(isAuthorized(event)).toBeFalsy();
     });
 
-    test("authorization should pass with POST override", () => {
-      event.httpMethod = "POST";
-      expect(isAuthorized(event, true)).toBeTruthy();
-    });
+    // test("authorization should pass with POST override", () => {
+    //   event.httpMethod = "POST";
+    //   expect(isAuthorized(event)).toBeTruthy();
+    // });
 
     test("authorization should fail from unauthorized http method", () => {
       event.httpMethod = "DELETE";
-      expect(isAuthorized(event, false)).toBeFalsy();
+      expect(isAuthorized(event)).toBeFalsy();
     });
 
-    test("authorization should pass with DELETE override", () => {
-      event.httpMethod = "DELETE";
-      expect(isAuthorized(event, true)).toBeTruthy();
-    });
+    // test("authorization should pass with DELETE override", () => {
+    //   event.httpMethod = "DELETE";
+    //   expect(isAuthorized(event)).toBeTruthy();
+    // });
   });
 });

--- a/services/app-api/libs/tests/handler-lib.test.ts
+++ b/services/app-api/libs/tests/handler-lib.test.ts
@@ -1,6 +1,6 @@
 import handlerLib from "../handler-lib";
 import { testEvent } from "../../test-util/testEvents";
-import { isAuthorized } from "../authorization";
+import { isAuthenticated } from "../authorization";
 import { flush } from "../debug-lib";
 
 jest.mock("../debug-lib", () => ({
@@ -11,7 +11,7 @@ jest.mock("../debug-lib", () => ({
 
 jest.mock("../authorization", () => ({
   __esModule: true,
-  isAuthorized: jest.fn(),
+  isAuthenticated: jest.fn(),
 }));
 
 describe("Test Lambda Handler Lib", () => {
@@ -19,7 +19,7 @@ describe("Test Lambda Handler Lib", () => {
     const testFunc = jest.fn().mockReturnValue({ status: 200, body: "test" });
     const handler = handlerLib(testFunc);
 
-    (isAuthorized as jest.Mock).mockReturnValue(true);
+    (isAuthenticated as jest.Mock).mockReturnValue(true);
     const res = await handler(testEvent, null);
 
     expect(res.statusCode).toBe(200);
@@ -31,7 +31,7 @@ describe("Test Lambda Handler Lib", () => {
     const testFunc = jest.fn();
     const handler = handlerLib(testFunc);
 
-    (isAuthorized as jest.Mock).mockReturnValue(false);
+    (isAuthenticated as jest.Mock).mockReturnValue(false);
     const res = await handler(testEvent, null);
 
     expect(res.statusCode).toBe(403);
@@ -47,7 +47,7 @@ describe("Test Lambda Handler Lib", () => {
     });
     const handler = handlerLib(testFunc);
 
-    (isAuthorized as jest.Mock).mockReturnValue(true);
+    (isAuthenticated as jest.Mock).mockReturnValue(true);
     const res = await handler(testEvent, null);
 
     expect(flush).toHaveBeenCalledWith(err);

--- a/services/app-api/libs/tests/handler-lib.test.ts
+++ b/services/app-api/libs/tests/handler-lib.test.ts
@@ -16,7 +16,7 @@ jest.mock("../authorization", () => ({
 
 describe("Test Lambda Handler Lib", () => {
   test("Test successful authorized lambda workflow", async () => {
-    const testFunc = jest.fn().mockReturnValue({ test: "test" });
+    const testFunc = jest.fn().mockReturnValue({ status: 200, body: "test" });
     const handler = handlerLib(testFunc);
 
     (isAuthorized as jest.Mock).mockReturnValue(true);

--- a/services/app-api/libs/tests/response-lib.test.ts
+++ b/services/app-api/libs/tests/response-lib.test.ts
@@ -1,14 +1,6 @@
-import { success, failure, buildResponse } from "../response-lib";
+import { failure, buildResponse } from "../response-lib";
 
 describe("Test the response-lib", () => {
-  test("Success should give a 200 status", () => {
-    const res = success({});
-    expect(res.body).toBe("{}");
-    expect(res.statusCode).toBe(200);
-    expect(res.headers["Access-Control-Allow-Origin"]).toBe("*");
-    expect(res.headers["Access-Control-Allow-Credentials"]).toBe(true);
-  });
-
   test("Failure should give a 500 status", () => {
     const res = failure({});
     expect(res.body).toBe("{}");

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -97,12 +97,11 @@ export const enum MeasureStatus {
 }
 
 export const enum UserRoles {
-  ADMIN = "mdctqmr-approver",
-  STATE = "mdctqmr-state-user",
-  HELP = "mdctqmr-help-desk",
-  INTERNAL = "mdctqmr-internal-user",
-  BO = "mdctqmr-bo-user",
-  BOR = "mdctqmr-bor",
+  ADMIN = "mdctqmr-bor", // "MDCT QMR ADMIN"
+  APPROVER = "mdctqmr-approver", // "MDCT QMR APPROVER"
+  INTERNAL = "mdctqmr-internal-user", // "MDCT QMR INTERNAL USER"
+  HELP_DESK = "mdctqmr-help-desk", // "MDCT QMR HELP DESK USER"
+  STATE_USER = "mdctqmr-state-user", // "MDCT QMR STATE USER"
 }
 
 export const enum RequestMethods {

--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -8,6 +8,8 @@ export const enum Errors {
   // template errors
   NO_TEMPLATE_NAME = "Must request template for download",
   INVALID_TEMPLATE_NAME = "Requested template does not exist or does not match",
+  // coreset errors
+  CORESET_ALREADY_EXISTS = "Failure to create coreset. Coreset already exists.",
 }
 
 export const enum StatusCodes {

--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -1,18 +1,43 @@
 [
   {
-    "username": "paul@test.com",
+    "username": "adminuser@test.com",
     "attributes": [
       {
         "Name": "email",
-        "Value": "paul@test.com"
+        "Value": "adminuser@test.com"
       },
       {
         "Name": "given_name",
-        "Value": "Paul"
+        "Value": "Anna"
       },
       {
         "Name": "family_name",
-        "Value": "McCartney"
+        "Value": "Admin"
+      },
+      {
+        "Name": "email_verified",
+        "Value": "true"
+      },
+      {
+        "Name": "custom:cms_roles",
+        "Value": "mdctqmr-bor"
+      }
+    ]
+  },
+  {
+    "username": "approver@test.com",
+    "attributes": [
+      {
+        "Name": "email",
+        "Value": "approver@test.com"
+      },
+      {
+        "Name": "given_name",
+        "Value": "Adam"
+      },
+      {
+        "Name": "family_name",
+        "Value": "Approver"
       },
       {
         "Name": "email_verified",
@@ -25,48 +50,19 @@
     ]
   },
   {
-    "username": "john@test.com",
+    "username": "helpdesk@test.com",
     "attributes": [
       {
         "Name": "email",
-        "Value": "john@test.com"
+        "Value": "helpdesk@test.com"
       },
       {
         "Name": "given_name",
-        "Value": "John"
+        "Value": "Clippy"
       },
       {
         "Name": "family_name",
-        "Value": "Lennon"
-      },
-      {
-        "Name": "email_verified",
-        "Value": "true"
-      },
-      {
-        "Name": "custom:cms_roles",
-        "Value": "mdctqmr-state-user"
-      },
-      {
-        "Name": "custom:cms_state",
-        "Value": "OH"
-      }
-    ]
-  },
-  {
-    "username": "george@test.com",
-    "attributes": [
-      {
-        "Name": "email",
-        "Value": "george@test.com"
-      },
-      {
-        "Name": "given_name",
-        "Value": "George"
-      },
-      {
-        "Name": "family_name",
-        "Value": "Harrison"
+        "Value": "Helperson"
       },
       {
         "Name": "email_verified",
@@ -100,31 +96,6 @@
       {
         "Name": "custom:cms_roles",
         "Value": "mdctqmr-internal-user"
-      }
-    ]
-  },
-  {
-    "username": "adminuser@test.com",
-    "attributes": [
-      {
-        "Name": "email",
-        "Value": "adminuser@test.com"
-      },
-      {
-        "Name": "given_name",
-        "Value": "Anna"
-      },
-      {
-        "Name": "family_name",
-        "Value": "Admin"
-      },
-      {
-        "Name": "email_verified",
-        "Value": "true"
-      },
-      {
-        "Name": "custom:cms_roles",
-        "Value": "mdctqmr-bor"
       }
     ]
   },
@@ -473,31 +444,6 @@
       {
         "Name": "custom:cms_state",
         "Value": "VA"
-      }
-    ]
-  },
-  {
-    "username": "approver@test.com",
-    "attributes": [
-      {
-        "Name": "email",
-        "Value": "approver@test.com"
-      },
-      {
-        "Name": "given_name",
-        "Value": "Adam"
-      },
-      {
-        "Name": "family_name",
-        "Value": "Admins"
-      },
-      {
-        "Name": "email_verified",
-        "Value": "true"
-      },
-      {
-        "Name": "custom:cms_roles",
-        "Value": "mdctqmr-approver"
       }
     ]
   },

--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -104,19 +104,19 @@
     ]
   },
   {
-    "username": "bouser@test.com",
+    "username": "adminuser@test.com",
     "attributes": [
       {
         "Name": "email",
-        "Value": "bouser@test.com"
+        "Value": "adminuser@test.com"
       },
       {
         "Name": "given_name",
-        "Value": "Bobby"
+        "Value": "Anna"
       },
       {
         "Name": "family_name",
-        "Value": "Business"
+        "Value": "Admin"
       },
       {
         "Name": "email_verified",
@@ -124,7 +124,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-bo-user"
+        "Value": "mdctqmr-bor"
       }
     ]
   },
@@ -477,11 +477,11 @@
     ]
   },
   {
-    "username": "adminuser@test.com",
+    "username": "approver@test.com",
     "attributes": [
       {
         "Name": "email",
-        "Value": "adminuser@test.com"
+        "Value": "approver@test.com"
       },
       {
         "Name": "given_name",

--- a/services/ui-src/src/components/Banner/CreateBannerForm.tsx
+++ b/services/ui-src/src/components/Banner/CreateBannerForm.tsx
@@ -51,6 +51,7 @@ export const CreateBannerForm = ({ writeAdminBanner, ...props }: Props) => {
         writeAdminBanner({ ...formData, startDateInMS, endDateInMS });
       }
     }
+    window.scrollTo(0, 0);
     setSubmitting(false);
   };
   return (

--- a/services/ui-src/src/hooks/api/useBanner.tsx
+++ b/services/ui-src/src/hooks/api/useBanner.tsx
@@ -12,7 +12,7 @@ export const useWriteBanner = () => {
 
 const _getBanner = async (bannerKey: string) => {
   const banner = await getBanner(bannerKey);
-  return await banner?.body.Item;
+  return await banner?.Item;
 };
 
 export const useGetBanner = (bannerKey: string) => {

--- a/services/ui-src/src/hooks/authHooks/userProvider.tsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.tsx
@@ -69,7 +69,7 @@ export const UserProvider = ({ children }: Props) => {
     ?.split(",")
     .find((r) => r.includes("mdctqmr"));
 
-  const isStateUser = userRole === UserRoles.STATE;
+  const isStateUser = userRole === UserRoles.STATE_USER;
 
   const userState =
     user?.signInUserSession?.idToken?.payload?.["custom:cms_state"];

--- a/services/ui-src/src/hooks/authHooks/userProvider.tsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.tsx
@@ -69,7 +69,7 @@ export const UserProvider = ({ children }: Props) => {
     ?.split(",")
     .find((r) => r.includes("mdctqmr"));
 
-  const isStateUser = userRole === UserRoles.STATE_USER;
+  const isStateUser = userRole === UserRoles.STATE_USER; // excludes all admin-type users (admin, approver, help desk, internal)
 
   const userState =
     user?.signInUserSession?.idToken?.payload?.["custom:cms_state"];

--- a/services/ui-src/src/measures/2021/Qualifiers/deliverySystems.tsx
+++ b/services/ui-src/src/measures/2021/Qualifiers/deliverySystems.tsx
@@ -94,7 +94,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
               {data.fieldValues.map((fieldValue, idx, arr) => {
                 return (
                   <CUI.Td key={`dataField.${idx}`}>
-                    {userRole === UserRoles.STATE && (
+                    {userRole === UserRoles.STATE_USER && (
                       <QMR.DeleteWrapper
                         allowDeletion={index >= 4 && !!(idx === arr.length - 1)}
                         onDelete={() => remove(index)}
@@ -113,7 +113,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
                         />
                       </QMR.DeleteWrapper>
                     )}
-                    {userRole !== UserRoles.STATE && (
+                    {userRole !== UserRoles.STATE_USER && (
                       <QMR.NumberInput
                         displayPercent
                         name={`PercentageEnrolledInEachDeliverySystem.${index}.${fieldValue}`}

--- a/services/ui-src/src/measures/2021/Qualifiers/deliverySystems.tsx
+++ b/services/ui-src/src/measures/2021/Qualifiers/deliverySystems.tsx
@@ -113,6 +113,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
                         />
                       </QMR.DeleteWrapper>
                     )}
+                    {/* only display to admin-type users (admin, approver, help desk, internal) */}
                     {userRole !== UserRoles.STATE_USER && (
                       <QMR.NumberInput
                         displayPercent

--- a/services/ui-src/src/measures/2022/shared/Qualifiers/deliverySystems.tsx
+++ b/services/ui-src/src/measures/2022/shared/Qualifiers/deliverySystems.tsx
@@ -94,7 +94,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
               {data.fieldValues.map((fieldValue, idx, arr) => {
                 return (
                   <CUI.Td key={`dataField.${idx}`}>
-                    {userRole === UserRoles.STATE && (
+                    {userRole === UserRoles.STATE_USER && (
                       <QMR.DeleteWrapper
                         allowDeletion={index >= 4 && !!(idx === arr.length - 1)}
                         onDelete={() => remove(index)}
@@ -113,7 +113,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
                         />
                       </QMR.DeleteWrapper>
                     )}
-                    {userRole !== UserRoles.STATE && (
+                    {userRole !== UserRoles.STATE_USER && (
                       <QMR.NumberInput
                         displayPercent
                         name={`PercentageEnrolledInEachDeliverySystem.${index}.${fieldValue}`}

--- a/services/ui-src/src/measures/2022/shared/Qualifiers/deliverySystems.tsx
+++ b/services/ui-src/src/measures/2022/shared/Qualifiers/deliverySystems.tsx
@@ -113,6 +113,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
                         />
                       </QMR.DeleteWrapper>
                     )}
+                    {/* only display to admin-type users (admin, approver, help desk, internal) */}
                     {userRole !== UserRoles.STATE_USER && (
                       <QMR.NumberInput
                         displayPercent

--- a/services/ui-src/src/measures/2023/shared/Qualifiers/deliverySystems.tsx
+++ b/services/ui-src/src/measures/2023/shared/Qualifiers/deliverySystems.tsx
@@ -94,7 +94,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
               {data.fieldValues.map((fieldValue, idx, arr) => {
                 return (
                   <CUI.Td key={`dataField.${idx}`}>
-                    {userRole === UserRoles.STATE && (
+                    {userRole === UserRoles.STATE_USER && (
                       <QMR.DeleteWrapper
                         allowDeletion={index >= 4 && !!(idx === arr.length - 1)}
                         onDelete={() => remove(index)}
@@ -113,7 +113,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
                         />
                       </QMR.DeleteWrapper>
                     )}
-                    {userRole !== UserRoles.STATE && (
+                    {userRole !== UserRoles.STATE_USER && (
                       <QMR.NumberInput
                         displayPercent
                         name={`PercentageEnrolledInEachDeliverySystem.${index}.${fieldValue}`}

--- a/services/ui-src/src/measures/2023/shared/Qualifiers/deliverySystems.tsx
+++ b/services/ui-src/src/measures/2023/shared/Qualifiers/deliverySystems.tsx
@@ -113,6 +113,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
                         />
                       </QMR.DeleteWrapper>
                     )}
+                    {/* only display to admin-type users (admin, approver, help desk, internal) */}
                     {userRole !== UserRoles.STATE_USER && (
                       <QMR.NumberInput
                         displayPercent

--- a/services/ui-src/src/types.ts
+++ b/services/ui-src/src/types.ts
@@ -7,12 +7,11 @@ export enum CoreSetAbbr {
 }
 
 export enum UserRoles {
-  ADMIN = "mdctqmr-approver",
-  STATE = "mdctqmr-state-user",
-  HELP = "mdctqmr-help-desk",
-  INTERNAL = "mdctqmr-internal-user",
-  BO = "mdctqmr-bo-user",
-  BOR = "mdctqmr-bor",
+  ADMIN = "mdctqmr-bor", // "MDCT QMR ADMIN"
+  APPROVER = "mdctqmr-approver", // "MDCT QMR APPROVER"
+  INTERNAL = "mdctqmr-internal-user", // "MDCT QMR INTERNAL USER"
+  HELP_DESK = "mdctqmr-help-desk", // "MDCT QMR HELP DESK USER"
+  STATE_USER = "mdctqmr-state-user", // "MDCT QMR STATE USER"
 }
 
 export enum MeasureStatus {

--- a/services/ui-src/src/views/AddChildCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddChildCoreSet/index.tsx
@@ -33,7 +33,7 @@ export const AddChildCoreSet = () => {
   const { state, year } = useParams();
   const register = useCustomRegister<ChildCoreSetReportType>();
 
-  if (userState && userState !== state && userRole === UserRoles.STATE) {
+  if (userState && userState !== state && userRole === UserRoles.STATE_USER) {
     return (
       <CUI.Box data-testid="unauthorized-container">
         <QMR.Notification

--- a/services/ui-src/src/views/AddChildCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddChildCoreSet/index.tsx
@@ -33,6 +33,7 @@ export const AddChildCoreSet = () => {
   const { state, year } = useParams();
   const register = useCustomRegister<ChildCoreSetReportType>();
 
+  // block display from state users without permissions for the corresponding state
   if (userState && userState !== state && userRole === UserRoles.STATE_USER) {
     return (
       <CUI.Box data-testid="unauthorized-container">

--- a/services/ui-src/src/views/AddHHCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddHHCoreSet/index.tsx
@@ -39,6 +39,7 @@ export const AddHHCoreSet = () => {
   const register = useCustomRegister<HealthHome>();
   const watchSPAchoice = methods.watch("HealthHomeCoreSet-SPA");
 
+  // block display from state users without permissions for the corresponding state
   if (userState && userState !== state && userRole === UserRoles.STATE_USER) {
     return (
       <CUI.Box data-testid="unauthorized-container">

--- a/services/ui-src/src/views/AddHHCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddHHCoreSet/index.tsx
@@ -39,7 +39,7 @@ export const AddHHCoreSet = () => {
   const register = useCustomRegister<HealthHome>();
   const watchSPAchoice = methods.watch("HealthHomeCoreSet-SPA");
 
-  if (userState && userState !== state && userRole === UserRoles.STATE) {
+  if (userState && userState !== state && userRole === UserRoles.STATE_USER) {
     return (
       <CUI.Box data-testid="unauthorized-container">
         <QMR.Notification

--- a/services/ui-src/src/views/AdminHome/index.tsx
+++ b/services/ui-src/src/views/AdminHome/index.tsx
@@ -4,6 +4,8 @@ import { stateAbbreviations } from "utils/constants";
 import { useNavigate } from "react-router";
 import config from "config";
 import { useFlags } from "launchdarkly-react-client-sdk";
+import { useUser } from "hooks/authHooks";
+import { UserRoles } from "types";
 
 export const AdminHome = () => {
   const [locality, setLocality] = useState("AL");
@@ -11,6 +13,8 @@ export const AdminHome = () => {
     ? config.currentReportingYear
     : parseInt(config.currentReportingYear) - 1;
   const navigate = useNavigate();
+  const { userRole } = useUser();
+
   return (
     <CUI.Container maxW="7xl" py="4">
       <CUI.Stack spacing="4" maxW="lg">
@@ -37,22 +41,25 @@ export const AdminHome = () => {
           Go To State Home
         </CUI.Button>
       </CUI.Stack>
-      <CUI.Stack spacing="4" maxW="xl" py="4">
-        <CUI.Divider />
-        <CUI.Heading size="sm">Banner Admin</CUI.Heading>
-        <CUI.Text fontSize="sm">
-          Click here to manage the announcement banner.
-        </CUI.Text>
-        <CUI.Button
-          colorScheme="blue"
-          onClick={() => navigate(`/admin/banner`)}
-          isFullWidth
-          data-cy="Banner Editor"
-          maxW="xs"
-        >
-          Banner Editor
-        </CUI.Button>
-      </CUI.Stack>
+      {/* hide admin banner button if not super admin */}
+      {userRole === UserRoles.ADMIN && (
+        <CUI.Stack spacing="4" maxW="xl" py="4">
+          <CUI.Divider />
+          <CUI.Heading size="sm">Banner Admin</CUI.Heading>
+          <CUI.Text fontSize="sm">
+            Click here to manage the announcement banner.
+          </CUI.Text>
+          <CUI.Button
+            colorScheme="blue"
+            onClick={() => navigate(`/admin/banner`)}
+            isFullWidth
+            data-cy="Banner Editor"
+            maxW="xs"
+          >
+            Banner Editor
+          </CUI.Button>
+        </CUI.Stack>
+      )}
     </CUI.Container>
   );
 };

--- a/services/ui-src/src/views/AdminHome/index.tsx
+++ b/services/ui-src/src/views/AdminHome/index.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router";
 import config from "config";
 import { useFlags } from "launchdarkly-react-client-sdk";
 import { useUser } from "hooks/authHooks";
+import { BannerCard } from "components/Banner/BannerCard";
 import { UserRoles } from "types";
 
 export const AdminHome = () => {
@@ -17,6 +18,9 @@ export const AdminHome = () => {
 
   return (
     <CUI.Container maxW="7xl" py="4">
+      <CUI.Container maxW="5xl" py="4">
+        <BannerCard />
+      </CUI.Container>
       <CUI.Stack spacing="4" maxW="lg">
         <CUI.Heading size="md">Admin Home</CUI.Heading>
         <CUI.Select

--- a/services/ui-src/src/views/Home/index.tsx
+++ b/services/ui-src/src/views/Home/index.tsx
@@ -13,11 +13,10 @@ export function Home() {
     ? config.currentReportingYear
     : parseInt(config.currentReportingYear) - 1;
   if (
-    userRole === UserRoles.HELP ||
-    userRole === UserRoles.INTERNAL ||
     userRole === UserRoles.ADMIN ||
-    userRole === UserRoles.BO ||
-    userRole === UserRoles.BOR
+    userRole === UserRoles.APPROVER ||
+    userRole === UserRoles.HELP_DESK ||
+    userRole === UserRoles.INTERNAL
   ) {
     return <Navigate to={`/admin`} />;
   }

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -110,6 +110,8 @@ const StateHome = () => {
   );
   const { userState, userRole } = useUser();
   const deleteCoreSet = Api.useDeleteCoreSet();
+
+  // block display from state users without permissions for the corresponding state
   if (userState && userState !== state && userRole === UserRoles.STATE_USER) {
     return (
       <CUI.Box data-testid="unauthorized-container">

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -183,6 +183,7 @@ const StateHome = () => {
       <QMR.Notification alertStatus="error" alertTitle="An Error Occured" />
     );
   }
+
   if (
     isLoading ||
     !data.Items ||

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -110,7 +110,7 @@ const StateHome = () => {
   );
   const { userState, userRole } = useUser();
   const deleteCoreSet = Api.useDeleteCoreSet();
-  if (userState && userState !== state && userRole === UserRoles.STATE) {
+  if (userState && userState !== state && userRole === UserRoles.STATE_USER) {
     return (
       <CUI.Box data-testid="unauthorized-container">
         <QMR.Notification

--- a/tests/cypress/cypress/e2e/features/kebab_menu_measures.spec.ts
+++ b/tests/cypress/cypress/e2e/features/kebab_menu_measures.spec.ts
@@ -9,22 +9,22 @@ describe("Measure kebab menus", () => {
   it('displays "View" option', () => {
     cy.get('[data-cy="ACS"]').click();
     cy.get('[data-cy="Measure Actions-AMM-AD"]').click();
-    cy.get('#menu-list-11 > [data-cy="View"]').should("have.text", "View");
+    cy.get('button[aria-label="View for AMM-AD"]').should("have.text", "View");
 
     cy.get('[data-cy="Measure Actions-AMR-AD"]').click();
-    cy.get('#menu-list-11 > [data-cy="View"]').should("have.text", "View");
+    cy.get('button[aria-label="View for AMR-AD"]').should("have.text", "View");
 
     cy.get('[data-cy="Measure Actions-PCR-AD"]').click();
-    cy.get('#menu-list-11 > [data-cy="View"]').should("have.text", "View");
+    cy.get('button[aria-label="View for PCR-AD"]').should("have.text", "View");
   });
 
   it('navigates to the measure page when "View" is selected', () => {
     cy.get('[data-cy="ACS"]').click();
     cy.get('[data-cy="Measure Actions-AMM-AD"]').click();
-    cy.get('#menu-list-11 > [data-cy="View"]').click({ force: true });
+    cy.get('button[aria-label="View for AMM-AD"]').click();
     cy.get('[data-cy="state-layout-container"').should(
       "include.text",
-      "FFY 2023AAB-AD - Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis: Age 18 And Older"
+      "FFY 2023AMM-AD - Antidepressant Medication Management"
     );
   });
 });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

#### Preamble
This is gonna be a long one. Hang in there. First, the main players:

- _ADMIN — This is the super admin or Business Owner Rep role. It is one of four "admin-type" (think: non-state-user) roles, and is the main role referred to as "Admin". It is held by only the application owner at the MDCT level and typically only one user at a time will have this role. Generally read-only, with the exception of the admin banner._
- _APPROVER — This is the approver user role, and it is one of four "admin-type" (think: non-state-user) roles. It is held by the lead Business Owners at CMS HQ with responsibility over QMR. Generally read only._
- _HELP DESK — This is the help desk user role, and it is one of four "admin-type" (think: non-state-user) roles.  It is held by help desk staff within MACPro assigned to Tier 2 support for the MDCT applications. Generally read only._
- _INTERNAL — This is the internal user role, and it is one of four "admin-type" (think: non-state-user) roles. It is held by internal CMS staff and contractors, like Mathematica and Coforma. Generally read only._
- _STATE USER — This is the state user role, and users with this type also have a state attribute. (Note: Any user can have a state attribute, but these ones need it.) It's held by state-level CMS staff and contractors. Has read/write access, but only for their associated state and not for the admin banner._

#### Chapter 1: An Unexpected Party
During validation of the new internal user role, I noticed that they had access to the `/admin` route and made a note to investigate further, assuming that we were simply not blocking that route in the UI & when routes were created, and that the API was surely locked down appropriately. I made a note to investigate further and thought nothing more of the matter. 

#### Chapter 2: A Shortcut to Madness
When I had more time to devote to the subject, I sat down to create what I thought would be a simple dozen-line PR adding a UI change and a matching test, only to find that we were not actually blocking the API and that it was, in fact, explicitly exposed to all users via an override prop being passed to the handler. I immediately set to work rectifying the situation, pulling ever so gently on the thread which would eventually unravel the entire mystery, but which first would lead me through the unknowable, unnamed parts of QMR.

#### Chapter 3: The Shadow of the Past
All API calls are wrapped in a [nifty handler](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/blob/master/services/app-api/libs/handler-lib.ts#L11-L33) provided by an internal library, `lib-handler`. But it has a dark secret: an optional argument, `postOverride`, which is passed through to an authorization utility used to determine if the user is authorized to access resources. This [auth utility](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/blob/master/services/app-api/libs/authorization.ts#L13-L41) was then using that override arg to determine if it should override certain checks and allow users to access resources regardless. I looked and it was only really being used by 3 handlers: `banners/create (createBanner)`, `banners/delete (deleteBanner)`, and `prince/pdf (getPdf)`. It was originally put in place to allow all users to interact with Prince XML, the pdf printing resource, because although the method is named "getPdf", it's a POST, and prior to it's adoption, QMR was only allowing state users to POST (admin-type users had no reason to do so back in these days). The implementation of the admin banner used this as well to allow admin users to POST and DELETE banners. But this inadvertently opened up the ability for anyone to do so, because as it turns out, the authorization util was doing a lot more than it should have been.

#### Chapter 4: A Utility Unmasked
The auth utility was not only checking for authentication, but also performing two other functions: (1) Checking for state permissions, and (2) Checking for role permissions. This would normally be ok, but the combination of the two was causing some problems. Some pseudocode of what it was doing for illustration (or you can look at the code yourself [here](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/blob/master/services/app-api/libs/authorization.ts#L30-L40)):

```js
const shouldWeAllowTheUserToDoThis = (event, postOverride) => {

// check if state user has the same state as the event (API call)
  if (isStateUser && userHasAssociatedState && EventParametersIncludesState) {
    return usersState === eventsState
  }

  // you got here, so user must be an admin*
  return (
    requestMethodIsGET ||                    // let everyone get stuff!
    requestMethodIsPOST && postOverride ||   // let the people post!
    requestMethodIsDELETE && postOverride   // let it all burn!
  );
}

// *eagle-eyed reviewers will notice this is not true. if the event doesn't include specify a state or if the state user doesn't have an associated state, you get here too.
```

#### Chapter 5: In The House of Brax Bombadil
Anyway, it was doing too much. And that is generally a bad™ thing. So I set to work fixing it. This wasn't too bad. I cleaned up `isAuthorized` (now renamed `isAuthenticated` thanks to @gmrabian), set up separate utilities in the `authorization.ts` util file to handle `hasStatePermissions` and `hasRolePermissions`, got those implemented and started writing up some tests. But testing started going bad. I was sure I was mocking things right. Or was I? Was it all a dream? _Did_ I used to read _Word Up!_ magazine? I had to find the answer, and quick. You see, I was expecting a series of 403 status codes to come back in tests, because I was testing that unauthorized users would get rejected. Instead, I kept getting 200s. Why?! The more I looked into it, the more positive I was that something odd was afoot. Then I figured it out. The response from each API call was something like this:

```js
const response = await dynamoDb.post(params);
console.log(response);

/*
{
  statusCode: 200,
  body: {
    statusCode: 403,
    body: "User is not authorized blah blah blah..."
  }
}
*/
```

You can imagine my surprise. 

#### Chapter 6: The Old Forest
As it turns out, another internal library, `response-lib.ts`, had a method called `success`, which was being used in that wrapping handler to just always return success (unless a user wasn't authenticated), making it so that any other failure, short of throwing an error and crashing, would just silently fail and return you that failure wrapped in a neat little 200 success package. Fun, huh?

#### Chapter 7: At the Sign of the Prancing Brax
Once I figure this out, things were seeming easier. Sure I had to change all the tests that were relying on these naive 200s coming back, but that was a small price for a clean API that returns what it means to, right? Right? Tell me it's worth it, please.

#### Chapter 8: Fog on the Braxow-Downs
By this point, I was feeling like I'd rewritten half the backend of QMR and was starting to feel kinda nervous. I hadn't even gotten to my original goal yet! (You'll remember I started this story approximately 1 year ago, and had planned to just hide the admin banner button from non super-admins and make sure they couldn't hit that route). So off I went to go figure out that stuff. But oh yeah, the user roles were all weird. So I labeled them. And I was like, wait, what is a `mdctqmr-bo-user`? Isn't it just `mdctqmr-bor`? I dug up the old QMR IDM tech specs and could find no mention of this BO User. I checked all the deployed AWS environment Cognito user pools, and likewise, not a trace of any user who had this BO User role. You'll note it is now removed. But I was real confused for a bit in there.

#### Chapter 9: Coder / Write in the Dark
Now I was really cruising. I cleaned up the user types. I cleaned up the users.json, I cleaned up the UI, I hid the button, I changed the routes. I was doing it! It was really happening! I made the banner appear on the AdminHome page and the user scroll up after submitting the banner. UX improvements! I checked all the existing instances of user role stuffs. I wrote comments! Such comments!

#### Chapter 10: Flight to the PR
And now we're here. Changes have been made and it's time to review them. I thank you for your time. I thank you for your diligence. If you read this, I thank you for your patience. Let's talk about what changed.


### Changes Made
- Modified handler authorization permissions (by calling new helper utilities) as follows:
    - Banners
        - createBanner: restricted to ADMIN
        - deleteBanner: restricted to ADMIN
        - fetchBanner: no auth changes, remains open to all users
    - Core Sets
        - createCoreSet: restricted to Admin* & STATE USERS (with matching state)
        - coreSetList: restricted to Admin* & STATE USERS (with matching state)
        - getCoreSet: restricted to Admin* & STATE USERS (with matching state)
        - deleteCoreSet: restricted to STATE USERS (with matching state)
        - editCoreSet: restricted to STATE USERS (with matching state)
    - Measures
        - createMeasure: restricted to Admin* & STATE USERS (with matching state)
        - listMeasure: restricted to Admin* & STATE USERS (with matching state)
        - getMeasure: restricted to Admin* & STATE USERS (with matching state)
        - deleteMeasure: restricted to STATE USERS (with matching state)
        - editMeasure: restricted to STATE USERS (with matching state)
    - Prince PDF: no auth changes, remains open to all users
- Modified handler-lib handler to no longer allow override of authorization checks
- Modified authorization lib to separate authentication concerns from permission concerns
    - Changed isAuthorized to isAuthenticated and simplified, moving checks to other helpers
    - Added hasStatePermissions and hasRolePermissions utils
- Modified response-lib handler to no longer default to success response that obfuscates true response in nested object
- Cleaned up user role types (ADMIN, APPROVER, HELP DESK, INTERNAL, STATE USER)
    - Removed unused BO user role
- Cleaned up references to user roles
- Updated all related tests and wrote new ones
- Oh yeah changed some UI stuff to block non-admin-type users from getting to `/admin` and block non-super-admin users from getting to `/admin/banner` and seeing the admin banner button. Plus some QOL improvements for the super admin UX.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
n/a

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
We should test each of the following handler & user combinations in the application UI to ensure they are working as expected (✅ = should work, 🚫 = should not work). *Admin-Type = APPROVER, HELP DESK, or INTERNAL

#### Banners
| # | File | Handler | ADMIN | Non Super Admin | STATE  | (Right State) | (Wrong State)
| :--------:  | ------- | ------- | :-------: | :-------: | :-------: | :-------: | :-------: | 
| 1 | banners/create | createBanner | ✅ | 🚫 | 🚫 | — | — | 
| 2 | banners/delete | deleteBanner | ✅ | 🚫 | 🚫 | — | — | 
| 3 | banners/fetch | fetchBanner | ✅ | ✅ | ✅ | — | — | 

#### Core Sets
| # | File | Handler | ADMIN | Non Super Admin | STATE  | (Right State) | (Wrong State)
| :--------:  | ------- | ------- | :-------: | :-------: | :-------: | :-------: | :-------: | 
| 4 | coreSets/create | createCoreSet | ✅ | ✅ | → | ✅ | 🚫 |
| 5 | coreSets/delete | deleteCoreSet | 🚫 | 🚫 | → | ✅ | 🚫 |
| 6 | coreSets/get | coreSetList | ✅ | ✅ | → | ✅ | 🚫 |
| 7 | coreSets/get | getCoreSet | ✅ | ✅ | → | ✅ | 🚫 |
| 8 | coreSets/update | editCoreSet | 🚫 | 🚫 | → | ✅ | 🚫 |

#### Measures
| # | File | Handler | ADMIN | Non Super Admin | STATE  | (Right State) | (Wrong State)
| :--------:  | ------- | ------- | :-------: | :-------: | :-------: | :-------: | :-------: | 
| 9 | measures/create | createMeasure | ✅ | ✅ | → | ✅ | 🚫 |
| 10 | measures/delete | deleteMeasure | 🚫 | 🚫 | → | ✅ | 🚫 |
| 11 | measures/get | getMeasure | ✅ | ✅ | → | ✅ | 🚫 |
| 12 | measures/get | listMeasures | ✅ | ✅ | → | ✅ | 🚫 |
| 13 | measures/update | editMeasure | 🚫 | 🚫 | → | ✅ | 🚫 |

#### Other
| # | File | Handler | ADMIN | Non Super Admin | STATE  | (Right State) | (Wrong State)
| :--------:  | ------- | ------- | :-------: | :-------: | :-------: | :-------: | :-------: | 
| 14 | prince/pdf | getPdf | ✅ | ✅ | ✅ | — | — | 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
