### PR TITLE
CMDCT-3336 - Disable size restriction for pdf

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -37,6 +37,9 @@ custom:
   region: ${opt:region, self:provider.region}
   wafPlugin:
     name: ${self:service}-${self:custom.stage}-webacl-waf
+  wafExcludeRules:
+    awsCommon:
+      - "SizeRestrictions_BODY"
   serverlessTerminationProtection:
     stages:
       - master


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Excludes the SizeRestriction_Body aws common rule that the waf plugin recently added. The rule is preventing PDF api calls from getting through.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-3336

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
The PDF call should not error with a 403 forbidden on the deployed branch. It may still return an error if the ephem branches aren't configured for Prince, but it should at least be new and exciting. At that point, master and val should be back in business if we can remove the 403.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
