### PR TITLE
Change styles and DOMPurify config to make PDFs look better

### DIFF
--- a/services/app-api/handlers/prince/pdf.ts
+++ b/services/app-api/handlers/prince/pdf.ts
@@ -79,18 +79,20 @@ function sanitizeHtml(htmlString: string) {
   }
   const commentlessHtml = doc.querySelector("html")!.outerHTML;
 
-  // decode body from base64, sanitize dangerous html
+  /* Sanitization parameters:
+   *  - WHOLE_DOCUMENT - Tells DOMPurify to return the entire <html> doc;
+   *    its default behavior is to return only the contents of the <body>.
+   *  - ADD_TAGS: "head" - Add <head> to the tag allowlist. It's important.
+   *  - ADD_TAGS: "link" - We use <link> tags to include some styles.
+   *  - ADD_TAGS: "base" - The <base> tag tells the renderer to treat relative
+   *    URLs (such as <img src="/bar.jpg"/>) as absolute ones (such as
+   *    <img src="https://foo.com/bar.jpg"/>). Without this, DocRaptor would
+   *    reject our documents; when they render it on their servers, relative
+   *    URLs would appear as filesystem access attempts, which they disallow.
+   */
   const sanitizedHtml = DOMPurify.sanitize(commentlessHtml, {
     WHOLE_DOCUMENT: true,
-    /*
-     * By default DOMPurify removes all <link> tags, due to the possibility
-     * of XSS in certain browsers. We include bootstrap styles and google
-     * fonts via <link> tags in QMR, and we don't expect this page to be
-     * rendered in vulnerable browsers. So we allowlist "link" here.
-     *
-     * https://github.com/cure53/DOMPurify/issues/2
-     */
-    ADD_TAGS: ["head", "link"],
+    ADD_TAGS: ["head", "link", "base"],
   });
 
   return sanitizedHtml;

--- a/services/app-api/handlers/prince/tests/pdf.test.ts
+++ b/services/app-api/handlers/prince/tests/pdf.test.ts
@@ -12,7 +12,7 @@ jest.mock("cross-fetch", () => ({
   fetch: jest.fn().mockResolvedValue({
     status: 200,
     headers: {
-      get: jest.fn().mockResolvedValue("3"),
+      get: jest.fn().mockReturnValue("3"),
     },
     arrayBuffer: jest.fn().mockResolvedValue(
       // An ArrayBuffer containing `%PDF-1.7`
@@ -58,7 +58,7 @@ describe("Test GetPDF handler", () => {
     const res = await getPDF(testEvent, null);
 
     expect(res.statusCode).toBe(500);
-    expect(res.body).toContain("Could not process request");
+    expect(res.body).toContain("must be base64-encoded HTML");
   });
 
   it("should throw error when config not defined", async () => {
@@ -87,7 +87,7 @@ describe("Test GetPDF handler", () => {
     expect(body).toEqual({
       user_credentials: "mock api key", // pragma: allowlist secret
       doc: expect.objectContaining({
-        document_content: sanitizedHtml,
+        document_content: `<html><head></head><body>${sanitizedHtml}</body></html>`,
         type: "pdf",
         prince_options: expect.objectContaining({
           profile: "PDF/UA-1",

--- a/services/app-api/handlers/prince/tests/pdf.test.ts
+++ b/services/app-api/handlers/prince/tests/pdf.test.ts
@@ -96,6 +96,31 @@ describe("Test GetPDF handler", () => {
     });
   });
 
+  it("should remove CSS comments before calling PDF API", async () => {
+    const htmlWithCssComment = `<html><head><style>/* emphasize <p> tags */ p {color:red;}</style></head><body><p>Hi</p></body></html>`;
+    const htmlWithoutComment = `<html><head><style> p {color:red;}</style></head><body><p>Hi</p></body></html>`;
+    const res = await getPDF(
+      {
+        ...testEvent,
+        body: Buffer.from(htmlWithCssComment).toString("base64"),
+      },
+      null
+    );
+
+    expect(res.statusCode).toBe(200);
+
+    expect(fetch).toHaveBeenCalled();
+    const request = (fetch as jest.Mock).mock.calls[0][1];
+    const body = JSON.parse(request.body);
+    expect(body).toEqual(
+      expect.objectContaining({
+        doc: expect.objectContaining({
+          document_content: htmlWithoutComment,
+        }),
+      })
+    );
+  });
+
   it("should handle an error response from the PDF API", async () => {
     (fetch as jest.Mock).mockResolvedValueOnce({
       status: 500,

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -202,7 +202,7 @@ export const usePrinceRequest: PrinceHook = () => {
 
       // add <base> to treat relative URLs as absolute
       const base = document.createElement("base");
-      base.href = window.location.host;
+      base.href = `https://${window.location.host}`;
       document.querySelector("head")!.prepend(base);
 
       // get cleaned html

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -213,7 +213,10 @@ export const usePrinceRequest: PrinceHook = () => {
        */
       for (let style of document.querySelectorAll("style")) {
         // Pulled from https://www.w3.org/TR/CSS2/grammar.html#scanner
-        style.innerHTML = style.innerHTML.replaceAll(/\/\*[^*]*\*+([^/*][^*]*\*+)*\//g, "");
+        style.innerHTML = style.innerHTML.replaceAll(
+          /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g,
+          ""
+        );
       }
 
       // get cleaned html

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -200,6 +200,11 @@ export const usePrinceRequest: PrinceHook = () => {
       const html = document.querySelector("html")!;
       html.querySelector("noscript")?.remove();
 
+      // add <base> to treat relative URLs as absolute
+      const base = document.createElement("base");
+      base.href = window.location.host;
+      document.querySelector("head")!.prepend(base);
+
       // get cleaned html
       const htmlString = htmlStringCleanup(html.outerHTML);
 

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -200,25 +200,6 @@ export const usePrinceRequest: PrinceHook = () => {
       const html = document.querySelector("html")!;
       html.querySelector("noscript")?.remove();
 
-      /*
-       * This HTML will eventually be sent through DOMPurify, which is very
-       * aggressive in removing potentially malicious code. Some of our style
-       * tags (namely, those included from @cmsgov/design-system) include
-       * comments with example HTML markup. This is sufficiently suspicious
-       * that DOMPurify will remove the entire style tag:
-       * https://github.com/cure53/DOMPurify/issues/593
-       *
-       * To avoid this, remove all comments from the page's CSS before sending
-       * it to be rendered to PDF.
-       */
-      for (let style of document.querySelectorAll("style")) {
-        // Pulled from https://www.w3.org/TR/CSS2/grammar.html#scanner
-        style.innerHTML = style.innerHTML.replaceAll(
-          /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g,
-          ""
-        );
-      }
-
       // get cleaned html
       const htmlString = htmlStringCleanup(html.outerHTML);
 

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -200,6 +200,25 @@ export const usePrinceRequest: PrinceHook = () => {
       const html = document.querySelector("html")!;
       html.querySelector("noscript")?.remove();
 
+      /*
+       * This HTML will eventually be sent through DOMPurify, which is very
+       * aggressive in removing potentially malicious code. Some of our style
+       * tags (namely, those included from @cmsgov/design-system) include
+       * comments with example HTML markup. This is sufficiently suspicious
+       * that DOMPurify will remove the entire style tag:
+       * https://github.com/cure53/DOMPurify/issues/593
+       *
+       * To avoid this, remove all comments from the page's CSS before sending
+       * it to be rendered to PDF.
+       */
+      for (let style of document.querySelectorAll("style")) {
+        /*
+         * The .*? trigraph means "match any string, but as short as possible".
+         * The s flag allows the . to match newline characters.
+         */
+        style.innerHTML = style.innerHTML.replaceAll(/\/\*.*?\*\//gs, "");
+      }
+
       // get cleaned html
       const htmlString = htmlStringCleanup(html.outerHTML);
 

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -212,11 +212,8 @@ export const usePrinceRequest: PrinceHook = () => {
        * it to be rendered to PDF.
        */
       for (let style of document.querySelectorAll("style")) {
-        /*
-         * The .*? trigraph means "match any string, but as short as possible".
-         * The s flag allows the . to match newline characters.
-         */
-        style.innerHTML = style.innerHTML.replaceAll(/\/\*.*?\*\//gs, "");
+        // Pulled from https://www.w3.org/TR/CSS2/grammar.html#scanner
+        style.innerHTML = style.innerHTML.replaceAll(/\/\*[^*]*\*+([^/*][^*]*\*+)*\//g, "");
       }
 
       // get cleaned html


### PR DESCRIPTION
### Description
We apply DOMPurify to print requests to avoid forwarding potentially-dangerous HTML to DocRaptor. But DOMPurify strips out rather a lot from our HTML. This PR puts some of it back.

1. DOMPurify, by default, returns only the sanitized inner HTML of the `<body>`. The outer `<html>` is restored by passing the `WHOLE_DOCUMENT` option, and the `<head>` is restored with `ADD_TAGS: ["head"]`.
2. DOMPurify removes any `<style>` tag that contains a `<` character. This is a problem because we include styles with example HTML, embedded as comments within the CSS. This is addressed by stripping out CSS comments on the browser side, before making the call to our API's print endpoint.
   * This removes a few dozen CSS comments. Most are linter directives, and a few are explanations or examples. Nothing is lost here. However we also have CSS source maps embedded as comments within `<style>` tags, so in theory our app's styles become more difficult for developers to debug after printing a PDF. These source maps are restored on page refresh, so this is not a huge loss either; I'm just noting it here.
3. DOMPurify, by default, removes all `<link>` tags. We use links to include the Open Sans font, as well as Bootstrap. I am of the opinion that DOMPurify is using an overabundance of caution here - I personally doubt that allowing `<link>` tags to be sent to DocRaptor poses a significant security risk to them, and I am personally confident that it poses no security risk to us. So I restore them here with `ADD_TAGS: ["link"]`.
4. I also tweaked the endpoint's input validation, adding a check and a new error message for the sake of a pre-existing unit test. I don't expect this new check or message to give us much value in practice, so I would be open to removing it (and the corresponding test). But I don't mind including it either; there's an outside chance it may help a future developer debug a PDF issue someday.
5. DocRaptor requires that all resources on the page are loaded from absolute URLs (because relative URLs appear to them as filesystem access attempts). Rather than tracking down & transforming all relative URLs on the page, I added a `<base>` tag pointing to the current domain. This also required me to `ADD_TAGS: ["base"]`, to prevent DOMPurify from wiping it out.
6. This does not represent a complete "fix" for all styling issues within the PDF. For example, I believe the color of the measure buttons at the very top should be a light gray, and I'm not seeing that. But it's a couple of big steps forward, and I would prefer to prioritize troubleshooting any minor remaining issues separately from this ticket.
   * I suspect that the remaining visual issues in the PDF are due to errors on DocRaptor's side, when attempting to load our resources. There may also be some inherent issues in our CSS, which our browsers might be handling differently from DR's renderer. That is what I gather from the logs viewable on DocRaptor's website; I may not be reading them correctly.

---
Future developers troubleshooting DOMPurify-related issues: The approach I found most effective for tracking down problems was to modify the print endpoint to write the HTML to file, just before sanitization. Then I wrote a script that looked like this:
```js
const fs = require("fs");
const createDOMPurify = require("dompurify");
const { JSDOM } = require("jsdom");
const windowEmulator = new JSDOM("").window;
const DOMPurify = createDOMPurify(windowEmulator);
const rawHtml = fs.readFileSync("before.html");
const sanitizedHtml = DOMPurify.sanitize(rawHtml, {
    WHOLE_DOCUMENT: true,
    ADD_TAGS: ["head", "link"],
  });
fs.writeFileSync("after.html", sanitizedHtml);
```
After which, I repeatedly made manual modifications to `before.html`, and invoked 
```bash
node test.js && my-favorite-difftool before.html after.html
```
This workflow let me see exactly what DOMPurify was doing, and to quickly test out sweeping changes (like deleting 1000 lines of CSS) in order to narrow down what could be triggering DOMPurify's behavior.

I will also note that the resulting diff will be _very_ noisy, due to DOMPurify's tendency to rearrange attributes. For example `<foo bar="1" baz="2"/>` might become `<foo baz="2" bar="1/>`. While this has no effect on the rendering of the page, it does greatly confuse any text-based diffing algorithm.

---
### Related ticket(s)
CMDCT-3370

---
### How to test
1. Log in to QMR
2. In the 3-dot menu for a core set, choose Export
3. Click Print at the top of the page
4. Look at the PDF. It should appear generally correct.


### Important updates

---
### Author checklist

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
