### PR TITLE
[CMDCT-3120] Remove zero validation errors from aab-ch validation set

### DIFF
--- a/services/ui-src/src/measures/2023/AABCH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/AABCH/index.test.tsx
@@ -191,15 +191,11 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(V.validateReasonForNotReporting).not.toHaveBeenCalled();
     expect(V.validateAtLeastOneRateComplete).toHaveBeenCalled();
     expect(V.validateNumeratorsLessThanDenominatorsPM).toHaveBeenCalled();
-    expect(V.validateRateNotZeroPM).toHaveBeenCalled();
-    expect(V.validateRateZeroPM).toHaveBeenCalled();
     expect(V.validateBothDatesCompleted).toHaveBeenCalled();
     expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
     expect(V.validateAtLeastOneDataSourceType).toHaveBeenCalled();
     expect(V.validateAtLeastOneDeviationFieldFilled).toHaveBeenCalled();
     expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
-    expect(V.validateRateZeroOMS).toHaveBeenCalled();
-    expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
     expect(V.validateTotalNDR).toHaveBeenCalled();
     expect(V.validateOMSTotalNDR).toHaveBeenCalled();
     expect(V.validateRequiredRadioButtonForCombinedRates).toHaveBeenCalled();

--- a/services/ui-src/src/measures/2023/AABCH/validation.ts
+++ b/services/ui-src/src/measures/2023/AABCH/validation.ts
@@ -34,8 +34,6 @@ const AABCHValidation = (data: FormData) => {
       ageGroups,
       PMD.categories
     ),
-    ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
-    ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason
@@ -65,8 +63,6 @@ const AABCHValidation = (data: FormData) => {
       validationCallbacks: [
         GV.validateNumeratorLessThanDenominatorOMS(),
         GV.validateOMSTotalNDR(),
-        GV.validateRateNotZeroOMS(),
-        GV.validateRateZeroOMS(),
       ],
     }),
   ];


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Entering 0/31 correctly sets the inverted rate but fails validation in both the nested rates and root for AAB-CH
![image](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/6362494/456681df-79d0-4e27-8985-27f384ef470e)
![image](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/6362494/cb613261-67b4-4615-93b7-45fb2674e0cb)


Removed the extra validation logic to match AAB-AD, thus no longer triggering the error

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3120

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Edit AAB-CH and set the rate numerators to 0. Validate, error should not be present.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
