### PR TITLE
TFL-CH Text + Rate Label Change

### DIFF
--- a/services/ui-src/src/measures/2024/TFLCH/data.ts
+++ b/services/ui-src/src/measures/2024/TFLCH/data.ts
@@ -5,7 +5,7 @@ export const { categories, qualifiers } = getCatQualLabels("TFL-CH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
-    "Percentage of enrolled children ages 1 through 20 who received at least two topical fluoride applications as: (1) dental or oral health services, (2) dental services, and (3) oral health services within the measurement year.",
+    "For FFY 2024 Child Core Set reporting, the following three rates are required: (1) Dental or oral health services: Total ages 1 through 20; (2) Dental services: Total ages 1 through 20; and (3) Oral health services: Total ages 1 through 20.",
   ],
   questionListItems: [],
   categories,

--- a/services/ui-src/src/measures/2024/rateLabelText.ts
+++ b/services/ui-src/src/measures/2024/rateLabelText.ts
@@ -1706,8 +1706,8 @@ export const data = {
                 "excludeFromOMS": true
             },
             {
-                "label": "Total Ages 1 through 20",
-                "text": "Total Ages 1 through 20",
+                "label": "Total Ages 1 through 20 (required rate)",
+                "text": "Total Ages 1 through 20 (required rate)",
                 "id": "Total"
             }
         ],

--- a/tests/cypress/cypress/e2e/a11y/TFLCHpage.spec.ts
+++ b/tests/cypress/cypress/e2e/a11y/TFLCHpage.spec.ts
@@ -1,0 +1,11 @@
+import { testingYear } from "../../../support/constants";
+
+describe("TFL-CH Page 508 Compliance Test", () => {
+  it("Check a11y on TFL-CH Page", () => {
+    cy.login();
+    cy.selectYear(testingYear);
+    cy.goToChildCoreSetMeasures();
+    cy.goToMeasure("TFL-CH");
+    cy.checkA11yOfPage();
+  });
+});


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Fun fact, TFL-CH does not have a cypress test so I added one for Accessibility.

TFL-CH has a performance measure content change to:
For FFY 2024 Child Core Set reporting, the following three rates are required: (1) Dental or oral health services: Total ages 1 through 20; (2) Dental services: Total ages 1 through 20; and (3) Oral health services: Total ages 1 through 20.

and the rate label 
Total ages 1 through 20
to
Total ages 1 through 20 **(required rate)**

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3367

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Sign into QMR
2. Create child measure
3. Go to CIS-CH
4. In Measure Specification section, select the first bullet
5. Scroll down to the Performance Measure
6. Check that the content update matches the jira ticket: https://jiraent.cms.gov/browse/CMDCT-3367

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
