### PR TITLE
Add x-frame-options header

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -202,7 +202,7 @@ resources:
             ViewerProtocolPolicy: redirect-to-https
             FunctionAssociations:
               - EventType: viewer-response
-                FunctionARN: !GetAtt HeadersCloudfrontFunction.FunctionMetadata.FunctionARN
+                FunctionARN: !GetAtt HstsCloudfrontFunction.FunctionMetadata.FunctionARN
           ViewerCertificate:
             Fn::If:
               - CreateCustomCloudFrontDomain
@@ -229,7 +229,7 @@ resources:
           HostedZoneId: Z2FDTNDATAQYW2
           EvaluateTargetHealth: false
         Type: A
-    HeadersCloudfrontFunction:
+    HstsCloudfrontFunction:
       Type: AWS::CloudFront::Function
       Properties:
         AutoPublish: true

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -202,7 +202,7 @@ resources:
             ViewerProtocolPolicy: redirect-to-https
             FunctionAssociations:
               - EventType: viewer-response
-                FunctionARN: !GetAtt HstsCloudfrontFunction.FunctionMetadata.FunctionARN
+                FunctionARN: !GetAtt HeadersCloudfrontFunction.FunctionMetadata.FunctionARN
           ViewerCertificate:
             Fn::If:
               - CreateCustomCloudFrontDomain
@@ -229,7 +229,7 @@ resources:
           HostedZoneId: Z2FDTNDATAQYW2
           EvaluateTargetHealth: false
         Type: A
-    HstsCloudfrontFunction:
+    HeadersCloudfrontFunction:
       Type: AWS::CloudFront::Function
       Properties:
         AutoPublish: true
@@ -238,6 +238,7 @@ resources:
             var response = event.response;
             var headers = response.headers;
             headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'};
+            headers['x-frame-options'] = { value: 'DENY' };
             return response;
           }
         FunctionConfig:


### PR DESCRIPTION
### Description
This PR adds an additional HTTP header when serving the website, which instructs browsers not to serve our content within an iframe.

Previously, the function which attaches HTTP headers for this app was named for the only header it cared about. It has been renamed appropriately.

### Related ticket(s)
CMDCT-271

---
### How to test
We don't use iframes to serve this website, so this PR shouldn't change anything. A quick smoke test (as provided by Cypress) should be sufficient.

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~

