### PR TITLE
cmdct-3404 changes to IU-HH 2024

### DIFF
--- a/services/ui-src/src/measures/2024/IUHH/data.ts
+++ b/services/ui-src/src/measures/2024/IUHH/data.ts
@@ -59,7 +59,7 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
   customPrompt:
     "Enter the appropriate data below. Completion of at least one set of Numerator/Denominator/Rate (numeric entry, other than zero) is required.",
   questionText: [
-    "Rate of acute inpatient care and services (total, mental and behavioral disorders, surgery, and medicine) per 1,000 enrollee months among health home enrollees.",
+    "Rate of acute inpatient care and services (total and mental and behavioral disorders) per 1,000 enrollee months among health home enrollees.",
   ],
   questionListItems: [],
   measureName,

--- a/services/ui-src/src/measures/2024/rateLabelText.ts
+++ b/services/ui-src/src/measures/2024/rateLabelText.ts
@@ -1210,18 +1210,6 @@ export const data = {
                 "id": "VX9uaf",
                 "excludeFromOMS": true
             },
-            {
-                "label": "Surgery",
-                "text": "Surgery",
-                "id": "QzuJDR",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Medicine",
-                "text": "Medicine",
-                "id": "ioz7ed",
-                "excludeFromOMS": true
-            }
         ]
     },
 


### PR DESCRIPTION
### Description

Text change, removal of some rates from IU-HH 2024

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3404

---
### How to test
Login as stateuserMN
Create Health Home Core Set -> IU-HH
Make these selections:
<img width="1085" alt="Screenshot 2024-03-13 at 10 52 25 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/22454493/d87327a4-4667-49f5-9b62-c402e87b66ac">

See that the text and NDR label rates match the card.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
