### PR TITLE
cmdct-3383 text change CCP-AD 2024

### DIFF
--- a/services/ui-src/src/measures/2024/CCPAD/data.ts
+++ b/services/ui-src/src/measures/2024/CCPAD/data.ts
@@ -8,8 +8,8 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
     "Among women ages 21 to 44 who had a live birth, the percentage that:",
   ],
   questionListItems: [
-    "Were provided a most effective or moderately effective method of contraception within 3 and 90 days of delivery",
-    "Were provided a long-acting reversible method of contraception (LARC) within 3 and 90 days of delivery",
+    "Were provided a most effective or moderately effective method of contraception within 3 days of delivery and within 90 days of delivery.",
+    "Were provided a long-acting reversible method of contraception (LARC) within 3 days of delivery and within 90 days of delivery.",
   ],
   categories,
   qualifiers,


### PR DESCRIPTION
### Description

Text change CCP-AD 2024

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3383

---
### How to test
Login as any user
go to CCP-AD 
Make these selections
<img width="1085" alt="Screenshot 2024-03-13 at 10 52 25 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/22454493/8d78d578-8a3f-4053-9bd9-3024e24a9c93">
See that the text in Performance Measures matches the card


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
