### PR TITLE
cmdct-3400 tiny text change

### DIFF
--- a/services/ui-src/src/measures/2024/CDFHH/data.ts
+++ b/services/ui-src/src/measures/2024/CDFHH/data.ts
@@ -6,7 +6,7 @@ export const { categories, qualifiers } = getCatQualLabels("CDF-HH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
-    "Percentage of health home enrollees age 12 and older screened for depression on the date of the encounter or 14 days prior to the date of the encounter using an age-appropriate standardized depression screening tool, and if positive, a follow-up plan is documented on the date of the eligible encounter.",
+    "Percentage of health home enrollees age 12 and older screened for depression on the date of the encounter or 14 days prior to the date of the encounter using an age-appropriate standardized depression screening tool, and if positive, a follow-up plan is documented on the date of the qualifying encounter.",
   ],
   categories,
   qualifiers,


### PR DESCRIPTION
For 2024 only: 

Percentage of enrollees age 12 and older screened for depression on the date of the encounter or 14 days prior to the date of the encounter using an age-appropriate standardized depression screening tool, and if positive, a follow-up plan is documented on the date of the `qualifying` encounter.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3400

---
### How to test
Login as a state that has home health (stateuserMN)

make these selections:
<img width="1154" alt="Screenshot 2024-03-13 at 8 59 11 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/22454493/66fc1ba7-4d06-4467-9dd4-347c6df9b55b">

See `Performance Measure` text appears like so:
<img width="1294" alt="Screenshot 2024-03-13 at 8 59 58 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/22454493/6d458971-8684-427b-b6e9-5aef58c4eece">



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
