### PR TITLE
cmdct-3403 text change to OUD-HH

### DIFF
--- a/services/ui-src/src/measures/2024/OUDHH/data.ts
+++ b/services/ui-src/src/measures/2024/OUDHH/data.ts
@@ -5,8 +5,8 @@ export const { categories, qualifiers } = getCatQualLabels("OUD-HH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
-    "Percentage of Medicaid health home enrollees ages 18 to 64 with an opioid use disorder (OUD) who filled a prescription for or were administered or dispensed an FDA-approved medication for the disorder during the measurement year. Five rates are reported:",
-    "A total (overall) rate capturing any medications used in medication assisted treatment of opioid dependence and addiction (Rate 1)",
+    "Percentage of health home enrollees ages 18 to 64 with an opioid use disorder (OUD) who filled a prescription for or were administered or dispensed an FDA-approved medication for the disorder during the measurement year. Five rates are reported:",
+    "A total (overall) rate capturing any medications used in medication assisted treatment of opioid dependence and addiction (Rate 1).",
     "Four separate rates representing the following types of FDA-approved drug products:",
   ],
   questionListItems: [


### PR DESCRIPTION
### Description

Small text changes to performance measures for OUD-HH 2024

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3403

---
### How to test
Login as stateuserMN
create Health Home Core Set -> OUD-HH
Make these selections:



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
<img width="1085" alt="Screenshot 2024-03-13 at 10 52 25 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/22454493/6cbf6c09-e94b-4616-a772-a485d03a60ff">

See that the text matches the card.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
