### PR TITLE
Remove signup email configuration, unused, revert to default account

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -36,7 +36,6 @@ custom:
       - master
       - val
       - prod
-  sesSourceEmailAddress: ${ssm:/configuration/${self:custom.stage}/sesSourceEmailAddress, ssm:/configuration/default/sesSourceEmailAddress, ""}
   attachments_bucket_arn: ${cf:uploads-${self:custom.stage}.AttachmentsBucketArn}
   api_gateway_rest_api_name: ${cf:app-api-${self:custom.stage}.ApiGatewayRestApiName}
   okta_metadata_url: ${ssm:/configuration/${self:custom.stage}/okta_metadata_url, ""}
@@ -61,11 +60,6 @@ functions:
 
 resources:
   Conditions:
-    CreateEmailConfiguration:
-      Fn::Not:
-        - Fn::Equals:
-            - ""
-            - ${self:custom.sesSourceEmailAddress}
     BackWithOkta:
       Fn::Not:
         - Fn::Equals:
@@ -80,12 +74,6 @@ resources:
           - email
         AutoVerifiedAttributes:
           - email
-        EmailConfiguration:
-          Fn::If:
-            - CreateEmailConfiguration
-            - EmailSendingAccount: DEVELOPER
-              SourceArn: !Sub arn:aws:ses:us-east-1:${AWS::AccountId}:identity/${self:custom.sesSourceEmailAddress}
-            - !Ref AWS::NoValue
         Schema:
           - Name: given_name
             AttributeDataType: String


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Remove a chunk of the logic about where emails come from when signing up in cognito. This functionality is no longer used in seds, all test accounts in lower envs are created via seeding.

Proved it worked in SEDS [PR](https://github.com/Enterprise-CMCS/macpro-mdct-seds/pull/14810).

The stream functions service still references the ssm params for these emails, but not the ARNs and should continue to deploy fine. The functions there that trigger emails already do not work and are likely dead code, but I am in the process of verifying that officially.

This will unblock deployments for now.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
