### PR TITLE
Measure Eligible Population Validation

### DIFF
--- a/services/ui-src/src/dataConstants.ts
+++ b/services/ui-src/src/dataConstants.ts
@@ -13,6 +13,7 @@ export const AHRQ_NCQA = "AHRQ-NCQA";
 export const AMOUNT_OF_POP_NOT_COVERED = "AmountOfPopulationNotCovered";
 export const BUDGET_CONSTRAINTS = "BudgetConstraints";
 export const CASE_MANAGEMENT_RECORD_REVIEW = "Case management record review";
+export const CASE_MANAGEMENT_RECORD_REVIEW_DATA = "Casemanagementrecordreview";
 export const CATEGORIES = "categories";
 export const CDC = "CDC";
 export const CHANGE_IN_POP_EXPLANATION = "ChangeInPopulationExplanation";

--- a/services/ui-src/src/measures/2024/CBPAD/validation.ts
+++ b/services/ui-src/src/measures/2024/CBPAD/validation.ts
@@ -42,6 +42,7 @@ const CBPValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),

--- a/services/ui-src/src/measures/2024/CBPHH/validation.ts
+++ b/services/ui-src/src/measures/2024/CBPHH/validation.ts
@@ -42,6 +42,7 @@ const CBPValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),

--- a/services/ui-src/src/measures/2024/CCSAD/validation.ts
+++ b/services/ui-src/src/measures/2024/CCSAD/validation.ts
@@ -50,6 +50,7 @@ const CCSADValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2024/CISCH/validation.ts
+++ b/services/ui-src/src/measures/2024/CISCH/validation.ts
@@ -49,8 +49,9 @@ const CISCHValidation = (data: FormData) => {
       PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
-    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2024/CPUAD/validation.ts
+++ b/services/ui-src/src/measures/2024/CPUAD/validation.ts
@@ -45,9 +45,9 @@ const CPUADValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
-    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
-
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       didCalculationsDeviate,
       deviationReason

--- a/services/ui-src/src/measures/2024/DEVCH/validation.ts
+++ b/services/ui-src/src/measures/2024/DEVCH/validation.ts
@@ -50,8 +50,9 @@ const DEVCHValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
-    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2024/HBDAD/validation.ts
+++ b/services/ui-src/src/measures/2024/HBDAD/validation.ts
@@ -59,6 +59,7 @@ const HBDADValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2024/HPCMIAD/validation.ts
+++ b/services/ui-src/src/measures/2024/HPCMIAD/validation.ts
@@ -49,8 +49,9 @@ const HPCMIADValidation = (data: FormData) => {
     ...GV.validateYearFormat(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
-    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2024/IMACH/validation.ts
+++ b/services/ui-src/src/measures/2024/IMACH/validation.ts
@@ -51,8 +51,9 @@ const DEVCHValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
-    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2024/LSCCH/validation.ts
+++ b/services/ui-src/src/measures/2024/LSCCH/validation.ts
@@ -26,6 +26,7 @@ const LSCCHValidation = (data: FormData) => {
     ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2024/PPCAD/validation.ts
+++ b/services/ui-src/src/measures/2024/PPCAD/validation.ts
@@ -50,6 +50,7 @@ const PPCADValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2024/PPCCH/validation.ts
+++ b/services/ui-src/src/measures/2024/PPCCH/validation.ts
@@ -50,6 +50,7 @@ const PPCCHValidation = (data: FormData) => {
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2024/WCCCH/validation.ts
+++ b/services/ui-src/src/measures/2024/WCCCH/validation.ts
@@ -37,6 +37,7 @@ const WCCHValidation = (data: FormData) => {
   errorArray = [
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateHybridMeasurePopulation(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),

--- a/services/ui-src/src/measures/2024/shared/globalValidations/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/index.ts
@@ -4,6 +4,7 @@ export * as Types from "./types";
 
 export * from "./validateAtLeastOneDataSource";
 export * from "./validateAtLeastOneDefinitionOfPopulation";
+export * from "./validateHybridMeasurePopulation";
 export * from "./validateAtLeastOneDataSourceType";
 export * from "./validateAtLeastOneDeliverySystem";
 export * from "./validateAtLeastOneDeviationFieldFilled";

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateHybridMeasurePopulation/index.test.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateHybridMeasurePopulation/index.test.ts
@@ -1,0 +1,56 @@
+import { testFormData } from "../testHelpers/_testFormData";
+import * as DC from "dataConstants";
+import { validateHybridMeasurePopulation } from ".";
+
+describe("validateHybridMeasurePopulation", () => {
+  let formData: any;
+  let errorArray: FormError[];
+
+  const _check_errors = (data: any, numErrors: number) => {
+    errorArray = [...validateHybridMeasurePopulation(data)];
+    expect(errorArray.length).toBe(numErrors);
+  };
+
+  beforeEach(() => {
+    formData = JSON.parse(JSON.stringify(testFormData)); // reset data
+    errorArray = [];
+  });
+
+  it("When no Data Source is selected, no validation warning shows", () => {
+    formData[DC.DEFINITION_OF_DENOMINATOR] = [];
+    _check_errors(formData, 0);
+  });
+
+  it("When Data Source - Hybrid is selected, a validation warning will show", () => {
+    formData[DC.DATA_SOURCE] = [
+      DC.HYBRID_ADMINSTRATIVE_AND_MEDICAL_RECORDS_DATA,
+    ];
+    _check_errors(formData, 1);
+  });
+
+  it("When Data Source - Case management record review is selected, a validation warning will show", () => {
+    formData[DC.DATA_SOURCE] = [DC.CASE_MANAGEMENT_RECORD_REVIEW_DATA];
+    _check_errors(formData, 1);
+  });
+
+  it("Error message text should match default errorMessage", () => {
+    formData[DC.DATA_SOURCE] = [
+      DC.HYBRID_ADMINSTRATIVE_AND_MEDICAL_RECORDS_DATA,
+    ];
+    errorArray = [...validateHybridMeasurePopulation(formData)];
+    expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe(
+      "Size of the measure-eligible population is required"
+    );
+  });
+
+  it("Error message text should match provided errorMessage", () => {
+    formData[DC.DATA_SOURCE] = [
+      DC.HYBRID_ADMINSTRATIVE_AND_MEDICAL_RECORDS_DATA,
+    ];
+    const errorMessage = "Another one bites the dust.";
+    errorArray = [...validateHybridMeasurePopulation(formData, errorMessage)];
+    expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe(errorMessage);
+  });
+});

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateHybridMeasurePopulation/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateHybridMeasurePopulation/index.ts
@@ -1,0 +1,25 @@
+import {
+  CASE_MANAGEMENT_RECORD_REVIEW_DATA,
+  HYBRID_ADMINSTRATIVE_AND_MEDICAL_RECORDS_DATA,
+} from "dataConstants";
+import * as Types from "measures/2024/shared/CommonQuestions/types";
+
+export const validateHybridMeasurePopulation = (
+  data: Types.DefaultFormData,
+  errorMessage?: string
+) => {
+  const errorArray: FormError[] = [];
+  if (
+    data.DataSource?.includes(HYBRID_ADMINSTRATIVE_AND_MEDICAL_RECORDS_DATA) ||
+    data.DataSource?.includes(CASE_MANAGEMENT_RECORD_REVIEW_DATA)
+  ) {
+    if (!data.HybridMeasurePopulationIncluded) {
+      errorArray.push({
+        errorLocation: "Definition of Population",
+        errorMessage:
+          errorMessage ?? "Size of the measure-eligible population is required",
+      });
+    }
+  }
+  return errorArray;
+};


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Certain measures have a data source option "Hybrid (Administrative and Medical Records Data)" or "Case management record review". When a user selects them, they new need to provide information here:
![Screenshot 2024-02-13 at 4 31 23 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/b8a4cc40-3bf9-4789-9ff4-0d28d1466ea6)

This PR adds a new validation that pops up if you don't fill that textbox
![Screenshot 2024-02-13 at 4 32 58 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/95931db4-11ea-45cb-96ec-1dcac3878efe)
lidation


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3294

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR
2) In adult coreset, select CBP-AD or any measure that captures hybrid data.
3) In the Data Source selection, check [Hybrid (Administrative and Medical Records Data)]
4) Scroll all the way down and validate
5) This should cause the error message to show up
6) Fill out [What is the size of the measure-eligible population?]
7) Scroll back down to validate and that should clear the error message.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
