### PR TITLE
Export Fix - Component & Cypress

### DIFF
--- a/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
@@ -122,8 +122,10 @@ export const PrintableMeasureWrapper = ({
   });
 
   //WIP: this code will be replaced with a dynamic import onces we refactored enough files
-  const shared: AnyObject =
-    Labels[`CQ${year}` as "CQ2021" | "CQ2022" | "CQ2023" | "CQ2024"];
+  const shared: AnyObject = {
+    ...Labels[`CQ${year}` as "CQ2021" | "CQ2022" | "CQ2023" | "CQ2024"],
+    year: year,
+  };
 
   useEffect(() => {
     // reset core set qualifier data to use the default values for table rendering

--- a/services/ui-src/src/views/ExportAll/index.tsx
+++ b/services/ui-src/src/views/ExportAll/index.tsx
@@ -99,6 +99,11 @@ export const ExportAll = () => {
             ? QualifierData.find((d) => d.year === measure.year + "")?.data
             : undefined;
 
+        if (Comp === undefined) {
+          console.error(`Measure does not exist: ${measure.measure}`);
+          return;
+        }
+
         return (
           <CUI.Box
             key={`measure-${measure.measure}-wrapper`}

--- a/services/ui-src/src/views/ExportAll/index.tsx
+++ b/services/ui-src/src/views/ExportAll/index.tsx
@@ -26,6 +26,26 @@ export const ExportAll = () => {
     .sort((a: any, b: any) => a?.measure?.localeCompare(b?.measure));
   const sortedData = [csqMeasure, ...regMeasures];
 
+  //build the data to render the measures
+  const measures = sortedData
+    .map((data) => {
+      const defaultData =
+        data.measure === "CSQ"
+          ? QualifierData.find((d) => d.year === data.year + "")?.data
+          : undefined;
+      const Comp =
+        data.measure === "CSQ"
+          ? Measures?.[data.year]?.["Qualifier"]
+          : Measures[data.year][data.measure];
+      return { data: data, comp: Comp, defaultData: defaultData };
+    })
+    .filter((measure) => {
+      //log any measure that is unrenderable, this could indicate unclean data in the database
+      if (!measure.comp)
+        console.error(`Measure does not exist: ${measure.data.measure}`);
+      return measure.comp;
+    });
+
   return (
     <>
       <style key="printerPreviewStyles">
@@ -74,53 +94,38 @@ export const ExportAll = () => {
           spacingX={5}
           spacingY={10}
         >
-          {sortedData?.map((measure: any) => {
+          {measures?.map((measure: any) => {
             return (
               <CUI.Button
                 as="a"
                 width={"28"}
-                href={`#${measure?.measure}`}
-                key={`buttonLink.${measure?.measure}`}
+                href={`#${measure?.data.measure}`}
+                key={`buttonLink.${measure?.data.measure}`}
               >
-                {measure?.measure}
+                {measure?.data.measure}
               </CUI.Button>
             );
           })}
         </CUI.SimpleGrid>
       </CUI.Center>
-      {sortedData?.map((measure: any) => {
-        const Comp =
-          measure.measure === "CSQ"
-            ? Measures?.[measure.year]?.["Qualifier"]
-            : Measures[measure.year][measure.measure];
-
-        const defaultData =
-          measure.measure === "CSQ"
-            ? QualifierData.find((d) => d.year === measure.year + "")?.data
-            : undefined;
-
-        if (Comp === undefined) {
-          console.error(`Measure does not exist: ${measure.measure}`);
-          return;
-        }
-
+      {measures?.map((measure: any) => {
         return (
           <CUI.Box
-            key={`measure-${measure.measure}-wrapper`}
+            key={`measure-${measure.data.measure}-wrapper`}
             className="prince-measure-wrapper-box"
           >
             <QMR.PrintableMeasureWrapper
-              measure={createElement(Comp)}
-              measureData={measure}
-              measureId={measure.measure}
-              name={measure.description}
-              year={measure.year}
-              key={measure.compoundKey}
-              defaultData={defaultData}
+              measure={createElement(measure.comp)}
+              measureData={measure.data}
+              measureId={measure.data.measure}
+              name={measure.data.description}
+              year={measure.data.year}
+              key={measure.data.compoundKey}
+              defaultData={measure.defaultData}
               spaName={spaName}
             />
             <CUI.Center
-              key={`returnButton.${measure.measure}`}
+              key={`returnButton.${measure.data.measure}`}
               mt="2"
               className="prince-top-link"
             >


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently, the export all page will stop rendering and provide a confusing error message if there is a measure in the database that's been removed. This fix will send an error alert message if the measure isn't there but continue rendering the pages and removing any calls to the missing measure. 

Note: i will write a cypress/unit test as part of the overall QMR refactoring, so ignore the lack of them for now.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Test this locally so that you can alter the database. Run dynamoDb:
 `DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin`

2)Open the dynamodb page, click the table [local-measures], in the table, click [Create Item]. Copy & Paste this chunk and then save it:
```
{
  "createdAt": 1711115060613,
  "compoundKey": "MA2024ACSFVA-AD",
  "measure": "FVA-AD",
  "year": 2024,
  "lastAltered": 1711115060613,
  "state": "MA",
  "coreSet": "ACS",
  "status": "incomplete"
}
``` 
3) Sign into QMR, any user
4) Select the 3 dots on the right of [Adult Core Set Measure] and select Export
5) The export page should render without displaying this measure
6) If you want to make sure that FVA was added into the database correctly, you should see it in the adult measure list looking like this
![Screenshot 2024-03-22 at 1 10 54 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/a4c3c04f-1fdc-4dd1-9263-56310a09e169)


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
