### PR TITLE
Cypress test to 2024

### DIFF
--- a/tests/cypress/cypress/e2e/a11y/PPC2CHpage.spec.ts
+++ b/tests/cypress/cypress/e2e/a11y/PPC2CHpage.spec.ts
@@ -1,9 +1,11 @@
+import { testingYear } from "../../../support/constants";
+
 describe("PPC-CH Page 508 Compliance Test", () => {
   it("Check a11y on PPC-CH Page", () => {
     cy.login();
-    cy.selectYear("2023");
+    cy.selectYear(testingYear);
     cy.goToChildCoreSetMeasures();
-    cy.goToMeasure("PPC-CH");
+    cy.goToMeasure("PPC2-CH");
     cy.checkA11yOfPage();
   });
 });

--- a/tests/cypress/cypress/e2e/features/export_all_measures.spec.ts
+++ b/tests/cypress/cypress/e2e/features/export_all_measures.spec.ts
@@ -1,4 +1,4 @@
-import { measureAbbrList2023, testingYear } from "../../../support/constants";
+import { measureAbbrList2024, testingYear } from "../../../support/constants";
 
 describe("Export All Measures", () => {
   beforeEach(() => {
@@ -16,7 +16,7 @@ describe("Export All Measures", () => {
     cy.get('[data-cy="Export"]').first().click();
 
     // Check all measures + CSQ present
-    for (const measureAbbr of measureAbbrList2023.ADULT) {
+    for (const measureAbbr of measureAbbrList2024.ADULT) {
       cy.get(`#${measureAbbr}`).should("be.visible");
     }
     cy.get("#CSQ").should("be.visible");
@@ -38,7 +38,7 @@ describe("Export All Measures", () => {
     });
 
     // Check all measures + CSQ present
-    for (const measureAbbr of measureAbbrList2023.CHILD) {
+    for (const measureAbbr of measureAbbrList2024.CHILD) {
       cy.get(`#${measureAbbr}`).should("be.visible");
     }
     cy.get("#CSQ").should("be.visible");
@@ -60,7 +60,7 @@ describe("Export All Measures", () => {
     });
 
     // Check all measures + CSQ present
-    for (const measureAbbr of measureAbbrList2023.HEALTH_HOME) {
+    for (const measureAbbr of measureAbbrList2024.HEALTH_HOME) {
       cy.get(`#${measureAbbr}`).should("be.visible");
     }
     cy.get("#CSQ").should("be.visible");

--- a/tests/cypress/cypress/e2e/features/kebab_menu_measures.spec.ts
+++ b/tests/cypress/cypress/e2e/features/kebab_menu_measures.spec.ts
@@ -24,7 +24,7 @@ describe("Measure kebab menus", () => {
     cy.get('button[aria-label="View for AMM-AD"]').click();
     cy.get('[data-cy="state-layout-container"').should(
       "include.text",
-      "FFY 2023AMM-AD - Antidepressant Medication Management"
+      "FFY 2024AMM-AD - Antidepressant Medication Management"
     );
   });
 });

--- a/tests/cypress/cypress/e2e/features/reporting_in_FY24_tag_for_alt_data_sources.spec.ts
+++ b/tests/cypress/cypress/e2e/features/reporting_in_FY24_tag_for_alt_data_sources.spec.ts
@@ -1,6 +1,6 @@
 import { testingYear } from "../../../support/constants";
 
-describe("OY2 15211 Reporting in FY22 Tag for Alt Data Sources", () => {
+describe("OY2 15211 Reporting in FY24 Tag for Alt Data Sources", () => {
   beforeEach(() => {
     cy.login("stateuser2");
     cy.selectYear(testingYear);
@@ -8,7 +8,7 @@ describe("OY2 15211 Reporting in FY22 Tag for Alt Data Sources", () => {
 
   it("N/A And Completed Statuses", () => {
     cy.get("a > [data-cy='ACS']").click();
-    cy.get("[data-cy='Reporting FFY 2023-NCIDDS-AD'] > p").should(
+    cy.get("[data-cy='Reporting FFY 2024-NCIDDS-AD'] > p").should(
       "have.text",
       "N/A"
     );

--- a/tests/cypress/cypress/e2e/features/submit_coreset.spec.ts
+++ b/tests/cypress/cypress/e2e/features/submit_coreset.spec.ts
@@ -1,4 +1,4 @@
-import { measureAbbrList2023, testingYear } from "../../../support/constants";
+import { measureAbbrList2024, testingYear } from "../../../support/constants";
 
 describe.skip("Submit Core Set button", () => {
   beforeEach(() => {
@@ -44,7 +44,7 @@ describe.skip("Submit Core Set button", () => {
   it("should require qualifiers to submit the core set", () => {
     // complete all measures
     cy.goToAdultMeasures();
-    for (const abbr of measureAbbrList2023.ADULT) {
+    for (const abbr of measureAbbrList2024.ADULT) {
       completeMeasure(abbr);
     }
     cy.get('[data-cy="Submit Core Set"]').should("be.disabled");
@@ -92,7 +92,7 @@ describe.skip("Submit Core Set button", () => {
     );
 
     // Edit a measure
-    cy.goToMeasure(measureAbbrList2023.ADULT[0]);
+    cy.goToMeasure(measureAbbrList2024.ADULT[0]);
     cy.get('[data-cy="Save"]').click();
     cy.wait(1000);
 
@@ -292,7 +292,7 @@ const completeMeasure = (measureName: string) => {
 
 const qualifierTestSetup = (abbrList: string, statusString: string) => {
   // complete all measures
-  for (const abbr of measureAbbrList2023[abbrList]) {
+  for (const abbr of measureAbbrList2024[abbrList]) {
     completeMeasure(abbr);
   }
 
@@ -312,13 +312,13 @@ const qualifierTestSetup = (abbrList: string, statusString: string) => {
   let numComplete = 0;
   switch (abbrList) {
     case "ADULT":
-      numComplete = measureAbbrList2023[abbrList].length + 1;
+      numComplete = measureAbbrList2024[abbrList].length + 1;
       break;
     case "CHILD":
-      numComplete = measureAbbrList2023[abbrList].length + 3;
+      numComplete = measureAbbrList2024[abbrList].length + 3;
       break;
     default:
-      numComplete = measureAbbrList2023[abbrList].length;
+      numComplete = measureAbbrList2024[abbrList].length;
   }
   cy.get(`[data-cy="Status-${statusString}"]`).should(
     "contain.text",

--- a/tests/cypress/cypress/e2e/init/create_delete_child.spec.ts
+++ b/tests/cypress/cypress/e2e/init/create_delete_child.spec.ts
@@ -27,4 +27,5 @@ const createChildCoreSetByYear = (year) => {
 };
 
 createChildCoreSetByYear(testingYear);
+createChildCoreSetByYear("2023");
 createChildCoreSetByYear("2021");

--- a/tests/cypress/cypress/e2e/measures/adult/PPCAD.spec.ts
+++ b/tests/cypress/cypress/e2e/measures/adult/PPCAD.spec.ts
@@ -31,6 +31,8 @@ describe("Measure: PPC-AD", () => {
 
     cy.enterValidDateRange();
 
+    cy.get('[data-cy="HybridMeasurePopulationIncluded"]').type("0");
+
     cy.get('[data-cy="PerformanceMeasure.rates.SyrrI1.0.numerator"]').type("0");
     cy.get('[data-cy="PerformanceMeasure.rates.SyrrI1.0.denominator"]').type(
       "5"

--- a/tests/cypress/cypress/e2e/measures/child/ADDCH.spec.ts
+++ b/tests/cypress/cypress/e2e/measures/child/ADDCH.spec.ts
@@ -156,13 +156,13 @@ describe("Measure: oy2-9921 ADD-CH", () => {
       "have.text",
       "Percentage of children newly prescribed attention-deficit/hyperactivity disorder (ADHD) medication who had at least three follow-up care visits within a 10-month period, one of which was within 30 days of when the first ADHD medication was dispensed. Two rates are reported."
     );
-    cy.get(".css-1af6wus > :nth-child(1) > .css-0").should(
+    cy.get(".css-1crglu1 > .css-0:nth-child(1)").should(
       "have.text",
-      "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication, who had one follow-up visit with a practitioner with prescribing authority during the 30-day Initiation Phase."
+      "Initiation PhasePercentage of children ages 6 to 12 with a prescription dispensed for ADHD medication, who had one follow-up visit with a practitioner with prescribing authority during the 30-day Initiation Phase."
     );
-    cy.get(".css-1af6wus > :nth-child(2) > .css-0").should(
+    cy.get(".css-1crglu1 > .css-0:nth-child(2)").should(
       "have.text",
-      "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication who remained on the medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended."
+      "Continuation and Maintenance (C&M) PhasePercentage of children ages 6 to 12 with a prescription dispensed for ADHD medication who remained on the medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended."
     );
     cy.get(
       '[data-cy="If this measure has been reported by the state previously and there has been a substantial change in the rate or measure-eligible population, please provide any available context below:"]'

--- a/tests/cypress/cypress/e2e/measures/child/PPC2CH.spec.ts
+++ b/tests/cypress/cypress/e2e/measures/child/PPC2CH.spec.ts
@@ -1,9 +1,11 @@
+import { testingYear } from "../../../../support/constants";
+
 describe("Measure: PPC-CH", () => {
   beforeEach(() => {
     cy.login();
-    cy.selectYear("2023");
+    cy.selectYear(testingYear);
     cy.goToChildCoreSetMeasures();
-    cy.goToMeasure("PPC-CH");
+    cy.goToMeasure("PPC2-CH");
   });
 
   it("Ensure correct sections display if user is/not reporting", () => {
@@ -60,11 +62,13 @@ describe("Measure: PPC-CH", () => {
       "have.text",
       "Performance Measure"
     );
-    cy.get(
-      '[data-cy="Prenatal care visit in the first trimester, on or before the enrollment start date or within 42 days of enrollment in Medicaid/CHIP."]'
-    ).should(
+    cy.get(".css-xiz5n3 > .css-0:nth-child(1)").should(
       "have.text",
-      "Prenatal care visit in the first trimester, on or before the enrollment start date or within 42 days of enrollment in Medicaid/CHIP."
+      "Timeliness of Prenatal Care: Percentage of deliveries that received a prenatal care visit in the first trimester, on or before the enrollment start date or within 42 days of enrollment in Medicaid/CHIP."
+    );
+    cy.get(".css-xiz5n3 > .css-0:nth-child(2)").should(
+      "have.text",
+      "Postpartum Care: Percentage of deliveries that had a postpartum visit on or between 7 and 84 days after delivery."
     );
   });
 

--- a/tests/cypress/cypress/e2e/measures/child/QUALIFIERS_child.spec.ts
+++ b/tests/cypress/cypress/e2e/measures/child/QUALIFIERS_child.spec.ts
@@ -16,7 +16,7 @@ describe("Child Measure Qualifier: CH", () => {
     cy.get("body").should("include.text", "Delivery System");
     cy.get("body").should(
       "include.text",
-      "As of September 30, 2022 what percentage of your Medicaid/CHIP enrollees (under age 21) were enrolled in each delivery system?"
+      "As of September 30, 2023 what percentage of your Medicaid/CHIP enrollees (under age 21) were enrolled in each delivery system?"
     );
     cy.get('[data-cy="PercentageEnrolledInEachDeliverySystem.0.label"]').should(
       "have.value",

--- a/tests/cypress/cypress/e2e/measures/child/QUALIFIERS_child.spec.ts
+++ b/tests/cypress/cypress/e2e/measures/child/QUALIFIERS_child.spec.ts
@@ -122,7 +122,7 @@ describe("Child Measure Qualifier: CH", () => {
       '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-OEV-CH - Oral Evaluation, Dental Services"]'
     ).should("be.visible");
     cy.get(
-      '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-PPC-CH - Prenatal and Postpartum Care: Timeliness of Prenatal Care"]'
+      '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-PPC2-CH - Prenatal and Postpartum Care: Under Age 21"]'
     ).should("be.visible");
     cy.get(
       '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-SFM-CH - Sealant Receipt on Permanent First Molars"]'

--- a/tests/cypress/cypress/e2e/measures/healthhome/QUALIFIERS_healthhome.spec.ts
+++ b/tests/cypress/cypress/e2e/measures/healthhome/QUALIFIERS_healthhome.spec.ts
@@ -71,9 +71,9 @@ describe("Health Home Measure Qualifier: HH", () => {
 
     //testing section 2 with fields inside it
     cy.get("body").should("include.text", "Cost Savings Data");
-    cy.get('[data-cy="Amount of cost savings for FFY 2022"]').should(
+    cy.get('[data-cy="Amount of cost savings for FFY 2023"]').should(
       "include.text",
-      "Amount of cost savings for FFY 2022"
+      "Amount of cost savings for FFY 2023"
     );
     cy.get('[data-cy="yearlyCostSavings"]').clear();
     cy.get('[data-cy="yearlyCostSavings"]').type("1234567890");
@@ -95,7 +95,7 @@ describe("Health Home Measure Qualifier: HH", () => {
     cy.get("body").should("include.text", "Delivery System");
     cy.get("body").should(
       "include.text",
-      "As of September 30, 2022 what percentage of your Medicaid Health Home enrollees were enrolled in each delivery system?"
+      "As of September 30, 2023 what percentage of your Medicaid Health Home enrollees were enrolled in each delivery system?"
     );
     cy.get("body").should("include.text", "Ages 0 to 17");
     cy.get("body").should("include.text", "Ages 18 to 64");

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -59,6 +59,12 @@ Cypress.Commands.add("goToChildCoreSetMeasures", () => {
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find('[data-cy="CCS"]').length > 0) {
       cy.get('[data-cy="CCS"]').click();
+    } else {
+      //add child core set if not child core was made
+      cy.get('[data-cy="add-childbutton"]').click(); // clicking on adding child core set measures
+      cy.get("#ChildCoreSet-ReportType-separate").click(); //selecting combined core set
+      cy.get('[data-cy="Create"]').click(); //clicking create
+      cy.get('[data-cy="add-childbutton"]').should("be.disabled"); // check button diabled if created
     }
   });
 });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -59,12 +59,6 @@ Cypress.Commands.add("goToChildCoreSetMeasures", () => {
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find('[data-cy="CCS"]').length > 0) {
       cy.get('[data-cy="CCS"]').click();
-    } else {
-      //add child core set if not child core was made
-      cy.get('[data-cy="add-childbutton"]').click(); // clicking on adding child core set measures
-      cy.get("#ChildCoreSet-ReportType-separate").click(); //selecting combined core set
-      cy.get('[data-cy="Create"]').click(); //clicking create
-      cy.get('[data-cy="add-childbutton"]').should("be.disabled"); // check button diabled if created
     }
   });
 });

--- a/tests/cypress/support/constants.ts
+++ b/tests/cypress/support/constants.ts
@@ -58,7 +58,7 @@ export const measureAbbrList2024 = {
     "LRCD-CH", // complete on creation
     "LSC-CH",
     "OEV-CH",
-    "PPC-CH",
+    "PPC2-CH",
     "SFM-CH",
     "TFL-CH",
     "W30-CH",

--- a/tests/cypress/support/constants.ts
+++ b/tests/cypress/support/constants.ts
@@ -1,6 +1,6 @@
 export const testingYear = "2024";
 
-export const measureAbbrList2023 = {
+export const measureAbbrList2024 = {
   ADULT: [
     "AAB-AD",
     "AMM-AD",

--- a/tests/cypress/support/constants.ts
+++ b/tests/cypress/support/constants.ts
@@ -1,4 +1,4 @@
-export const testingYear = "2023";
+export const testingYear = "2024";
 
 export const measureAbbrList2023 = {
   ADULT: [


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently the cypress test is looking at Reporting Year 2023. This will update cypress year to look at reporting 2024.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3362

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
The cypress test passes.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
