### PR TITLE
replace non-existent banner status code to 200 from 404

### DIFF
--- a/services/app-api/handlers/banners/fetch.ts
+++ b/services/app-api/handlers/banners/fetch.ts
@@ -14,9 +14,6 @@ export const fetchBanner = handler(async (event, _context) => {
   };
   const response = await dynamoDb.get(params);
 
-  let status = StatusCodes.SUCCESS;
-  if (!response?.Item) {
-    status = StatusCodes.NOT_FOUND;
-  }
+  const status = StatusCodes.SUCCESS;
   return { status: status, body: response };
 });

--- a/services/app-api/handlers/banners/tests/fetch.test.ts
+++ b/services/app-api/handlers/banners/tests/fetch.test.ts
@@ -32,14 +32,14 @@ const testEvent: APIGatewayProxyEvent = {
 };
 
 describe("Test fetchBanner API method", () => {
-  test("Test Report not found Fetch", async () => {
+  test("Test Successful empty Banner Fetch", async () => {
     jest.spyOn(dynamoDb, "get").mockImplementation(
       mockDocumentClient.get.promise.mockReturnValueOnce({
         Item: undefined,
       })
     );
     const res = await fetchBanner(testEvent, null);
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
   });
 
   test("Test Successful Banner Fetch", async () => {


### PR DESCRIPTION
### Description
Successful retrieval of an empty banner returns a 200 status code instead of a 404 error.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2908

---
### How to test
Open inspect -> Network tab. Login and see that the adminBanner request results in a 200 status code with an empty object in the body.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
