### PR TITLE
OEV-CH Missing Label

### DIFF
--- a/services/ui-src/src/measures/2024/rateLabelText.ts
+++ b/services/ui-src/src/measures/2024/rateLabelText.ts
@@ -1328,7 +1328,7 @@ export const data = {
                 "excludeFromOMS": true
             },
             {
-                "label": "Total ages <1 to 20",
+                "label": "Total ages <1 to 20 (required rate)",
                 "text": "Total ages <1 to 20 (required rate)",
                 "id": "Total"
             }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
missed from a previous PR, OEV-CH OMS needed the label updated as well

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3332

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Sign into QMR
2. Create child core set
3. go to OEV-CH
4. Select first radio option in Measure Specification to open up Performance Measure section
5. see text matches AC
6. Fill in a N/D/R to open the OMS section
7. See that the qualifier text says "Total ages <1 to 20 (required rate)"

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
