### PR TITLE
[Fix] SS-HH Cypress Test

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -68,6 +68,12 @@ Cypress.Commands.add("goToHealthHomeSetMeasures", () => {
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find('[data-cy^="HHCS"]').length > 0) {
       cy.get('[data-cy^="HHCS"]').first().click();
+    } else {
+      // adds first available HH core set if no healthhome was made
+      cy.get('[data-cy="add-hhbutton"]').click(); // clicking on adding child core set measures
+      cy.get('[data-cy="HealthHomeCoreSet-SPA"]').select(1); // select first available SPA
+      cy.get('[data-cy="Create"]').click(); //clicking create
+      cy.get('[data-cy^="HHCS"]').first().click();
     }
   });
 });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Have you personally suffered from SS-HH cypress test just failing endlessly. The struggles of re-running the job over and over again because of this one script? The time wasted, the frustration, the senselessness of it all.

With this PR, I hope to fix this. Due to the inconsistent run order of the cypress test, the Health Home core measures sometimes gets deleted before its able to run the cypress test for HH, thereby causing the test to fail. SS-HH is trying to engage as if there's already a Health Home created when there isn't. This PR adds to the conditional that if there is no health home generated, go through the process to add it.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Cypress test should pass on this PR and locally

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
