### PR TITLE
Cypress SS-HH Fix 2

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -278,6 +278,15 @@ const _detailedDescription =
 Cypress.Commands.add(
   "addStateSpecificMeasure",
   (description = _description, detailedDescription = _detailedDescription) => {
+    //possible fix, cypress sometimes says the add button is disabled, and that usually happens when 5 ss has been added.
+    cy.get('[data-cy="add-ssm-button"]').then(($btn) => {
+      //if button turns out to be disable, try deleting a SS before proceeding
+      if ($btn.is(":disabled")) {
+        cy.get('tr [data-cy="undefined-kebab-menu"]').last().click();
+        cy.get('[data-cy="Delete"]').last().click();
+        cy.get('[data-cy="delete-table-item-input"]').type("DELETE{enter}");
+      }
+    });
     cy.get('[data-cy="add-ssm-button"]').click();
     cy.get('[data-cy="add-ssm.0.description"]').type(description);
     cy.get('[data-cy="add-ssm.0.detailedDescription"]').type(

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -68,6 +68,12 @@ Cypress.Commands.add("goToHealthHomeSetMeasures", () => {
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find('[data-cy^="HHCS"]').length > 0) {
       cy.get('[data-cy^="HHCS"]').first().click();
+    } else {
+      // adds first available HH core set if no healthhome was made
+      cy.get('[data-cy="add-hhbutton"]').click(); // clicking on adding child core set measures
+      cy.get('[data-cy="HealthHomeCoreSet-SPA"]').select(1); // select first available SPA
+      cy.get('[data-cy="Create"]').click(); //clicking create
+      cy.get('[data-cy^="HHCS"]').first().click();
     }
   });
 });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Recently failures have shown me that there might be another step where SS-HH gets caught and that is when "Add State Specific Measure" button becomes disabled. My running theory is that during the whole cypress cycle, somehow 5 SS-HH gets added (that's the max allowed) and that is why the button is disabled. This fix will remove the last added  SS-HH before trying to add a new one.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Cypress local and github actions needs to pass

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
