### PR TITLE
cmdct-3331 - text change

### DIFF
--- a/services/ui-src/src/measures/2024/FUMCH/data.ts
+++ b/services/ui-src/src/measures/2024/FUMCH/data.ts
@@ -8,8 +8,8 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
     "Percentage of emergency department (ED) visits for beneficiaries ages 6 to 17 with a principal diagnosis of mental illness or intentional self-harm and who had a follow-up visit for mental illness. Two rates are reported:",
   ],
   questionListItems: [
-    "Percentage of ED visits for mental illness for which the beneficiary received follow-up within 30 days of the ED visit (31 total days)",
-    "Percentage of ED visits for mental illness for which the beneficiary received follow-up within 7 days of the ED visit (8 total days)",
+    "Percentage of ED visits for which the beneficiary received follow-up within 30 days of the ED visit (31 total days)",
+    "Percentage of ED visits for which the beneficiary received follow-up within 7 days of the ED visit (8 total days)",
   ],
   categories,
   qualifiers,

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -8866,7 +8866,7 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ip@^1.1.0, ip@^1.1.5:
+ip@^1.1.0, ip@^1.1.5, ip@^1.1.8:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.9.tgz#8dfbcc99a754d07f425310b86a99546b1151e396"
   integrity sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -8866,7 +8866,7 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ip@^1.1.0, ip@^1.1.5, ip@^1.1.8:
+ip@^1.1.0, ip@^1.1.5:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.9.tgz#8dfbcc99a754d07f425310b86a99546b1151e396"
   integrity sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==


### PR DESCRIPTION
### Description


Removed text has been put into code segments:


Percentage of emergency department (ED) visits for beneficiaries ages 6 to 17 with a principal diagnosis of mental illness or intentional self-harm and who had a follow-up visit for mental illness. Two rates are reported: 

Percentage of ED visits `for mental illness` for which the beneficiary received follow-up within 30 days of the ED visit (31 total days)
Percentage of ED visits `for mental illness` for which the beneficiary received follow-up within 7 days of the ED visit (8 total days)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3331

---
### How to test
Create child core set
Go to FUM-CH
Select first option in `Measurement Specification`
See text change matches the card


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
