### PR TITLE
fix cypress tests hanging

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -44,6 +44,9 @@ jobs:
   e2e-tests:
     name: Execute Cypress Tests
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.16.0-chrome107-ff107
+      options: --user 1001
     needs: setup
     strategy:
       fail-fast: false

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -5,6 +5,7 @@ export default async (on, config) => {
     if (browser.name === "chrome" && browser.isHeadless) {
       launchOptions.args.push("--window-size=1400,9000");
       launchOptions.args.push("--force-device-scale-factor=1");
+      launchOptions.args.push("--headless=old");
     }
     return launchOptions;
   });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Following up on the discovery from [this PR](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/1982)

[old headless plus container locked to chrome version](https://github.com/cypress-io/cypress/issues/27264#issuecomment-1732192738)

I guess the latest versions of chrome do "headless" differently so by pinning an older version using a container and choosing to run the "old" headless version it works


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2977

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---