### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -71,18 +71,8 @@ jobs:
           CYPRESS_TEST_USER_4: ${{ secrets.cypress-user4 }}
           CYPRESS_TEST_PASSWORD_1: ${{ secrets.cypress-password }}
       - name: Upload screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
-          path: |
-            tests/cypress/screenshots/
-            tests/cypress/videos/
-      - name: Slack Notification
-        if: env.slack-url != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,ref # selectable (default: repo,message)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.slack-url }}
+          path: tests/cypress/screenshots/

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Dependabot Gather Metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.0
+        uses: dependabot/fetch-metadata@v1
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,15 @@ jobs:
           # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
           # This can optionally be set as an GitHub Actions Secret
           ./deploy.sh $STAGE_PREFIX$branch_name
+      - name: Endpoint
+        id: endpoint
+        run: |
+          APPLICATION_ENDPOINT=$(./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name)
+          echo "application_endpoint=$APPLICATION_ENDPOINT" >> $GITHUB_OUTPUT
+          echo "## Application Endpoint" >> $GITHUB_STEP_SUMMARY
+          echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
+    outputs:
+      application_endpoint: ${{ steps.endpoint.outputs.application_endpoint}}
   # run e2e tests after deploy completes
   e2e-tests-init:
     name: Initialize End To End Tests
@@ -75,6 +84,11 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
+      - name: Verify Endpoint
+        if: ${{ needs.deploy.outputs.application_endpoint == ''}}
+        run: |
+          echo "No endpoint set, Check if the deploy workflow was successful."
+          exit 1
       - uses: actions/checkout@v3
       - name: set branch_name
         run: |
@@ -121,21 +135,6 @@ jobs:
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-      - name: Endpoint
-        id: endpoint
-        run: |
-          pushd services
-          export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
-          echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_OUTPUT
-          echo "Application endpoint: $APPLICATION_ENDPOINT"
-          popd
-      - name: Verify Endpoint
-        if: ${{ steps.endpoint.outputs.APPLICATION_ENDPOINT == ''}}
-        run: |
-          echo "No endpoint set, Check if the deploy workflow was successful."
-          exit 1
-    outputs:
-      APPLICATION_ENDPOINT: ${{ steps.endpoint.outputs.APPLICATION_ENDPOINT}}
 
   setup-tests:
     name: "Setup End To End Tests"
@@ -143,7 +142,7 @@ jobs:
     needs: e2e-tests-init
     with:
       test-path: "init"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.APPLICATION_ENDPOINT }}"
+      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -160,7 +159,7 @@ jobs:
       - setup-tests
     with:
       test-path: "measures/child"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.APPLICATION_ENDPOINT }}"
+      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -177,7 +176,7 @@ jobs:
       - setup-tests
     with:
       test-path: "measures/adult"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.APPLICATION_ENDPOINT }}"
+      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -194,7 +193,7 @@ jobs:
       - setup-tests
     with:
       test-path: "measures/healthhome"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.APPLICATION_ENDPOINT }}"
+      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -211,7 +210,7 @@ jobs:
       - setup-tests
     with:
       test-path: "features"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.APPLICATION_ENDPOINT }}"
+      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -231,7 +230,7 @@ jobs:
     uses: ./.github/workflows/cypress-workflow.yml
     with:
       test-path: "a11y"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.APPLICATION_ENDPOINT }}"
+      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,6 +136,8 @@ jobs:
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+    outputs:
+      application_endpoint: ${{ needs.deploy.outputs.application_endpoint }}
 
   setup-tests:
     name: "Setup End To End Tests"
@@ -143,7 +145,7 @@ jobs:
     needs: e2e-tests-init
     with:
       test-path: "init"
-      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
+      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -160,7 +162,7 @@ jobs:
       - setup-tests
     with:
       test-path: "measures/child"
-      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
+      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -177,7 +179,7 @@ jobs:
       - setup-tests
     with:
       test-path: "measures/adult"
-      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
+      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -194,7 +196,7 @@ jobs:
       - setup-tests
     with:
       test-path: "measures/healthhome"
-      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
+      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -211,7 +213,7 @@ jobs:
       - setup-tests
     with:
       test-path: "features"
-      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
+      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
@@ -231,7 +233,7 @@ jobs:
     uses: ./.github/workflows/cypress-workflow.yml
     with:
       test-path: "a11y"
-      test-endpoint: "${{ needs.deploy.outputs.application_endpoint }}"
+      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
     secrets:
       slack-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,17 +48,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - name: read .nvmrc
-        id: node_version
-        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-      - uses: actions/cache@v2
+          node-version-file: ".nvmrc"
+      - uses: actions/cache@v3
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
@@ -97,16 +94,13 @@ jobs:
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
           COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - name: read .nvmrc
-        id: node_version
-        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+          node-version-file: ".nvmrc"
       - name: Combine yarn.lock files to single file
         run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
       - name: cache service dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             services/app-api/node_modules
@@ -118,7 +112,7 @@ jobs:
             node_modules
           key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,7 @@ jobs:
           echo "application_endpoint=$APPLICATION_ENDPOINT" >> $GITHUB_OUTPUT
           echo "## Application Endpoint" >> $GITHUB_STEP_SUMMARY
           echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
+        working-directory: services
     outputs:
       application_endpoint: ${{ steps.endpoint.outputs.application_endpoint}}
   # run e2e tests after deploy completes

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -34,7 +34,7 @@ jobs:
           AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/git-secrets.yaml
+++ b/.github/workflows/git-secrets.yaml
@@ -4,8 +4,8 @@ jobs:
   gitleaks-scan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run gitlakes docker	    
-      uses: docker://zricethezav/gitleaks
-      with:
-        args: detect --source /github/workspace/ --no-git --verbose
+      - uses: actions/checkout@v3
+      - name: Run gitleaks docker
+        uses: docker://zricethezav/gitleaks
+        with:
+          args: detect --source /github/workspace/ --no-git --verbose

--- a/.github/workflows/pullrequest-precommit-check.yml
+++ b/.github/workflows/pullrequest-precommit-check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.2
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0
         with:
           extra_args: --all-files

--- a/.github/workflows/scan_security-hub-jira-integration.yml
+++ b/.github/workflows/scan_security-hub-jira-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}

--- a/.github/workflows/scan_snyk-jira-integration.yml
+++ b/.github/workflows/scan_snyk-jira-integration.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Snyk and Run Snyk test
         run: |
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Snyk and Run Snyk test
         run: |

--- a/.github/workflows/unittest-workflow.yml
+++ b/.github/workflows/unittest-workflow.yml
@@ -16,13 +16,10 @@ jobs:
         run: ./.github/build_vars.sh set_values
         env:
           CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
-      - name: read .nvmrc
-        id: node_version
-        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-      - uses: actions/cache@v2
+          node-version-file: ".nvmrc"
+      - uses: actions/cache@v3
         with:
           path: |
             **/node_modules
@@ -35,7 +32,7 @@ jobs:
         run: ./test-unit.sh
       - name: publish test coverage to code climate
         if: env.CODE_CLIMATE_ID != ''
-        uses: paambaati/codeclimate-action@v2.7.5
+        uses: paambaati/codeclimate-action@v5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
         with:
@@ -43,7 +40,7 @@ jobs:
             ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: Store unit test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: unit_test_results
           path: ${{github.workspace}}/services/ui-src/coverage/lcov.info


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updating versions to avoid warnings and deprecations

Note: these have already been tested in [another PR](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/1982) and I'm migrating them here

DOCS:
[aws-configure-credentials readme](https://github.com/aws-actions/configure-aws-credentials) – no breaking changes between 1 and 4. ("By default, your account ID will not be masked in workflow logs. This was changed from being masked by default in the previous version. AWS does not consider account IDs as sensitive information, so this change reflects that stance." Let me know if you want to mask this still and I'll add that option)
[cache readme](https://github.com/actions/cache) – no breaking changes with v3
[codeclimate action changelog](https://github.com/paambaati/codeclimate-action/releases) – breaking changes not relevant to us
[node version action](https://github.com/actions/setup-node) – update allows us to read from .nvmrc natively
[pre-commit/action changelog](https://github.com/pre-commit/action/releases) – doesn't specifically call out a fix but the warnings were resolved by upgrading
[actions/checkout changelog](https://github.com/actions/checkout/releases/tag/v3.0.0) – v3 uses node 16 which will be deprecated soon but doesn't have a warning for now, and keeps it up to date with our other checkouts@v3
[dependabot/fetch-metadata action changelog](https://github.com/dependabot/fetch-metadata/releases) – specifically v1.5.0 removes deprecated set-output so by changing to @v1 it will automatically use latest version

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-none

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
All steps here pass