### PR TITLE
Improve input validation

### DIFF
--- a/.github/waf-controller.sh
+++ b/.github/waf-controller.sh
@@ -8,7 +8,7 @@ DEBUG=1
 
 set -o pipefail -o nounset -u
 
-case ${1} in
+case ${1-} in
   append)
     OP=append
     ;;
@@ -17,17 +17,19 @@ case ${1} in
     ;;
   *)
     echo "Error:  unkown operation"
-    echo "Usage: ${0} [append|set]" && exit 1
+    echo "Usage: ${0} [append|set] [ip_set name] [ip_set id] [list of CIDR blocks]" && exit 1
     ;;
 esac
 
 shift
-NAME="${1}"
-ID="${2}"
+NAME="${1-}"
+ID="${2-}"
 shift; shift
-RUNNER_CIDRS="${@}"
+RUNNER_CIDRS="${@-}"
 
-[[ $DEBUG -ge 1 ]] && echo "Inputs:  NAME ${NAME}, ID ${ID}, RUNNER_CIDRS ${RUNNER_CIDRS}"
+[[ $DEBUG -ge 1 ]] && echo "Inputs:  NAME \"${NAME}\", ID \"${ID}\", RUNNER_CIDRS \"${RUNNER_CIDRS}\""
+
+[[ -z "${NAME}" ]] || [[ -z "${ID}" ]] || [[ -z "${RUNNER_CIDRS}" ]] && echo "Error:  one or more inputs are missing" && exit 1
 
 #Exponential backoff with jitter
 jitter() {


### PR DESCRIPTION
### Description
[The options configured for the waf-controller.sh script issue the '-u' flag for bett
](https://linuxcommand.org/lc3_man_pages/seth.html)

The options are configured as follows:  `set -o pipefail -o nounset -u`

As can be seen in the before-mentioned reference, in order to avoid attempting to process unset variables, we want to error should something not correctly be set:
`-u  Treat unset variables as an error when substituting.`

However, this produces an obtuse error message when the script's variables aren't correctly supplied: 
`./waf-controller.sh: line 11: 1: unbound variable`

In order to better inform an engineer when a build step is misconfigured, rather than the script failing to collect or set the parameters in the waf's ip-set, this pull request implements some very basic input feedback.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3302

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
` % ./.github/waf-controller.sh `
`Error:  unkown operation`
`Usage: ./.github/waf-controller.sh [append|set] [ip_set name] [ip_set id] [list of CIDR blocks]`

` % ./.github/waf-controller.sh append`
`Inputs:  NAME "", ID "", RUNNER_CIDRS ""`
`Error:  one or more inputs are missing`


`% ./.github/waf-controller.sh set   `
`Inputs:  NAME "", ID "", RUNNER_CIDRS ""`
`Error:  one or more inputs are missing`

`% ./.github/waf-controller.sh append test test`
`Inputs:  NAME "test", ID "test", RUNNER_CIDRS ""`
`Error:  one or more inputs are missing`

A successful build with tests running demonstrate the working condition.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
