### PR TITLE
Auotmate resource auditing for account

### DIFF
--- a/.github/audit-account.sh
+++ b/.github/audit-account.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -o pipefail -o nounset -u
+git fetch --all > /dev/null
+
+#Parse inputs
+case ${1-} in
+  "ci_active"|"ci_inactive"|"cf_other"|"untagged")
+    OP=${1-}
+    ;;
+  *)
+    echo "Error:  unkown operation"
+    echo "Usage: ${0} [ci_active|ci_inactive|cf_other|untagged] [resource_tagging_response|null]" && exit 1
+    ;;
+esac
+
+shift
+if [ ! -z "${1-}" ]; then
+  if [ -f "${1-}" ]; then
+    RESOURCES=$(<"${1-}")
+  else 
+    RESOURCES="${@-}"  
+  fi
+  jq empty <<< "${RESOURCES}"
+  [ "$?" != 0 ] && echo "Error:  supplied JSON is invalid." && echo ${RESOURCES} && exit 1  
+else
+  RESOURCES=$(aws resourcegroupstaggingapi get-resources)
+fi
+
+#Create array of objects with the branch name and the interpolated branch name (for bot created branches)
+get_branches () {
+ RAW_BRANCHES=$(git for-each-ref --format='%(refname)' refs/remotes/origin | sed 's|^.\+\/||g')
+ BRANCHES=()
+ for B in $RAW_BRANCHES; do
+   [ "${B}" == "HEAD" ] && continue
+   IBRANCH=$(./setBranchName.sh ${B})
+   BRANCHES+=($(echo '{"BRANCH":"'${B}'","IBRANCH":"'${IBRANCH}'"}'))
+ done
+
+ jq -s '{BRANCHES:.}' <<< ${BRANCHES[*]}
+}
+
+get_composite_ci () {
+  local BRANCHES=$(get_branches)
+  local RESOURCES=$(jq -r '{RESOURCES:[.ResourceTagMappingList[] | select(.Tags[]?.Key?=="STAGE")]}' <<< "${1}")
+  jq -rs 'reduce .[] as $item ({}; . * $item) 
+          | [JOIN(INDEX(.BRANCHES[]; .IBRANCH); .RESOURCES[]; .Tags[].Value; add)] 
+          | [.[] 
+          | {"BRANCH":.BRANCH, "STAGE":.Tags[] 
+          | select(.Key=="STAGE").Value, "ResourceARN":.ResourceARN}]' <<< $(echo ${BRANCHES}${RESOURCES})
+}
+
+#Produce report for active stacks created by the ci pipeline (has a corresponding branch)
+ci_active () {
+  jq -r '[.[] | select(.BRANCH != null)] | sort_by(.STAGE)' <<< $(get_composite_ci "${1}")
+}
+
+#Produce report for active stacks created by the ci pipeline (does NOT have a corresponding branch)
+ci_inactive () {
+  jq -r '[.[] | select(.BRANCH == null)] | del(.[].BRANCH) | sort_by(.STAGE)' <<< $(get_composite_ci "${1}")
+}
+
+#Produce report for resources that have tags but were not created by the ci pipeline
+cf_other () {
+  jq -r '[.ResourceTagMappingList[] | select((.Tags? | length) > 0) | del(select(.Tags[].Key=="STAGE")) // empty | 
+         {
+           InferredId: .Tags[] | select(.Key=="aws:cloudformation:stack-name" or .Key=="cms-cloud-service" or .Key=="Name").Value,
+           ResourceARN: .ResourceARN
+         }] | sort' <<< "${1}"
+}
+
+#Produce report for resources that are untagged (some are still created by the ci pipeline)
+untagged () {
+  jq -r '[{ResourceARN:.ResourceTagMappingList[] | select((.Tags? | length) < 1).ResourceARN}] | sort' <<< "${1}"
+}
+
+#Execute operation
+$OP "${RESOURCES}"

--- a/.github/workflows/audit-account.yml
+++ b/.github/workflows/audit-account.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 16 * * 1" # Every Monday at 1600 UTC
   workflow_dispatch:
-  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.ref }}
@@ -15,7 +14,7 @@ permissions:
 
 jobs:
   audit:
-    #if: github.event.ref == 'master' || inputs.environment != ''
+    if: github.event.ref == 'master' || inputs.environment != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4  

--- a/.github/workflows/audit-account.yml
+++ b/.github/workflows/audit-account.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 16 * * 1" # Every Monday at 1600 UTC
   workflow_dispatch:
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.ref }}
@@ -14,15 +15,10 @@ permissions:
 
 jobs:
   audit:
-    if: github.event.ref == 'master' || inputs.environment != ''
+    #if: github.event.ref == 'master' || inputs.environment != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: "Setup jq"
-        uses: dcarbone/install-jq-action@v2.1.0
-        with:
-          version: "${{ inputs.version }}"
-          force: "${{ inputs.force }}"      
+      - uses: actions/checkout@v4  
       - name: set variable values
         run: ./.github/build_vars.sh set_values
         env:
@@ -57,4 +53,4 @@ jobs:
         with:
           name: resource-reports
           path: .github/reports/
-          retention-days: 7
+          retention-days: 14

--- a/.github/workflows/audit-account.yml
+++ b/.github/workflows/audit-account.yml
@@ -61,5 +61,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: resource-reports
-          path: |
-            .github/reports/
+          path: .github/reports/
+          retention-days: 7

--- a/.github/workflows/audit-account.yml
+++ b/.github/workflows/audit-account.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: "0 16 * * 1" # Every Monday at 1600 UTC
   workflow_dispatch:
-    inputs:
-      environment:
-        description: "This doesn't take an input, it just allows execution..."
-        required: false  
-  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.ref }}
@@ -19,7 +14,7 @@ permissions:
 
 jobs:
   audit:
-    #if: github.event.ref == 'master' || inputs.environment != ''
+    if: github.event.ref == 'master' || inputs.environment != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/audit-account.yml
+++ b/.github/workflows/audit-account.yml
@@ -1,0 +1,65 @@
+name: Audit Account
+
+on:
+  schedule:
+    - cron: "0 16 * * 1" # Every Monday at 1600 UTC
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "This doesn't take an input, it just allows execution..."
+        required: false  
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.ref }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+
+jobs:
+  audit:
+    #if: github.event.ref == 'master' || inputs.environment != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Setup jq"
+        uses: dcarbone/install-jq-action@v2.1.0
+        with:
+          version: "${{ inputs.version }}"
+          force: "${{ inputs.force }}"      
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Collect resources from account
+        run: pushd .github && aws resourcegroupstaggingapi get-resources > resources.json
+      - name: List active resources created by CI pipeline
+        run: pushd .github && ./audit-account.sh ci_active resources.json
+      - name: List orphaned resources created by CI pipeline
+        run: pushd .github && ./audit-account.sh ci_inactive resources.json
+      - name: List resources created by Cloudformation but not from CI pipeline
+        run: pushd .github && ./audit-account.sh cf_other resources.json
+      - name: List untagged resources
+        run: pushd .github && ./audit-account.sh untagged resources.json            
+      - name: Create reports dir
+        run: pushd .github && mkdir -p reports
+      - name: Assemble CSV files
+        run: |
+          pushd .github
+          jq -r '(.[0] | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "$(./audit-account.sh ci_active resources.json)" > reports/ci_active.csv
+          jq -r '(.[0] | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "$(./audit-account.sh ci_inactive resources.json)" > reports/ci_inactive.csv
+          jq -r '(.[0] | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "$(./audit-account.sh cf_other resources.json)" > reports/cf_other.csv
+          jq -r '(.[0] | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "$(./audit-account.sh untagged resources.json)" > reports/untagged.csv
+      - name: Upload reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: resource-reports
+          path: |
+            .github/reports/


### PR DESCRIPTION
### Description
The purpose of this PR is to prototype a scheduled job which produces an automated report.   The report is scheduled to run once a week, on Monday morning, and will create a downloadable zip file containing four distinct CSV files.  The job also posts JSON output for each of the four reports within the build log, allowing viewing without needing to download and subsequently open the spreadsheets.

Under the hood, this report is scanning the tagging API output which returns all active resources.  Two other approaches were investigated and the result of that work can be reviewed in comments in this [ticket](https://jiraent.cms.gov/browse/CMDCT-3318).  The tagging API is a relatively new feature and allows for querying and applying tags to resources.  

In our application stack, our CI pipeline applies a tag,`{"Key":"STAGE","Value":"[stage_name]"}`, to every resource directly created by the generated Cloudformation template.  Some child resources, such as rules, do not inherit these mapping and will subsequently be reported in the untagged report.  What this audit is effectively doing is comparing tags against branch names, using the derived branch name for Snyk and Dependabot generated stages.  There are effectively four categories of reports for this resource audit:

#### CI Active
These resources were created by our CI pipeline, and has an active branch in the repository.

#### CI Inctive
These resources were created  by our CI pipeline, but there is no matching branch.  This is likely infrastructure that was not cleaned up during a destroy action, but in any case, this is orphaned infrastructure.

#### CF Other
These resources have tags and are assumed to have been created by a Cloudformation template but they do not have the STAGE tag and therefore were not created by our CI pipeline.  These were likely created by CMS Cloud Engineering teams.  It's possible to manually tag a resource, and those resources would also appear in this report.

#### Untagged
These resources have no tags.  They could have been manually created, or they could be child resources that simply don't inherit tags.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3410

---
### How to test
[Workflow](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/runs/8426680938) (note that this will vanish after this PR is merged)

Download the artifacts from the above link, and verify the contents.

### Important updates
At some point in the future we may want to automate reporting of certain items produced by these reports, such as active stages (did you push a branch and forget about it), and we could also amend this script to check for open PRs against branches.  We could possibly introduce a culture change where we're expecting engineers to create draft PRs for any active branch and use this to report on forgotten work, but that's not something I'm necessarily advocating for at this time.  At the minimum, this should improve observability to orphaned and neglected resources in any account to which this automated workflow is operating against.


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
