### PR TITLE
Bug: Fix Display Logic for Core Set Text

### DIFF
--- a/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
+++ b/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
@@ -82,7 +82,7 @@ export const AddCoreSetCards = ({
           coreSetExists={healthHomesCoreSetExists}
         />
       )}
-      {year && parseInt(year) >= 2024 && (
+      {year && parseInt(year) < 2024 && (
         <CUI.Center w="44" textAlign="center">
           <CUI.Text fontStyle="italic" fontSize="sm">
             Only one group of Adult Core Set Measures can be submitted per FFY


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The following text area should not be displayed for 2024 and onward:

![Screenshot 2024-02-29 at 11 09 22 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/b09b1b0f-7c14-4e42-8b8e-5b5db862366f)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Verify that the highlighted text above isn't visible for FFY2024

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
