### PR TITLE
CMDCT-3295: Landing Page Content Update

### DIFF
--- a/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
+++ b/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
@@ -82,7 +82,7 @@ export const AddCoreSetCards = ({
           coreSetExists={healthHomesCoreSetExists}
         />
       )}
-      {year !== "2024" && (
+      {year && parseInt(year) >= 2024 && (
         <CUI.Center w="44" textAlign="center">
           <CUI.Text fontStyle="italic" fontSize="sm">
             Only one group of Adult Core Set Measures can be submitted per FFY

--- a/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
+++ b/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
@@ -65,6 +65,7 @@ export const AddCoreSetCards = ({
   healthHomesCoreSetExists,
   renderHealthHomeCoreSet = true,
 }: Props) => {
+  const { year } = useParams();
   return (
     <>
       <AddCoreSetCard
@@ -81,11 +82,13 @@ export const AddCoreSetCards = ({
           coreSetExists={healthHomesCoreSetExists}
         />
       )}
-      <CUI.Center w="44" textAlign="center">
-        <CUI.Text fontStyle="italic" fontSize="sm">
-          Only one group of Adult Core Set Measures can be submitted per FFY
-        </CUI.Text>
-      </CUI.Center>
+      {year !== "2024" && (
+        <CUI.Center w="44" textAlign="center">
+          <CUI.Text fontStyle="italic" fontSize="sm">
+            Only one group of Adult Core Set Measures can be submitted per FFY
+          </CUI.Text>
+        </CUI.Center>
+      )}
     </>
   );
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
For the FFY2024 landing page, the BOs have requested the removal of this text:

![Screenshot 2024-02-13 at 3 21 35 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/65b1f879-b78a-4167-94bf-7a0cb09b79f3)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3295

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user

You should not see that text area for 2024, but it should be visible for other years.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
