### PR TITLE
cmdct-3402 text change for FUM-HH 2024

### DIFF
--- a/services/ui-src/src/measures/2024/FUMHH/data.ts
+++ b/services/ui-src/src/measures/2024/FUMHH/data.ts
@@ -8,8 +8,8 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
     "Percentage of emergency department (ED) visits for health home enrollees age 6 and older with a principal diagnosis of mental illness or intentional self-harm and who had a follow-up visit for mental illness. Two rates are reported:",
   ],
   questionListItems: [
-    "Percentage of ED visits for mental illness for which the enrollee received follow-up within 30 days of the ED visit (31 total days)",
-    "Percentage of ED visits for mental illness for which the enrollee received follow-up within 7 days of the ED visit (8 total days)",
+    "Percentage of ED visits for which the enrollee received follow-up within 30 days of the ED visit (31 total days)",
+    "Percentage of ED visits for which the enrollee received follow-up within 7 days of the ED visit (8 total days)",
   ],
   categories,
   qualifiers,


### PR DESCRIPTION
### Description

Text change in Performance Measures for 2024:

Percentage of ED visits ~~for mental illness~~  for which the enrollee received follow-up within 30 days of the ED visit (31 total days)
Percentage of ED visits ~~for mental illness~~  for which the enrollee received follow-up within 7 days of the ED visit (8 total days)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3402

---
### How to test
Login as stateuserMN
create Health Home Core Set
go to FUM-HH
Make these selections:
<img width="1085" alt="Screenshot 2024-03-13 at 10 52 25 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/22454493/3b68841c-a02f-47d7-bd1c-f4a71de7f9b3">

See that text matches from the description above

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
