### PR TITLE
Fix infrastructure destroy actions

### DIFF
--- a/.github/setBranchName.sh
+++ b/.github/setBranchName.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+GITHUB_REFNAME="${1}"
+
+[ -z "${GITHUB_REFNAME}" ] && echo "Error setting branch name.  No input given." && exit 1
+
+case ${GITHUB_REFNAME} in
+  $([[ "$GITHUB_REFNAME" =~ ^dependabot/.* ]] && echo ${GITHUB_REFNAME}))
+    echo ${GITHUB_REFNAME} | md5sum | head -c 10 | sed 's/^/x/'
+    ;;
+  $([[ "$GITHUB_REFNAME" =~ ^snyk-* ]] && echo ${GITHUB_REFNAME}))
+    echo ${GITHUB_REFNAME} | head -c 10 | sed 's/^/s/'
+    ;;
+  *)
+    echo ${GITHUB_REFNAME}
+    ;;
+esac

--- a/.github/waf-controller.sh
+++ b/.github/waf-controller.sh
@@ -58,7 +58,7 @@ for ((i=1; i <= $CIRCUIT_BREAKER; i++)); do
     [[ $CMD_CD -eq $AWS_RETRY_ERROR ]] || break
 
     SLEEP_FOR=$(jitter ${j})
-    echo "CLI retries exceed.  Waiting for ${SLEEP_FOR} seconds to execute read again...$({j})"
+    echo "CLI retries exceed.  Waiting for ${SLEEP_FOR} seconds to execute read again...(${j})"
     sleep ${SLEEP_FOR}
   done
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
           BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
@@ -99,7 +99,7 @@ jobs:
         run: |
           echo "No endpoint set, Check if the deploy workflow was successful."
           exit 1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set branch_name
         run: |
           BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
@@ -315,7 +315,7 @@ jobs:
     env:
       SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
       - "!skipci*"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
 
 permissions:
   id-token: write
@@ -19,7 +19,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     uses: ./.github/workflows/unittest-workflow.yml
-    if: github.ref == 'refs/heads/master'
+    if: github.ref_name == 'master'
     secrets:
       CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
   deploy:
@@ -27,17 +27,11 @@ jobs:
     env:
       SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
     steps:
+      - uses: actions/checkout@v3
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
-          echo "GITHUB_REF=${GITHUB_REF}"        
-          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then
-            echo "branch_name=`echo ${GITHUB_REF##*/*-} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
-          elif [[ "$GITHUB_REF" =~ ^refs/.*/snyk-* ]]; then
-            echo "branch_name=`echo ${GITHUB_REF##*/*-} | head -c 10 | sed 's/^/s/'`" >> $GITHUB_ENV
-          else
-            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          fi
-      - uses: actions/checkout@v3
+          BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0
         with:
@@ -95,7 +89,7 @@ jobs:
   # run e2e tests after deploy completes
   e2e-tests-init:
     name: Initialize End To End Tests
-    if: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/val' && github.ref != 'refs/heads/prod' }}
+    if: ${{ github.ref_name != 'master' && github.ref_name != 'val' && github.ref_name != 'prod' }}
     needs:
       - deploy
     runs-on: ubuntu-latest
@@ -108,14 +102,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: set branch_name
         run: |
-          echo "GITHUB_REF=${GITHUB_REF}"        
-          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then
-            echo "branch_name=`echo ${GITHUB_REF##*/*-} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
-          elif [[ "$GITHUB_REF" =~ ^refs/.*/snyk-* ]]; then
-            echo "branch_name=`echo ${GITHUB_REF##*/*-} | head -c 10 | sed 's/^/s/'`" >> $GITHUB_ENV
-          else
-            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          fi
+          BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
       - name: set branch specific variable names
         id: set_names
         run: ./.github/build_vars.sh set_names

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,6 +1,7 @@
 name: Destroy
 
-on: delete
+on: 
+  delete:
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,6 +1,11 @@
 name: Destroy
 
 on: delete
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Name of the environment to destroy:"
+        required: true
 
 permissions:
   id-token: write
@@ -14,17 +19,23 @@ jobs:
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
-    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "val", "prod"]'), github.event.ref)
+    if: |
+      (
+        github.event.ref_type == 'branch' &&
+        (!startsWith(github.event.ref, 'skipci')) &&
+        (!contains(fromJson('["master", "val", "production"]'), github.event.ref))
+      ) ||
+      (
+        inputs.environment != '' &&
+        (!contains(fromJson('["master", "val", "production"]'), inputs.environment))
+      )
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: set branch_name
         run: |
-          if [[ "${{ github.event.ref }}" =~ ^dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${{ github.event.ref }} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
-          else
-            echo "branch_name=${{ github.event.ref }}" >> $GITHUB_ENV
-          fi
-      - uses: actions/checkout@v3
+          BRANCH_NAME=$(./.github/setBranchName.sh ${{ inputs.environment || github.event.ref }})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names
       - name: set variable values

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -24,11 +24,11 @@ jobs:
       (
         github.event.ref_type == 'branch' &&
         (!startsWith(github.event.ref, 'skipci')) &&
-        (!contains(fromJson('["master", "val", "production"]'), github.event.ref))
+        (!contains(fromJson('["master", "val", "prod"]'), github.event.ref))
       ) ||
       (
         inputs.environment != '' &&
-        (!contains(fromJson('["master", "val", "production"]'), inputs.environment))
+        (!contains(fromJson('["master", "val", "prod"]'), inputs.environment))
       )
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -32,7 +32,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set branch_name
         run: |
           BRANCH_NAME=$(./.github/setBranchName.sh ${{ inputs.environment || github.event.ref }})

--- a/destroy.sh
+++ b/destroy.sh
@@ -35,6 +35,16 @@ set -e
 # Find cloudformation stacks associated with stage
 stackList=(`aws cloudformation describe-stacks | jq -r ".Stacks[] | select(.Tags[] | select(.Key==\"STAGE\") | select(.Value==\"$stage\")) | .StackName"`)
 
+if [ ${#stackList[@]} -eq 0 ]; then
+    echo """
+      ---------------------------------------------------------------------------------------------
+      ERROR: No stacks were identified for destruction
+      ---------------------------------------------------------------------------------------------
+      Please verify the stage name:  $stage
+    """
+    exit 1
+fi
+
 # Find buckets attached to any of the stages, so we can empty them before removal.
 bucketList=()
 set +e


### PR DESCRIPTION
### Description

The purpose of this pull request is to correct destroy actions for Snyk or Dependabot created branches by providing a consistent means to generate shortened stage names from autogenerated branches that may exceed Cloudformation length requirements when prefixed to services managed by Cloudformation stacks.  Additionally, this pull request adds the ability to trigger destroy actions manually against any non-protected target using any Github hosted branch.

- `GITHUB_REF` environment variable is the same as `github.ref` and includes the fully qualified path
- Destroy actions always trigger on the default branch so `GITHUB_REF`/`github.ref` would be `/refs/heads/master`
- Destroy actions know what the target is based on `github.event.ref` which is NOT the fully qualified path
- Defining `workflow_dispatch` enables manual triggering destroy actions against a given code base and enables specifying target.

The changes in this pull request do the following:
- Apply consistent lookups in Deploy (concurrency lock would be deploy-[branch] rather than deploy-/refs/heads/[branch])
- Remove hard coded addition to destroy action which would break if a tag is deleted
- Enable manual dispatching of events.

For other repositories which may differ in structure, it is suggested that the `workflow_dispatch` be added as an initial pull request, as this has to make it to the default stage before it can be acted upon.  This will enable development against destroy actions which can only trigger from the default branch until the configuration change is merged.

<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3257

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Once this has been merged...

Create three branches

dependabot/npm_and_yarn/berry-did-this
snyk-upgrade-berry-did-this9faf06c882b46cc4a8e83
berry-test
Push and wait for builds to succeed.

Delete the remote branches and verify the destroy step completes.

Create one more branch, any arbitrary name, and add echo this is a test && exit 1 to the destroy yaml file at line 37. Exercise the manual trigger and verify the update in the unmerged branch is executed in the destroy step

### Important updates

No functional changes should be experienced during normal development activities.  The changes do include some minor refactoring of how references are leveraged, but the functional changes should apply to Snyk and Dependabot created branches with the addition of Github actions manual triggering from the destroy workflow.

As of the time of writing of this pull request, the following are the remote branches for this product, and the highlighted ones are the ones this pull requests asserts to be protected:
  origin/berry-test
  origin/deployed-login
  origin/entjira
  origin/fix-snykdependa-destroy
  origin/iam
  **origin/master**
  **origin/prod**
  origin/skipci-fix-snyc-jira-sync
  origin/skipci-whitelist-gha-cidrs
  origin/snyk-fix-2b8efea0f3610daa3da7981342c7806d
  origin/snyk-upgrade-0423a0cea1480868aaa764d684553e91
  origin/snyk-upgrade-051019ec32e59ecdb41dc5984b09a5b2
  origin/snyk-upgrade-796c34068a569533c3116c7807574d9c
  origin/snyk-upgrade-8aa0ba3488495e9c428d253b5eada593
  origin/snyk-upgrade-ba6915d13282c86e0c0f201e6a32b181
  origin/snyk-upgrade-ce82709dd58d0031edf2aa9149be08e2
  origin/snyk-upgrade-e23107549426666253c1ebf267ca2955
  origin/tealium-3288
  **origin/val**
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
