### PR TITLE
OPM - Describe Rate Validation

### DIFF
--- a/services/ui-src/src/measures/2024/shared/globalValidations/omsValidator/index.test.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/omsValidator/index.test.ts
@@ -126,4 +126,31 @@ describe("Testing OMS validation processor", () => {
     });
     expect(errors.length).toBe(74);
   });
+
+  it("should have errors from empty rate description in OPM", () => {
+    const errors = omsValidations({
+      categories,
+      qualifiers,
+      locationDictionary,
+      dataSource: [],
+      data: {
+        MeasurementSpecification: "Other",
+        "OtherPerformanceMeasure-Rates": [
+          {
+            rate: [
+              {
+                denominator: "",
+                numerator: "",
+                rate: "",
+              },
+            ],
+            description: "",
+          },
+        ],
+      } as DefaultFormData,
+      validationCallbacks: [],
+    });
+
+    expect(errors.length).toBe(1);
+  });
 });

--- a/services/ui-src/src/measures/2024/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/omsValidator/index.ts
@@ -349,5 +349,14 @@ const validateNDRs = (
       }
     }
   }
+
+  //check to see if the rate has been described for other performance measure
+  if (isOPM && qualifiers.find((qual) => !qual.label)) {
+    errorArray.push({
+      errorLocation: `Other Performance Measure Error`,
+      errorMessage: "Rate name required",
+    });
+  }
+
   return errorArray;
 };

--- a/services/ui-src/src/measures/2024/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/omsValidator/index.ts
@@ -353,7 +353,7 @@ const validateNDRs = (
   //check to see if the rate has been described for other performance measure
   if (isOPM && qualifiers.find((qual) => !qual.label)) {
     errorArray.push({
-      errorLocation: `Other Performance Measure Error`,
+      errorLocation: `Other Performance Measure`,
       errorMessage: "Rate name required",
     });
   }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The entering Other Performance Measure, there is no validation for checking whether the user had provided a description for the rate. This PR adds a validation to trigger when the textbox is empty.

![Screenshot 2024-02-13 at 11 46 29 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/50722b91-c55b-4f8e-8577-3ac589850579)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3293

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR
2) Select any coreset where [Measurement Specification] has an [Other] radio button.
3) Select [Other] to enable the Other Performance Measure section
4) Try to validate without filling out the rate description
5) The validation error message from above should show up
6) Fill out the rate description textbox and validate again
7) The message should go away

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
