### PR TITLE
Remove unnecessary step which breaks job

### DIFF
--- a/.github/workflows/snyk-auto-merge.yml
+++ b/.github/workflows/snyk-auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Snyk PRs
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Description
[Fixes an omission here](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2108)

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
