### PR TITLE
validation text change

### DIFF
--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
@@ -45,6 +45,18 @@ describe("validateOneDataSourceType", () => {
     };
     errorArray = [...validateAtLeastOneDataSourceType(formData)];
     expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe("You must select a data source");
+  });
+
+  it("Error message text should match default errorMessage", () => {
+    formData[DC.DATA_SOURCE] = [];
+    formData[DC.DATA_SOURCE_SELECTIONS] = {
+      OtherDataSource: {
+        selected: undefined,
+      },
+    };
+    errorArray = [...validateAtLeastOneDataSourceType(formData)];
+    expect(errorArray.length).toBe(1);
     expect(errorArray[0].errorMessage).toBe(
       "Please describe the Other Data Source"
     );

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
@@ -45,7 +45,9 @@ describe("validateOneDataSourceType", () => {
     };
     errorArray = [...validateAtLeastOneDataSourceType(formData)];
     expect(errorArray.length).toBe(1);
-    expect(errorArray[0].errorMessage).toBe("You must select a data source");
+    expect(errorArray[0].errorMessage).toBe(
+      "Please describe the Other Data Source"
+    );
   });
 
   it("Error message text should match provided errorMessage", () => {

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -14,9 +14,12 @@ export const validateAtLeastOneDataSourceType = (
         })
         .indexOf(true);
       if (!Object.values(source[index])[0]) {
+        const dataErrorMessage = source.includes("OtherDataSource")
+          ? "Please describe the Other Data Source"
+          : "You must select a data source";
         errorArray.push({
           errorLocation: "Data Source",
-          errorMessage: errorMessage ?? "Please describe the Other Data Source",
+          errorMessage: errorMessage ?? dataErrorMessage,
         });
       }
     });

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -16,7 +16,7 @@ export const validateAtLeastOneDataSourceType = (
       if (!Object.values(source[index])[0]) {
         errorArray.push({
           errorLocation: "Data Source",
-          errorMessage: errorMessage ?? "You must select a data source",
+          errorMessage: errorMessage ?? "Please describe the Other Data Source",
         });
       }
     });

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
@@ -45,6 +45,18 @@ describe("validateOneDataSourceType", () => {
     };
     errorArray = [...validateAtLeastOneDataSourceType(formData)];
     expect(errorArray.length).toBe(1);
+    expect(errorArray[0].errorMessage).toBe("You must select a data source");
+  });
+
+  it("Error message text should match default errorMessage", () => {
+    formData[DC.DATA_SOURCE] = [];
+    formData[DC.DATA_SOURCE_SELECTIONS] = {
+      OtherDataSource: {
+        selected: undefined,
+      },
+    };
+    errorArray = [...validateAtLeastOneDataSourceType(formData)];
+    expect(errorArray.length).toBe(1);
     expect(errorArray[0].errorMessage).toBe(
       "Please describe the Other Data Source"
     );

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
@@ -45,7 +45,9 @@ describe("validateOneDataSourceType", () => {
     };
     errorArray = [...validateAtLeastOneDataSourceType(formData)];
     expect(errorArray.length).toBe(1);
-    expect(errorArray[0].errorMessage).toBe("You must select a data source");
+    expect(errorArray[0].errorMessage).toBe(
+      "Please describe the Other Data Source"
+    );
   });
 
   it("Error message text should match provided errorMessage", () => {

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -14,9 +14,12 @@ export const validateAtLeastOneDataSourceType = (
         })
         .indexOf(true);
       if (!Object.values(source[index])[0]) {
+        const dataErrorMessage = source.includes("OtherDataSource")
+          ? "Please describe the Other Data Source"
+          : "You must select a data source";
         errorArray.push({
           errorLocation: "Data Source",
-          errorMessage: errorMessage ?? "Please describe the Other Data Source",
+          errorMessage: errorMessage ?? dataErrorMessage,
         });
       }
     });

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -16,8 +16,7 @@ export const validateAtLeastOneDataSourceType = (
       if (!Object.values(source[index])[0]) {
         errorArray.push({
           errorLocation: "Data Source",
-          errorMessage:
-            errorMessage ?? " Please describe the Other Data Source",
+          errorMessage: errorMessage ?? "Please describe the Other Data Source",
         });
       }
     });

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -16,7 +16,8 @@ export const validateAtLeastOneDataSourceType = (
       if (!Object.values(source[index])[0]) {
         errorArray.push({
           errorLocation: "Data Source",
-          errorMessage: errorMessage ?? "You must select a data source",
+          errorMessage:
+            errorMessage ?? " Please describe the Other Data Source",
         });
       }
     });


### PR DESCRIPTION
### Description
`Update the language in the validation that flags when a state selects "Other Data Source" but doesn't enter text in the box provided. Currently, the flag says "Data Source Error: You must select a data source" which may be confusing to states because a data source has already been selected. Can you please update the flag language to say "Data Source Error: Please describe the Other Data Source"? `


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3480

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
