### PR TITLE
MDCT-2985: Cleaning Up LD Feature Flag

### DIFF
--- a/services/ui-src/src/views/AddHHCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddHHCoreSet/index.tsx
@@ -8,7 +8,7 @@ import { useCustomRegister } from "hooks/useCustomRegister";
 import { useQueryClient } from "react-query";
 import { useUser } from "hooks/authHooks";
 import { CoreSetAbbr, UserRoles } from "types";
-import { useFlags } from "launchdarkly-react-client-sdk";
+
 interface HealthHome {
   "HealthHomeCoreSet-SPA": string;
   "HealthHomeCoreSet-ShareSSM": string;
@@ -27,8 +27,7 @@ export const AddHHCoreSet = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { userState, userRole } = useUser();
-  const releasedTwentyTwentyThree = useFlags()?.["release2023"];
-  const { data, isLoading } = Api.useGetCoreSets(releasedTwentyTwentyThree);
+  const { data, isLoading } = Api.useGetCoreSets(true);
   const { state, year } = useParams();
 
   const methods = useForm<HealthHome>({

--- a/services/ui-src/src/views/AdminHome/index.tsx
+++ b/services/ui-src/src/views/AdminHome/index.tsx
@@ -9,7 +9,7 @@ import { UserRoles } from "types";
 
 export const AdminHome = () => {
   const [locality, setLocality] = useState("AL");
-  const releaseYearByFlag = parseInt(config.currentReportingYear) - 1;
+  const releaseYearByFlag = parseInt(config.currentReportingYear);
   const navigate = useNavigate();
   const { userRole } = useUser();
 

--- a/services/ui-src/src/views/AdminHome/index.tsx
+++ b/services/ui-src/src/views/AdminHome/index.tsx
@@ -3,16 +3,13 @@ import * as CUI from "@chakra-ui/react";
 import { stateAbbreviations } from "utils/constants";
 import { useNavigate } from "react-router";
 import config from "config";
-import { useFlags } from "launchdarkly-react-client-sdk";
 import { useUser } from "hooks/authHooks";
 import { BannerCard } from "components/Banner/BannerCard";
 import { UserRoles } from "types";
 
 export const AdminHome = () => {
   const [locality, setLocality] = useState("AL");
-  const releaseYearByFlag = useFlags()?.["release2023"]
-    ? config.currentReportingYear
-    : parseInt(config.currentReportingYear) - 1;
+  const releaseYearByFlag = parseInt(config.currentReportingYear) - 1;
   const navigate = useNavigate();
   const { userRole } = useUser();
 

--- a/services/ui-src/src/views/Home/index.tsx
+++ b/services/ui-src/src/views/Home/index.tsx
@@ -8,7 +8,8 @@ import { useUser } from "hooks/authHooks";
 
 export function Home() {
   const { userRole, userState } = useUser();
-  const releaseYearByFlag = parseInt(config.currentReportingYear) - 1;
+  const releaseYearByFlag = parseInt(config.currentReportingYear);
+
   if (
     userRole === UserRoles.ADMIN ||
     userRole === UserRoles.APPROVER ||

--- a/services/ui-src/src/views/Home/index.tsx
+++ b/services/ui-src/src/views/Home/index.tsx
@@ -5,13 +5,10 @@ import * as CUI from "@chakra-ui/react";
 import "./index.module.scss";
 import * as QMR from "components";
 import { useUser } from "hooks/authHooks";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 export function Home() {
   const { userRole, userState } = useUser();
-  const releaseYearByFlag = useFlags()?.["release2023"]
-    ? config.currentReportingYear
-    : parseInt(config.currentReportingYear) - 1;
+  const releaseYearByFlag = parseInt(config.currentReportingYear) - 1;
   if (
     userRole === UserRoles.ADMIN ||
     userRole === UserRoles.APPROVER ||

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -48,10 +48,6 @@ const ReportingYear = () => {
         }))
       : [{ displayValue: `${year} Core Set`, value: `${year}` }];
 
-  reportingyearOptions = reportingyearOptions.filter(
-    (entry) => entry.value !== "2023"
-  );
-
   return (
     <CUI.Box w={{ base: "full", md: "48" }}>
       <CUI.Text fontSize="sm" fontWeight="600" mb="2">

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -16,7 +16,7 @@ import { useGetReportingYears } from "hooks/api";
 import { useUpdateAllMeasures } from "hooks/useUpdateAllMeasures";
 import { useResetCoreSet } from "hooks/useResetCoreSet";
 import { BannerCard } from "components/Banner/BannerCard";
-import { useFlags } from "launchdarkly-react-client-sdk";
+
 interface HandleDeleteData {
   state: string;
   year: string;
@@ -39,7 +39,6 @@ const ReportingYear = () => {
   const navigate = useNavigate();
   const { state, year } = useParams();
   const { data: reportingYears } = useGetReportingYears();
-  const releasedTwentyTwentyThree = useFlags()?.["release2023"];
 
   let reportingyearOptions: IRepYear[] =
     reportingYears && reportingYears.length
@@ -49,11 +48,10 @@ const ReportingYear = () => {
         }))
       : [{ displayValue: `${year} Core Set`, value: `${year}` }];
 
-  if (!releasedTwentyTwentyThree) {
-    reportingyearOptions = reportingyearOptions.filter(
-      (entry) => entry.value !== "2023"
-    );
-  }
+  reportingyearOptions = reportingyearOptions.filter(
+    (entry) => entry.value !== "2023"
+  );
+
   return (
     <CUI.Box w={{ base: "full", md: "48" }}>
       <CUI.Text fontSize="sm" fontWeight="600" mb="2">
@@ -104,10 +102,7 @@ const StateHome = () => {
   const queryClient = useQueryClient();
   const mutation = useUpdateAllMeasures();
   const resetCoreSetMutation = useResetCoreSet();
-  const releasedTwentyTwentyThree = useFlags()?.["release2023"];
-  const { data, error, isLoading } = Api.useGetCoreSets(
-    releasedTwentyTwentyThree
-  );
+  const { data, error, isLoading } = Api.useGetCoreSets(true);
   const { userState, userRole } = useUser();
   const deleteCoreSet = Api.useDeleteCoreSet();
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Removing the `release2023` feature flag from our codebase since they are no longer being used.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2985

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Log in, you should land on the 2023 reporting year by default and you should see 2023 as an option on the year dropdown.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
