### PR TITLE
cmdct-3401 - COL-HH text changes

### DIFF
--- a/services/ui-src/src/measures/2024/COLHH/data.ts
+++ b/services/ui-src/src/measures/2024/COLHH/data.ts
@@ -6,7 +6,7 @@ export const { categories, qualifiers } = getCatQualLabels("COL-HH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
-    "Percentage of health home enrollees ages 46 to 75 who had appropriate screening for colorectal cancer.",
+    "Percentage of health home enrollees ages 45 to 75 who had appropriate screening for colorectal cancer. This measure applies to enrollees ages 46 to 75 to account for the look back period. (to ensure that the enrollee was at least age 45 for the entire enrollment period.)",
   ],
   categories,
   qualifiers,

--- a/services/ui-src/src/measures/2024/rateLabelText.ts
+++ b/services/ui-src/src/measures/2024/rateLabelText.ts
@@ -614,18 +614,18 @@ export const data = {
     "COL-HH": {
         "qualifiers": [
             {
-                "label": "Ages 46 to 49",
-                "text": "Ages 46 to 49",
+                "label": "Ages 46 to 50",
+                "text": "Ages 46 to 50",
                 "id": "RHlNkr"
             },
             {
-                "label": "Ages 50 to 64",
-                "text": "Ages 50 to 64",
+                "label": "Ages 51 to 65",
+                "text": "Ages 51 to 65",
                 "id": "u1n5QA"
             },
             {
-                "label": "Ages 65 to 75",
-                "text": "Ages 65 to 75",
+                "label": "Ages 66 to 75",
+                "text": "Ages 66 to 75",
                 "id": "2ATODe"
             }
         ],


### PR DESCRIPTION
### Description

Text changes to COL-HH for 2024

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3401

---
### How to test
Login as stateuserMN
Create a Health Home Core Set
Make these selections:
<img width="1085" alt="Screenshot 2024-03-13 at 10 52 25 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/22454493/1094d85b-3c8d-4fa9-be61-7b67973f099d">

See that the Performance Measures have this text and labels:

`Percentage of health home enrollees ages 45 to 75 who had appropriate screening for colorectal cancer. This measure applies to enrollees ages 46 to 75 to account for the look back period. (to ensure that the enrollee was at least age 45 for the entire enrollment period.)`

<img width="1317" alt="Screenshot 2024-03-13 at 10 51 45 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/22454493/b5b85a72-d409-4c40-92f2-f20250d2af6f">


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
