### PR TITLE
Implement DocRaptor for PDF generation

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -23,3 +23,5 @@ MEASURE_TABLE_NAME=local-measures
 # LAUNCHDARKLY
 LD_PROJECT_KEY=mdct-qmr
 LD_SDK_KEY=sdk-25b0f45f-bb20-4223-aede-32d66b525721 #pragma allowlist secret
+
+docraptorApiKey=YOUR_API_KEY_HERE

--- a/.env_example
+++ b/.env_example
@@ -24,4 +24,4 @@ MEASURE_TABLE_NAME=local-measures
 LD_PROJECT_KEY=mdct-qmr
 LD_SDK_KEY=sdk-25b0f45f-bb20-4223-aede-32d66b525721 #pragma allowlist secret
 
-docraptorApiKey=YOUR_API_KEY_HERE
+docraptorApiKey=YOUR_API_KEY_HERE #pragma allowlist secret

--- a/.env_example
+++ b/.env_example
@@ -22,6 +22,6 @@ MEASURE_TABLE_NAME=local-measures
 
 # LAUNCHDARKLY
 LD_PROJECT_KEY=mdct-qmr
-LD_SDK_KEY=sdk-25b0f45f-bb20-4223-aede-32d66b525721 #pragma allowlist secret
+LD_SDK_KEY=sdk-25b0f45f-bb20-4223-aede-32d66b525721 #pragma: allowlist secret
 
-docraptorApiKey=YOUR_API_KEY_HERE #pragma allowlist secret
+docraptorApiKey=YOUR_API_KEY_HERE #pragma: allowlist secret

--- a/services/app-api/handlers/prince/pdf.ts
+++ b/services/app-api/handlers/prince/pdf.ts
@@ -1,11 +1,8 @@
-import handler from "../../libs/handler-lib";
-import { StatusCodes } from "../../utils/constants/constants";
-import { URL } from "url";
-import { SignatureV4 } from "@smithy/signature-v4";
-import { Sha256 } from "@aws-crypto/sha256-js";
-import { fetch } from "cross-fetch"; // TODO remove this polyfill once QMR is on Node 18+
+import { fetch } from "cross-fetch"; // TODO delete this line and uninstall this package, once QMR is running on Nodejs 18+
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
+import handler from "../../libs/handler-lib";
+import { StatusCodes } from "../../utils/constants/constants";
 
 const windowEmulator: any = new JSDOM("").window;
 const DOMPurify = createDOMPurify(windowEmulator);
@@ -15,64 +12,132 @@ export const getPDF = handler(async (event, _context) => {
   if (!rawBody) {
     throw new Error("Missing request body");
   }
-  let encodedSanitizedBody;
-  if (DOMPurify.isSupported && typeof rawBody === "string") {
-    // decode body from base64, sanitize dangerous html, encode back to base64
-    const decodedBody = Buffer.from(rawBody, "base64").toString();
-    const sanitizedBody = DOMPurify.sanitize(decodedBody);
-    encodedSanitizedBody = Buffer.from(sanitizedBody).toString("base64");
-  }
 
-  if (!encodedSanitizedBody) {
+  let sanitizedBody;
+  if (DOMPurify.isSupported && typeof rawBody === "string") {
+    // decode body from base64, sanitize dangerous html
+    const decodedBody = Buffer.from(rawBody, "base64").toString();
+    sanitizedBody = DOMPurify.sanitize(decodedBody);
+  }
+  if (!sanitizedBody) {
     throw new Error("Could not process request");
   }
 
-  const {
-    // princeApiHost: hostname, // JUST the host name, no protocol, ex: "my-site.cms.gov"
-    // princeApiPath: path, // Needs leading slash, ex: "/doc-conv/508html-to-508pdf"
-    princeUrl,
-    AWS_ACCESS_KEY_ID: accessKeyId,
-    AWS_SECRET_ACCESS_KEY: secretAccessKey,
-    AWS_SESSION_TOKEN: sessionToken,
-  } = process.env;
-
-  if (
-    princeUrl === undefined ||
-    accessKeyId === undefined ||
-    secretAccessKey === undefined ||
-    sessionToken === undefined
-  ) {
+  const { docraptorApiKey, stage } = process.env;
+  if (!docraptorApiKey) {
     throw new Error("No config found to make request to PDF API");
   }
 
-  const { hostname, pathname: path } = new URL(princeUrl);
-
-  const request = {
-    method: "POST",
-    protocol: "https",
-    hostname,
-    path,
-    headers: {
-      host: hostname, // Prince requires this to be signed
+  const requestBody = {
+    user_credentials: docraptorApiKey,
+    doc: {
+      document_content: sanitizedBody,
+      type: "pdf" as const,
+      // This tag differentiates QMR and CARTS requests in DocRaptor's logs.
+      tag: "QMR",
+      test: stage !== "prod",
+      prince_options: {
+        profile: "PDF/UA-1" as const,
+      },
     },
-    body: encodedSanitizedBody,
   };
 
-  const signer = new SignatureV4({
-    service: "execute-api",
-    region: "us-east-1",
-    credentials: { accessKeyId, secretAccessKey, sessionToken },
-    sha256: Sha256,
-  });
-
-  const signedRequest = await signer.sign(request);
-
-  const response = await fetch(`https://${hostname}${path}`, signedRequest);
-
-  const base64EncodedPdfData = await response.json();
-
+  const arrayBuffer = await sendDocRaptorRequest(requestBody);
+  const base64PdfData = Buffer.from(arrayBuffer).toString("base64");
   return {
     status: StatusCodes.SUCCESS,
-    body: base64EncodedPdfData,
+    body: base64PdfData,
   };
 });
+
+async function sendDocRaptorRequest(request: DocRaptorRequestBody) {
+  const response = await fetch("https://docraptor.com/docs", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+
+  await handlePdfStatusCode(response);
+
+  const pdfPageCount = response.headers.get("X-DocRaptor-Num-Pages");
+  console.debug(`Successfully generated a ${pdfPageCount}-page PDF.`);
+
+  return response.arrayBuffer();
+}
+
+/**
+ * If PDF generation was not successful, log the reason and throw an error.
+ *
+ * For more details see https://docraptor.com/documentation/api/status_codes
+ */
+async function handlePdfStatusCode(response: Response) {
+  if (response.status === 200) {
+    return;
+  }
+
+  const xmlErrorMessage = await response.text();
+  console.warn("DocRaptor Error Message:\n" + xmlErrorMessage);
+
+  switch (response.status) {
+    case 400: // Bad Request
+    case 422: // Unprocessable Entity
+      throw new Error("PDF generation failed - possibly an HTML issue");
+    case 401: // Unauthorized
+    case 403: // Forbidden
+      throw new Error(
+        "PDF generation failed - possibly a configuration or throttle issue"
+      );
+    default:
+      throw new Error(
+        `Received status code ${response.status} from PDF generation service`
+      );
+  }
+}
+
+type DocRaptorRequestBody = {
+  /** Your DocRaptor API key */
+  user_credentials: string;
+  doc: DocRaptorParameters;
+};
+
+/**
+ * Here is some in-band documentation for the more common DocRaptor options.
+ * There also options for JS handling, asset handling, PDF metadata, and more.
+ * Note that we do not use DocRaptor's hosting; we return the PDF directly.
+ * For more details see https://docraptor.com/documentation/api
+ */
+type DocRaptorParameters = {
+  /** Test documents are watermarked, but don't count against API limits. */
+  test?: boolean;
+  /** We only use `pdf`. */
+  type: "pdf" | "xls" | "xlsx";
+  /** The HTML to render. Either this or `document_url` is required. */
+  document_content?: string;
+  /** The URL to fetch and render. Either this or `document_content` is required. */
+  document_url?: string;
+  /** Synchronous calls have a 60s limit. Callbacks are required for longer-running docs. */
+  async?: false;
+  /** This name will show up in the logs: https://docraptor.com/doc_logs */
+  name?: string;
+  /** This tag will also show up in DocRaptor's logs. */
+  tag?: string;
+  /** Should DocRaptor run JS embedded in your HTML? Default is `false`. */
+  javascript?: boolean;
+  prince_options: {
+    /**
+     * In theory we can choose a different PDF version, but UA-1 is the only accessible one.
+     * https://docraptor.com/documentation/article/6637003-accessible-tagged-pdfs
+     */
+    profile: "PDF/UA-1";
+    /** The default is `print`. */
+    media?: "print" | "screen";
+    /** May be needed to load relative urls. Alternatively, use the `<base>` tag. */
+    baseurl?: string;
+    /** The title of your PDF. By default this is the `<title>` of your HTML. */
+    pdf_title?: string;
+    /** This may be used to override the default DPI of `96`. */
+    css_dpi?: number;
+  };
+};

--- a/services/app-api/handlers/prince/tests/pdf.test.ts
+++ b/services/app-api/handlers/prince/tests/pdf.test.ts
@@ -1,13 +1,9 @@
 import { getPDF } from "../pdf";
-
 import { fetch } from "cross-fetch";
 import { testEvent } from "../../../test-util/testEvents";
 
-jest.mock("../../../libs/debug-lib", () => ({
-  __esModule: true,
-  init: jest.fn(),
-  flush: jest.fn(),
-}));
+jest.spyOn(console, "error").mockImplementation();
+jest.spyOn(console, "warn").mockImplementation();
 
 jest.mock("../../../libs/authorization", () => ({
   isAuthenticated: jest.fn().mockReturnValue(true),
@@ -15,35 +11,21 @@ jest.mock("../../../libs/authorization", () => ({
 
 jest.mock("cross-fetch", () => ({
   fetch: jest.fn().mockResolvedValue({
-    // Base64 PDFs always start with JBVERi0, which is "%PDF-"
-    json: jest.fn().mockResolvedValue("JVBERi0xLjc="),
+    status: 200,
+    headers: {
+      get: jest.fn().mockResolvedValue("3"),
+    },
+    arrayBuffer: jest.fn().mockResolvedValue(
+      // An ArrayBuffer containing `%PDF-1.7`
+      new Uint8Array([37, 80, 68, 70, 45, 49, 46, 55]).buffer
+    ),
   }),
 }));
 
-jest.mock("@smithy/signature-v4", () => ({
-  SignatureV4: function () {
-    return {
-      sign: jest.fn().mockImplementation((request) => {
-        expect(request.headers).toHaveProperty("host", "princefakeurl.com");
-        return {
-          ...request,
-          headers: {
-            ...request.headers,
-            authorization: "mock authorization",
-          },
-        };
-      }),
-    };
-  },
-}));
-
 const dangerousHtml = "<p>abc<iframe//src=jAva&Tab;script:alert(3)>def</p>";
+const sanitizedHtml = "<p>abc</p>";
 const base64EncodedDangerousHtml =
   Buffer.from(dangerousHtml).toString("base64");
-
-const sanitizedHtml = "<p>abc</p>";
-const base64EncodedSanitizedHtml =
-  Buffer.from(sanitizedHtml).toString("base64");
 
 const noBodyEvent = {
   ...testEvent,
@@ -55,48 +37,77 @@ const dangerousHtmlBodyEvent = {
   body: base64EncodedDangerousHtml,
 };
 
-describe("Test GetPDF handler errors", () => {
-  test("Test throws error when no body provided", async () => {
+describe("Test GetPDF handler", () => {
+  beforeEach(() => {
+    process.env = {
+      docraptorApiKey: "mock api key", // pragma: allowlist secret
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should throw error when no body provided", async () => {
     const res = await getPDF(noBodyEvent, null);
+
     expect(res.statusCode).toBe(500);
     expect(res.body).toContain("Missing request body");
   });
 
-  test("Test throws error when body is not type string", async () => {
+  it("should throw error when body is not type string", async () => {
     const res = await getPDF(testEvent, null);
+
     expect(res.statusCode).toBe(500);
     expect(res.body).toContain("Could not process request");
   });
 
-  test("Test throws error when config not defined", async () => {
+  it("should throw error when config not defined", async () => {
+    delete process.env.docraptorApiKey;
+
     const res = await getPDF(dangerousHtmlBodyEvent, null);
+
     expect(res.statusCode).toBe(500);
     expect(res.body).toContain("No config found to make request to PDF API");
   });
-});
 
-describe("Test GetPDF handler", () => {
-  beforeEach(() => {
-    process.env = {
-      princeUrl: "https://princefakeurl.com/print",
-      AWS_ACCESS_KEY_ID: "FAKEKEY",
-      AWS_SECRET_ACCESS_KEY: "FAKESECRET", // pragma: allowlist secret
-      AWS_SESSION_TOKEN: "FAKETOKEN",
-    };
-  });
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-  test("Test successful prince call with sanitized html", async () => {
+  it("should call PDF API with sanitized html", async () => {
     const res = await getPDF(dangerousHtmlBodyEvent, null);
-    expect(fetch).toHaveBeenCalledWith(
-      "https://princefakeurl.com/print",
-      expect.objectContaining({
-        body: base64EncodedSanitizedHtml,
-        headers: expect.objectContaining({
-          authorization: "mock authorization",
+
+    expect(res.statusCode).toBe(200);
+
+    expect(fetch).toHaveBeenCalled();
+    const [url, request] = (fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(request.body);
+    expect(url).toBe("https://docraptor.com/docs");
+    expect(request).toEqual({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: expect.stringMatching(/^\{.*\}$/),
+    });
+    expect(body).toEqual({
+      user_credentials: "mock api key", // pragma: allowlist secret
+      doc: expect.objectContaining({
+        document_content: sanitizedHtml,
+        type: "pdf",
+        prince_options: expect.objectContaining({
+          profile: "PDF/UA-1",
         }),
-      })
-    );
+      }),
+    });
+  });
+
+  it("should handle an error response from the PDF API", async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      status: 500,
+      text: jest.fn().mockResolvedValue("<error>It broke.</error>"),
+    });
+
+    const res = await getPDF(dangerousHtmlBodyEvent, null);
+
+    expect(res.statusCode).toBe(500);
+
+    // eslint-disable-next-line no-console
+    expect(console.warn).toBeCalledWith(expect.stringContaining("It broke."));
   });
 });

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -35,8 +35,6 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@aws-crypto/sha256-js": "^5.2.0",
-    "@smithy/signature-v4": "^2.0.18",
     "aws-sdk": "^2.1310.0",
     "aws4": "^1.11.0",
     "cross-fetch": "^4.0.0",

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -47,7 +47,7 @@ custom:
       - prod
   dotenv:
     path: ../../.env
-  princeUrl: ${ssm:/configuration/default/princeurl, "https://macpro-platform-dev.cms.gov/doc-conv/508html-to-508pdf"}
+  docraptorApiKey: ${env:docraptorApiKey, ssm:/${self:custom.stage}/pdf/docraptorApiKey, ssm:/default/pdf/docraptorApiKey}
   bootstrapBrokerStringTls: ${ssm:/configuration/${self:custom.stage}/qmr/bootstrapBrokerStringTls, ssm:/configuration/default/qmr/bootstrapBrokerStringTls, ''}
   coreSetTableName: ${env:coreSetTableName, cf:database-${self:custom.stage}.CoreSetTableName}
   coreSetTableArn: ${env:DYNAMO_TABLE_ARN, cf:database-${self:custom.stage}.CoreSetTableArn}
@@ -120,7 +120,7 @@ provider:
     uploadS3BucketName: ${ssm:/s3bucket/uploads, cf:uploads-${self:custom.stage}.AttachmentsBucketName, "local-uploads"}
     dynamoSnapshotS3BucketName: ${ssm:/s3bucket/snapshots, cf:uploads-${self:custom.stage}.DynamoSnapshotBucketName, "local-dynamo-snapshots"}
     stage: ${opt:stage, self:provider.stage}
-    princeUrl: ${self:custom.princeUrl}
+    docraptorApiKey: ${self:custom.docraptorApiKey}
 
 functions:
   listMeasures:

--- a/services/app-api/yarn.lock
+++ b/services/app-api/yarn.lock
@@ -18,57 +18,6 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-crypto/crc32@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-3.0.0.tgz#07300eca214409c33e3ff769cd5697b57fdd38fa"
-  integrity sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==
-  dependencies:
-    "@aws-crypto/util" "^3.0.0"
-    "@aws-sdk/types" "^3.222.0"
-    tslib "^1.11.1"
-
-"@aws-crypto/sha256-js@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz#c4fdb773fdbed9a664fc1a95724e206cf3860042"
-  integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
-  dependencies:
-    "@aws-crypto/util" "^5.2.0"
-    "@aws-sdk/types" "^3.222.0"
-    tslib "^2.6.2"
-
-"@aws-crypto/util@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-3.0.0.tgz#1c7ca90c29293f0883468ad48117937f0fe5bfb0"
-  integrity sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==
-  dependencies:
-    "@aws-sdk/types" "^3.222.0"
-    "@aws-sdk/util-utf8-browser" "^3.0.0"
-    tslib "^1.11.1"
-
-"@aws-crypto/util@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
-  integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
-  dependencies:
-    "@aws-sdk/types" "^3.222.0"
-    "@smithy/util-utf8" "^2.0.0"
-    tslib "^2.6.2"
-
-"@aws-sdk/types@^3.222.0":
-  version "3.468.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.468.0.tgz#f97b34fc92a800d1d8b866f47693ae8f3d46517b"
-  integrity sha512-rx/9uHI4inRbp2tw3Y4Ih4PNZkVj32h7WneSg3MVgVjAoVD5Zti9KhS5hkvsBxfgmQmg0AQbE+b1sy5WGAgntA==
-  dependencies:
-    "@smithy/types" "^2.7.0"
-    tslib "^2.5.0"
-
-"@aws-sdk/util-utf8-browser@^3.0.0":
-  version "3.55.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz#a045bf1a93f6e0ff9c846631b168ea55bbb37668"
-  integrity sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==
-  dependencies:
-    tslib "^2.3.1"
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
@@ -821,82 +770,6 @@
   integrity sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
-
-"@smithy/eventstream-codec@^2.0.15":
-  version "2.0.15"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-2.0.15.tgz#733e638fd38e7e264bc0429dbda139bab950bd25"
-  integrity sha512-crjvz3j1gGPwA0us6cwS7+5gAn35CTmqu/oIxVbYJo2Qm/sGAye6zGJnMDk3BKhWZw5kcU1G4MxciTkuBpOZPg==
-  dependencies:
-    "@aws-crypto/crc32" "3.0.0"
-    "@smithy/types" "^2.7.0"
-    "@smithy/util-hex-encoding" "^2.0.0"
-    tslib "^2.5.0"
-
-"@smithy/is-array-buffer@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz#8fa9b8040651e7ba0b2f6106e636a91354ff7d34"
-  integrity sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==
-  dependencies:
-    tslib "^2.5.0"
-
-"@smithy/signature-v4@^2.0.18":
-  version "2.0.18"
-  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-2.0.18.tgz#53b78b238edaa84cc8d61faf67d2b3c926cdd698"
-  integrity sha512-SJRAj9jT/l9ocm8D0GojMbnA1sp7I4JeStOQ4lEXI8A5eHE73vbjlzlqIFB7cLvIgau0oUl4cGVpF9IGCrvjlw==
-  dependencies:
-    "@smithy/eventstream-codec" "^2.0.15"
-    "@smithy/is-array-buffer" "^2.0.0"
-    "@smithy/types" "^2.7.0"
-    "@smithy/util-hex-encoding" "^2.0.0"
-    "@smithy/util-middleware" "^2.0.8"
-    "@smithy/util-uri-escape" "^2.0.0"
-    "@smithy/util-utf8" "^2.0.2"
-    tslib "^2.5.0"
-
-"@smithy/types@^2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-2.7.0.tgz#6ed9ba5bff7c4d28c980cff967e6d8456840a4f3"
-  integrity sha512-1OIFyhK+vOkMbu4aN2HZz/MomREkrAC/HqY5mlJMUJfGrPRwijJDTeiN8Rnj9zUaB8ogXAfIOtZrrgqZ4w7Wnw==
-  dependencies:
-    tslib "^2.5.0"
-
-"@smithy/util-buffer-from@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz#7eb75d72288b6b3001bc5f75b48b711513091deb"
-  integrity sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==
-  dependencies:
-    "@smithy/is-array-buffer" "^2.0.0"
-    tslib "^2.5.0"
-
-"@smithy/util-hex-encoding@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz#0aa3515acd2b005c6d55675e377080a7c513b59e"
-  integrity sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==
-  dependencies:
-    tslib "^2.5.0"
-
-"@smithy/util-middleware@^2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-2.0.8.tgz#2ec1da1190d09b69512ce0248ebd5e819e3c8a92"
-  integrity sha512-qkvqQjM8fRGGA8P2ydWylMhenCDP8VlkPn8kiNuFEaFz9xnUKC2irfqsBSJrfrOB9Qt6pQsI58r3zvvumhFMkw==
-  dependencies:
-    "@smithy/types" "^2.7.0"
-    tslib "^2.5.0"
-
-"@smithy/util-uri-escape@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz#19955b1a0f517a87ae77ac729e0e411963dfda95"
-  integrity sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==
-  dependencies:
-    tslib "^2.5.0"
-
-"@smithy/util-utf8@^2.0.0", "@smithy/util-utf8@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.0.2.tgz#626b3e173ad137208e27ed329d6bea70f4a1a7f7"
-  integrity sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==
-  dependencies:
-    "@smithy/util-buffer-from" "^2.0.0"
-    tslib "^2.5.0"
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -5256,25 +5129,10 @@ ts-node@^10.7.0:
     v8-compile-cache-lib "^3.0.0"
     yn "3.1.1"
 
-tslib@^1.11.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@^2.1.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
-
-tslib@^2.3.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
-
-tslib@^2.5.0, tslib@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 type-check@~0.3.2:
   version "0.3.2"

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -8866,7 +8866,7 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ip@^1.1.0, ip@^1.1.5, ip@^1.1.8:
+ip@^1.1.0, ip@^1.1.5:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.9.tgz#8dfbcc99a754d07f425310b86a99546b1151e396"
   integrity sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==


### PR DESCRIPTION
### Description
Instead of sending HTML to CMS's Prince instance to be rendered to PDF, send it to DocRaptor's instance.

### Related ticket(s)
CMDCT-3249

---
### How to test
* Attempt to print a PDF
   * There are two ways to do this in QMR. The big "print" button at the top of each measure page uses browser print, but the "export" option for an entire core set uses the API print. Don't do the browser print one.
* You should see a PDF
   * If you don't, check your browser's address bar to see if it blocked a pop-up. That'll be it.
* The watermark on that PDF is expected
   * Even though I didn't see one when I tested in this branch's environment? Maybe something to do with the DR pricing tier CMS selected.
   * But I verified in DR's logs that the `test: true` parameter definitely came through, and it was counted as a test request.


### Important updates
There is a new environment variable, `docraptorApiKey`. You only need to provide a value if you're trying to test PDF generation locally. Either sign up for a free trial key at DocRaptor.com, or ask me for my key - I'm happy to share it privately.

---
### Author checklist

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~

