### PR TITLE
Othermeasure rates bug

### DIFF
--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -57,7 +57,7 @@ interface MeasureProps {
 }
 
 const Measure = ({ measure, handleSave, ...rest }: MeasureProps) => {
-  const { watch } = useFormContext();
+  const { watch, setValue } = useFormContext();
 
   const watchedData = useWatch();
 
@@ -67,6 +67,11 @@ const Measure = ({ measure, handleSave, ...rest }: MeasureProps) => {
   const watchMeasureSpecification = useWatch({
     name: "MeasurementSpecification",
   });
+
+  const opmRates = useWatch({
+    name: DC.OPM_RATES,
+  });
+
   const isOtherMeasureSpecSelected = watchMeasureSpecification === "Other";
   const isPrimaryMeasureSpecSelected =
     watchMeasureSpecification && !isOtherMeasureSpecSelected;
@@ -75,6 +80,17 @@ const Measure = ({ measure, handleSave, ...rest }: MeasureProps) => {
     watchedData,
     rest.measureId
   );
+
+  useEffect(() => {
+    if (isOtherMeasureSpecSelected && !opmRates) {
+      setValue(DC.OPM_RATES, [
+        {
+          rate: [{ denominator: "", numerator: "", rate: "" }],
+          description: "",
+        },
+      ]);
+    }
+  }, [watch, isOtherMeasureSpecSelected, setValue]);
 
   useEffect(() => {
     const subscription = watch((value, { name, type }) => {

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -90,7 +90,7 @@ const Measure = ({ measure, handleSave, ...rest }: MeasureProps) => {
         },
       ]);
     }
-  }, [watch, isOtherMeasureSpecSelected, setValue]);
+  }, [watch, isOtherMeasureSpecSelected, opmRates, setValue]);
 
   useEffect(() => {
     const subscription = watch((value, { name, type }) => {

--- a/services/ui-src/src/components/Rate/index.tsx
+++ b/services/ui-src/src/components/Rate/index.tsx
@@ -2,7 +2,7 @@ import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
 import { useController, useFormContext } from "react-hook-form";
 import objectPath from "object-path";
-import { useEffect, useLayoutEffect } from "react";
+import { useEffect } from "react";
 import { getLabelText } from "utils";
 import { defaultRateCalculation } from "utils/rateFormulas";
 import { getMeasureYear } from "utils/getMeasureYear";
@@ -218,16 +218,6 @@ export const Rate = ({
     },
     [unregister, name]
   );
-
-  useLayoutEffect(() => {
-    field.onChange(field.value);
-
-    return () => {
-      field.onChange([]);
-    };
-    // purposefully ignoring field to stop infinite rerender
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [name]);
 
   return (
     <>

--- a/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
@@ -16,6 +16,7 @@ import {
   validationsMockObj as V,
 } from "measures/2023/shared/util/validationsMock";
 import { axe, toHaveNoViolations } from "jest-axe";
+import * as DC from "dataConstants";
 
 expect.extend(toHaveNoViolations);
 
@@ -229,7 +230,7 @@ const notReportingData = {
 const OPMData = {
   MeasurementSpecification: "Other",
   DidReport: "yes",
-  "OtherPerformanceMeasure-Rates": [
+  [DC.OPM_RATES]: [
     {
       rate: [{ denominator: "", numerator: "", rate: "" }],
       description: "",

--- a/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
@@ -16,6 +16,8 @@ import {
   validationsMockObj as V,
 } from "measures/2023/shared/util/validationsMock";
 import { axe, toHaveNoViolations } from "jest-axe";
+import * as DC from "dataConstants";
+
 expect.extend(toHaveNoViolations);
 
 // Test Setup
@@ -137,7 +139,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     apiData.useGetMeasureValues.data.Item.data = OPMData;
     useApiMock(apiData);
     renderWithHookForm(component);
-    expect(screen.queryByTestId("OPM"));
+    expect(screen.queryByTestId("OPM")).toBeInTheDocument();
     expect(screen.queryByTestId("performance-measure")).not.toBeInTheDocument();
     expect(
       screen.queryByTestId("deviation-from-measure-specification")
@@ -225,7 +227,16 @@ const notReportingData = {
   DidReport: "no",
 };
 
-const OPMData = { MeasurementSpecification: "Other", DidReport: "yes" };
+const OPMData = {
+  MeasurementSpecification: "Other",
+  DidReport: "yes",
+  "OtherPerformanceMeasure-Rates": [
+    {
+      rate: [{ denominator: "", numerator: "", rate: "" }],
+      description: "",
+    },
+  ],
+};
 
 const completedMeasureData = {
   PerformanceMeasure: {

--- a/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AMRAD/index.test.tsx
@@ -16,7 +16,6 @@ import {
   validationsMockObj as V,
 } from "measures/2023/shared/util/validationsMock";
 import { axe, toHaveNoViolations } from "jest-axe";
-import * as DC from "dataConstants";
 
 expect.extend(toHaveNoViolations);
 

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.test.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.test.tsx
@@ -3,6 +3,7 @@ import { OtherPerformanceMeasure } from ".";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { screen } from "@testing-library/react";
 import { DataDrivenTypes } from "../types";
+import * as DC from "dataConstants";
 
 interface Props {
   rateAlwaysEditable?: boolean;
@@ -12,13 +13,23 @@ interface Props {
   RateComponent?: RateComp | undefined;
 }
 
-const renderComponet = ({ RateComponent, data, rateAlwaysEditable }: Props) =>
+const renderComponent = ({ RateComponent, data, rateAlwaysEditable }: Props) =>
   renderWithHookForm(
     <OtherPerformanceMeasure
       rateAlwaysEditable={rateAlwaysEditable}
       data={data}
       RateComponent={RateComponent}
-    />
+    />,
+    {
+      defaultValues: {
+        [DC.OPM_RATES]: [
+          {
+            rate: [{ denominator: "", numerator: "", rate: "" }],
+            description: "",
+          },
+        ],
+      },
+    }
   );
 
 describe("Test the OtherPerformanceMeasure RateComponent prop", () => {
@@ -32,7 +43,7 @@ describe("Test the OtherPerformanceMeasure RateComponent prop", () => {
   });
 
   test("Component renders", () => {
-    renderComponet(props);
+    renderComponent(props);
     // should render QMR.Rate layout using example data
     expect(screen.getByText(/Other Performance Measure/i)).toBeVisible();
     expect(screen.getByText("Describe the Rate:")).toBeVisible();
@@ -52,7 +63,7 @@ describe("Test the OtherPerformanceMeasure RateComponent prop", () => {
   test("Added Rates can be deleted", () => {
     const labelText =
       "For example, specify the age groups and whether you are reporting on a certain indicator:";
-    renderComponet(props);
+    renderComponent(props);
     const addRate = screen.getByText("+ Add Another");
     fireEvent.click(addRate);
     const deleteAddedRate = screen.getByTestId("delete-wrapper");

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
@@ -49,7 +49,7 @@ export const OtherPerformanceMeasure = ({
   });
 
   useEffect(() => {
-    register("OtherPerformanceMeasure-Rates");
+    register(DC.OPM_RATES);
   }, [register]);
 
   // ! Waiting for data source refactor to type data source here

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/OtherPerformanceMeasure/index.tsx
@@ -3,7 +3,7 @@ import * as CUI from "@chakra-ui/react";
 import * as DC from "dataConstants";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "../types";
-import React from "react";
+import { useEffect } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { DataDrivenTypes } from "../types";
 
@@ -40,23 +40,17 @@ export const OtherPerformanceMeasure = ({
   rateCalc,
 }: Props) => {
   const register = useCustomRegister<Types.OtherPerformanceMeasure>();
-  const { getValues } = useFormContext<Types.OtherPerformanceMeasure>();
-  const savedRates = getValues(DC.OPM_RATES);
   const { control } = useFormContext();
-  const [showRates, setRates] = React.useState<Types.OtherRatesFields[]>(
-    savedRates ?? [
-      {
-        rate: [{ denominator: "", numerator: "", rate: "" }],
-        description: "",
-      },
-    ]
-  );
 
-  const { remove } = useFieldArray({
+  const { fields, append, remove } = useFieldArray({
     name: DC.OPM_RATES,
     control,
     shouldUnregister: true,
   });
+
+  useEffect(() => {
+    register("OtherPerformanceMeasure-Rates");
+  }, [register]);
 
   // ! Waiting for data source refactor to type data source here
   const { watch } = useFormContext<Types.DataSource>();
@@ -83,12 +77,12 @@ export const OtherPerformanceMeasure = ({
         {...register(DC.OPM_EXPLAINATION)}
       />
       <CUI.Box marginTop={10}>
-        {showRates.map((_item, index) => {
+        {fields.map((_item, index) => {
           return (
             <QMR.DeleteWrapper
               allowDeletion={index !== 0}
               onDelete={() => remove(index)}
-              key={index}
+              key={_item.id}
             >
               <CUI.Stack key={index} my={10}>
                 <CUI.Heading fontSize="lg" fontWeight="600">
@@ -140,8 +134,8 @@ export const OtherPerformanceMeasure = ({
             colorScheme: "blue",
             color: "blue.500",
           }}
-          onClick={() => {
-            showRates.push({
+          onClick={() =>
+            append({
               description: "",
               rate: [
                 {
@@ -150,9 +144,8 @@ export const OtherPerformanceMeasure = ({
                   rate: "",
                 },
               ],
-            });
-            setRates([...showRates]);
-          }}
+            })
+          }
         />
       </CUI.Box>
     </QMR.CoreQuestionWrapper>

--- a/tests/cypress/cypress/e2e/features/partially_completed_validation.spec.ts
+++ b/tests/cypress/cypress/e2e/features/partially_completed_validation.spec.ts
@@ -25,6 +25,7 @@ describe("OY2 16341 NDR set validation updates for all measures ", () => {
     cy.get(`[data-cy="PerformanceMeasure.rates.cvc5jQ.0.denominator"]`)
       .clear()
       .type("8");
+    cy.wait(500);
     cy.get(`[data-cy="OptionalMeasureStratification.options0"]`).click();
     cy.get(
       `[data-cy="OptionalMeasureStratification.selections.3dpUZu.options0"]`
@@ -65,6 +66,7 @@ describe("OY2 16341 NDR set validation updates for all measures ", () => {
     cy.get(`[data-cy="PerformanceMeasure.rates.8w4t99.0.denominator"]`)
       .clear()
       .type("8");
+    cy.wait(500);
     cy.get(`[data-cy="OptionalMeasureStratification.options0"]`).click();
     cy.get(
       `[data-cy="OptionalMeasureStratification.selections.3dpUZu.options0"]`

--- a/tests/cypress/cypress/e2e/measures/adult/CCWAD.spec.ts
+++ b/tests/cypress/cypress/e2e/measures/adult/CCWAD.spec.ts
@@ -128,6 +128,7 @@ describe("CCW-AD", () => {
       "Manually entered rate should be 0 if numerator is 0"
     );
 
+    cy.wait(1000);
     cy.get('[data-cy="+ Add Another"]').click();
     cy.get('[data-cy="OtherPerformanceMeasure-Rates.3.description"]').type(
       "check1"

--- a/tests/cypress/cypress/e2e/measures/adult/COBAD.spec.ts
+++ b/tests/cypress/cypress/e2e/measures/adult/COBAD.spec.ts
@@ -61,6 +61,7 @@ describe("OY2 9940 COB-AD", () => {
       "Manually entered rate should be 0 if numerator is 0"
     );
 
+    cy.wait(1000);
     cy.get('[data-cy="+ Add Another"]').click();
     cy.get('[data-cy="OtherPerformanceMeasure-Rates.3.description"]').type(
       "check1"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Other Performance Measure was crashing the render when you deleted a measure and saved because a null value got into the array. This fixes that issue. See video and How to Test for more info.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3062

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
On this branch:
- Sign in as a state user
- Generate Child core sets separately
- Go to Child core sets: medicaid and go to DEV-CH (note: fix applies to other measures. This is just what we've been testing)
- Select `Yes`, `Final Data`, `Other`, `Other` for the first four options
- Scroll down to Other Performance Measures and create three (description not necessary)
- Click save after creating three
- Delete the middle measure and save again
- Edit any other field and save once more. 

If you run this on `master`
- The render should crash.
- In dynamodb-admin you can see the `null` value that causes the break. If you delete the `null` it goes away.

video of crash:
https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/57802560/5438c1fa-35b7-4425-8945-df1ffa3fcbbb

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---