### PR TITLE
FUM-AD Content Change

### DIFF
--- a/services/ui-src/src/measures/2024/FUMAD/data.ts
+++ b/services/ui-src/src/measures/2024/FUMAD/data.ts
@@ -8,8 +8,8 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
     "Percentage of emergency department (ED) visits for beneficiaries age 18 and Older with a principal diagnosis of mental illness or intentional self-harm and who had a follow-up visit for mental illness. Two rates are reported:",
   ],
   questionListItems: [
-    "Percentage of ED visits for mental illness for which the beneficiary received follow-up within 30 days of the ED visit (31 total days)",
-    "Percentage of ED visits for mental illness for which the beneficiary received follow-up within 7 days of the ED visit (8 total days)",
+    "Percentage of ED visits for which the beneficiary received follow-up within 30 days of the ED visit (31 total days)",
+    "Percentage of ED visits for which the beneficiary received follow-up within 7 days of the ED visit (8 total days)",
   ],
   categories,
   qualifiers,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Text changes for FUM-AD: removed `for mental illness` from the performance measure text.
![Screenshot 2024-03-18 at 11 25 29 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/3959b102-87a8-4872-939c-c6cb3c34322b)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3395

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Sign into QMR
2. Select Adult Measures
3. Go to FUM-AD
4. In Measure Specification section, select the first bullet
5. Scroll down to the Performance Measure
6. Check that the content update matches the jira ticket: https://jiraent.cms.gov/browse/CMDCT-3389

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
