### PR TITLE
CMDCT-3324: ADD-CH Content Updates (FFY2024)

### DIFF
--- a/services/ui-src/src/measures/2024/ADDCH/data.ts
+++ b/services/ui-src/src/measures/2024/ADDCH/data.ts
@@ -8,11 +8,11 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
     "Percentage of children newly prescribed attention-deficit/hyperactivity disorder (ADHD) medication who had at least three follow-up care visits within a 10-month period, one of which was within 30 days of when the first ADHD medication was dispensed. Two rates are reported.",
   ],
-  questionSubtextTitles: [
+  questionListTitles: [
     "Initiation Phase",
     "Continuation and Maintenance (C&M) Phase",
   ],
-  questionSubtext: [
+  questionListOrderedItems: [
     "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication, who had one follow-up visit with a practitioner with prescribing authority during the 30-day Initiation Phase.",
     "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication who remained on the medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.",
   ],

--- a/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/data.ts
+++ b/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/data.ts
@@ -10,6 +10,7 @@ export interface PerformanceMeasureData {
   customPrompt?: string; // Default: "Enter a number for the numerator and the denominator. Rate will auto-calculate:"
   questionText?: string[];
   questionListItems?: string[];
+  questionListOrderedItems?: string[];
   questionListTitles?: string[];
   questionSubtext?: string[];
   questionSubtextTitles?: string[];

--- a/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -231,20 +231,20 @@ export const PerformanceMeasure = ({
         })}
       </CUI.Stack>
       {data.questionSubtext && (
-        <CUI.OrderedList my="5" spacing={5}>
+        <CUI.Stack my="5" spacing={5}>
           {data.questionSubtext.map((item, idx) => {
             return (
-              <CUI.ListItem key={`performanceMeasureListItem.${idx}`}>
+              <CUI.Text key={`performanceMeasureListItem.${idx}`}>
                 {data.questionSubtextTitles?.[idx] && (
                   <CUI.Text display="inline" fontWeight="600">
                     {data.questionSubtextTitles?.[idx]}
                   </CUI.Text>
                 )}
                 <CUI.Text>{item}</CUI.Text>
-              </CUI.ListItem>
+              </CUI.Text>
             );
           })}
-        </CUI.OrderedList>
+        </CUI.Stack>
       )}
       {data.questionListItems && (
         <CUI.UnorderedList m="5" ml="10" spacing={5}>
@@ -261,6 +261,23 @@ export const PerformanceMeasure = ({
             );
           })}
         </CUI.UnorderedList>
+      )}
+      {data.questionListOrderedItems && (
+        <CUI.OrderedList m="5" ml="10" spacing={5}>
+          {data.questionListOrderedItems?.map((item, idx) => {
+            return (
+              <CUI.ListItem key={`performanceMeasureListItem.${idx}`}>
+                {data.questionListTitles?.[idx] && (
+                  <CUI.Text display="inline" fontWeight="600">
+                    {data.questionListTitles?.[idx]}
+                    <br />
+                  </CUI.Text>
+                )}
+                {item}
+              </CUI.ListItem>
+            );
+          })}
+        </CUI.OrderedList>
       )}
       {showtextbox && (
         <QMR.TextArea

--- a/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -231,20 +231,20 @@ export const PerformanceMeasure = ({
         })}
       </CUI.Stack>
       {data.questionSubtext && (
-        <CUI.Stack my="5" spacing={5}>
+        <CUI.OrderedList my="5" spacing={5}>
           {data.questionSubtext.map((item, idx) => {
             return (
-              <CUI.Text key={`performanceMeasureListItem.${idx}`}>
+              <CUI.ListItem key={`performanceMeasureListItem.${idx}`}>
                 {data.questionSubtextTitles?.[idx] && (
                   <CUI.Text display="inline" fontWeight="600">
                     {data.questionSubtextTitles?.[idx]}
                   </CUI.Text>
                 )}
                 <CUI.Text>{item}</CUI.Text>
-              </CUI.Text>
+              </CUI.ListItem>
             );
           })}
-        </CUI.Stack>
+        </CUI.OrderedList>
       )}
       {data.questionListItems && (
         <CUI.UnorderedList m="5" ml="10" spacing={5}>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updating the `Performance Measure` description section of **ADD-CH** to include numbering as seen below:

![Screenshot 2024-03-01 at 11 12 18 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/605b7be8-ace2-438a-a58c-d24f7d9a0819)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3324

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Add child core sets
- Navigate to ADD-CH

Verify that the `Performance Measures` description matches the screenshot.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
