### PR TITLE
CMDCT-3479: Deviations -> Variations (FFY2024 Content Change)

### DIFF
--- a/services/ui-src/src/labels/2021/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2021/commonQuestionsLabel.tsx
@@ -67,6 +67,26 @@ export const commonQuestionsLabel = {
       " resource.",
     ],
   },
+  DeviationFromMeasureSpecification: {
+    header: "Deviations from Measure Specifications",
+    section:
+      "Did your calculation of the measure deviate from the measure specification in any way?",
+    optionsText: "Select and explain the deviation(s):",
+    options: [
+      {
+        displayValue:
+          "Yes, the calculation of the measure deviates from the measure specification.",
+        value: DC.YES,
+      },
+      {
+        displayValue:
+          "No, the calculation of the measure does not deviate from the measure specification in any way.",
+        value: DC.NO,
+      },
+    ],
+    deviationReason:
+      "Explain the deviation(s) (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+  },
   MeasureSpecifications: {
     measureSpecDescriptor:
       "NCQA, the measure steward, changed its naming convention. HEDIS MY 2020 refers to a different federal fiscal year (FFY) than HEDIS 2020. Please note the FFY Core Set specification below.",

--- a/services/ui-src/src/labels/2022/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2022/commonQuestionsLabel.tsx
@@ -66,6 +66,26 @@ export const commonQuestionsLabel = {
       " resource.",
     ],
   },
+  DeviationFromMeasureSpecification: {
+    header: "Deviations from Measure Specifications",
+    section:
+      "Did your calculation of the measure deviate from the measure specification in any way?",
+    optionsText: "Select and explain the deviation(s):",
+    options: [
+      {
+        displayValue:
+          "Yes, the calculation of the measure deviates from the measure specification.",
+        value: DC.YES,
+      },
+      {
+        displayValue:
+          "No, the calculation of the measure does not deviate from the measure specification in any way.",
+        value: DC.NO,
+      },
+    ],
+    deviationReason:
+      "Explain the deviation(s) (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+  },
   MeasureSpecifications: {
     measureSpecDescriptor:
       "NCQA, the measure steward, changed its naming convention. HEDIS MY 2020 refers to a different federal fiscal year (FFY) than HEDIS 2020. Please note the FFY Core Set specification below.",

--- a/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
@@ -75,6 +75,19 @@ export const commonQuestionsLabel = {
     header: "Deviations from Measure Specifications",
     section:
       "Did your calculation of the measure deviate from the measure specification in any way?",
+    optionsText: "Select and explain the deviation(s):",
+    options: [
+      {
+        displayValue:
+          "Yes, the calculation of the measure deviates from the measure specification.",
+        value: DC.YES,
+      },
+      {
+        displayValue:
+          "No, the calculation of the measure does not deviate from the measure specification in any way.",
+        value: DC.NO,
+      },
+    ],
     deviationReason:
       "Explain the deviation(s) (<em>text in this field is included in publicly-reported state-specific comments</em>):",
   },

--- a/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
@@ -72,11 +72,26 @@ export const commonQuestionsLabel = {
     ],
   },
   DeviationFromMeasureSpecification: {
-    header: "Deviations from Measure Specifications",
+    header: "Variations from Measure Specifications",
     section:
-      "Did your calculation of the measure deviate from the measure specification in any way?",
+      "Did your calculation of the measure vary from the measure specification in any way?",
+    helper:
+      "For example: variation from measure specification might include different methodology, timeframe, or reported age groups.",
+    optionsText: "Select and explain the variation(s):",
+    options: [
+      {
+        displayValue:
+          "Yes, the calculation of the measure varies from the measure specification.",
+        value: DC.YES,
+      },
+      {
+        displayValue:
+          "No, the calculation of the measure does not vary from the measure specification in any way.",
+        value: DC.NO,
+      },
+    ],
     deviationReason:
-      "Explain the deviation(s) (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+      "Explain the variation(s) (<em>text in this field is included in publicly-reported state-specific comments</em>):",
   },
   MeasureSpecifications: {
     options: [

--- a/services/ui-src/src/shared/commonQuestions/DeviationFromMeasureSpecificationCheckboxes.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DeviationFromMeasureSpecificationCheckboxes.test.tsx
@@ -1,31 +1,35 @@
 import { renderWithHookForm } from "utils";
 import { DeviationFromMeasureSpec } from "./DeviationFromMeasureSpecificationCheckboxes";
 import { fireEvent, screen } from "@testing-library/react";
+import commonQuestionsLabel from "labels/2024/commonQuestionsLabel";
+import SharedContext from "shared/SharedContext";
 
 describe("Test DeviationFromMeasureSpec Component", () => {
   beforeEach(() => {
     renderWithHookForm(
-      <DeviationFromMeasureSpec categories={[]}></DeviationFromMeasureSpec>
+      <SharedContext.Provider value={commonQuestionsLabel}>
+        <DeviationFromMeasureSpec categories={[]}></DeviationFromMeasureSpec>
+      </SharedContext.Provider>
     );
   });
 
   it("component renders", () => {
     expect(
-      screen.getByText("Deviations from Measure Specifications")
+      screen.getByText("Variations from Measure Specifications")
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Did your calculation of the measure deviate from the measure specification in any way?"
+        "Did your calculation of the measure vary from the measure specification in any way?"
       )
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Yes, the calculation of the measure deviates from the measure specification."
+        "Yes, the calculation of the measure varies from the measure specification."
       )
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "No, the calculation of the measure does not deviate from the measure specification in any way."
+        "No, the calculation of the measure does not vary from the measure specification in any way."
       )
     ).toBeInTheDocument();
   });
@@ -44,7 +48,7 @@ describe("Test DeviationFromMeasureSpec Component", () => {
   it("No checkboxes are shown when user selects yes and no N/D/R is filled", () => {
     //simulate user clicking yes to trigger the textarea to show
     const radioButtonYes = screen.getByRole("radio", {
-      name: "Yes, the calculation of the measure deviates from the measure specification.",
+      name: "Yes, the calculation of the measure varies from the measure specification.",
     });
     fireEvent.click(radioButtonYes);
     const checkboxes = screen.queryAllByRole("checkbox");

--- a/services/ui-src/src/shared/commonQuestions/DeviationFromMeasureSpecificationCheckboxes.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DeviationFromMeasureSpecificationCheckboxes.tsx
@@ -5,6 +5,8 @@ import { useWatch } from "react-hook-form";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { cleanString } from "utils/cleanString";
 import { getLabelText } from "utils";
+import { useContext } from "react";
+import SharedContext from "shared/SharedContext";
 
 interface GetTopLvlDeviationOptions {
   categories: string[];
@@ -130,6 +132,9 @@ export const DeviationFromMeasureSpec = ({
   });
   const labelText = getLabelText();
 
+  //WIP: using form context to get the labels for this component temporarily.
+  const labels: any = useContext(SharedContext);
+
   const getTopLvlDeviationOptions = ({
     categories,
     customTotalLabel,
@@ -216,24 +221,24 @@ export const DeviationFromMeasureSpec = ({
 
   return (
     <QMR.CoreQuestionWrapper
-      label="Deviations from Measure Specifications"
+      label={labels.DeviationFromMeasureSpecification.header}
       testid="deviation-from-measure-specification"
     >
       <QMR.RadioButton
         renderHelperTextAbove
         {...register(DC.DID_CALCS_DEVIATE)}
         formLabelProps={{ fontWeight: 600 }}
-        label="Did your calculation of the measure deviate from the measure specification in any way?"
-        helperText="For example: deviation from measure specification might include different methodology, timeframe, or reported age groups."
+        label={labels.DeviationFromMeasureSpecification.section}
+        helperText={labels.DeviationFromMeasureSpecification.helper}
         options={[
           {
             displayValue:
-              "Yes, the calculation of the measure deviates from the measure specification.",
-            value: DC.YES,
+              labels.DeviationFromMeasureSpecification.options[0].displayValue,
+            value: labels.DeviationFromMeasureSpecification.options[0].value,
             children: [
               <QMR.Checkbox
                 {...register(DC.DEVIATION_OPTIONS)}
-                label="Select and explain the deviation(s):"
+                label={labels.DeviationFromMeasureSpecification.optionsText}
                 options={getTopLvlDeviationOptions({
                   categories,
                   customTotalLabel,
@@ -243,8 +248,8 @@ export const DeviationFromMeasureSpec = ({
           },
           {
             displayValue:
-              "No, the calculation of the measure does not deviate from the measure specification in any way.",
-            value: DC.NO,
+              labels.DeviationFromMeasureSpecification.options[1].displayValue,
+            value: labels.DeviationFromMeasureSpecification.options[1].value,
           },
         ]}
       />

--- a/services/ui-src/src/shared/commonQuestions/DeviationFromMeasureSpecificationTextField.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DeviationFromMeasureSpecificationTextField.test.tsx
@@ -15,21 +15,21 @@ describe("Test DeviationFromMeasureSpec Component", () => {
 
   it("component renders", () => {
     expect(
-      screen.getByText("Deviations from Measure Specifications")
+      screen.getByText("Variations from Measure Specifications")
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Did your calculation of the measure deviate from the measure specification in any way?"
+        "Did your calculation of the measure vary from the measure specification in any way?"
       )
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Yes, the calculation of the measure deviates from the measure specification."
+        "Yes, the calculation of the measure varies from the measure specification."
       )
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "No, the calculation of the measure does not deviate from the measure specification in any way."
+        "No, the calculation of the measure does not vary from the measure specification in any way."
       )
     ).toBeInTheDocument();
   });
@@ -49,17 +49,17 @@ describe("Test DeviationFromMeasureSpec Component", () => {
     //by default, there should not be a textbox active on the page
     expect(
       screen.queryByRole("textbox", {
-        name: "Explain the deviation(s) ( text in this field is included in publicly-reported state-specific comments ):",
+        name: "Explain the variation(s) ( text in this field is included in publicly-reported state-specific comments ):",
       })
     ).not.toBeInTheDocument();
     //simulate user clicking yes to trigger the textarea to show
     const radioButtonYes = screen.getByRole("radio", {
-      name: "Yes, the calculation of the measure deviates from the measure specification.",
+      name: "Yes, the calculation of the measure varies from the measure specification.",
     });
     fireEvent.click(radioButtonYes);
     //look for the textfield and check that it's in the doc
     const textarea = screen.getByRole("textbox", {
-      name: "Explain the deviation(s) ( text in this field is included in publicly-reported state-specific comments ):",
+      name: "Explain the variation(s) ( text in this field is included in publicly-reported state-specific comments ):",
     });
     expect(textarea).toBeInTheDocument();
   });

--- a/services/ui-src/src/shared/commonQuestions/DeviationFromMeasureSpecificationTextField.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DeviationFromMeasureSpecificationTextField.tsx
@@ -23,12 +23,12 @@ export const DeviationFromMeasureSpec = () => {
         {...register(DC.DID_CALCS_DEVIATE)}
         formLabelProps={{ fontWeight: 600 }}
         label={labels.DeviationFromMeasureSpecification.section}
-        helperText="For example: deviation from measure specification might include different methodology, timeframe, or reported age groups."
+        helperText={labels.DeviationFromMeasureSpecification.helper}
         options={[
           {
             displayValue:
-              "Yes, the calculation of the measure deviates from the measure specification.",
-            value: DC.YES,
+              labels.DeviationFromMeasureSpecification.options[0].displayValue,
+            value: labels.DeviationFromMeasureSpecification.options[0].value,
             children: [
               <QMR.TextArea
                 {...register(DC.DEVIATION_REASON)}
@@ -41,8 +41,8 @@ export const DeviationFromMeasureSpec = () => {
           },
           {
             displayValue:
-              "No, the calculation of the measure does not deviate from the measure specification in any way.",
-            value: DC.NO,
+              labels.DeviationFromMeasureSpecification.options[1].displayValue,
+            value: labels.DeviationFromMeasureSpecification.options[1].value,
           },
         ]}
       />


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updating verbiage from `Deviations` to `Variations` for FFY2024, as well as refactoring how these labels are displayed within each component by moving them to the `commonQuestionLabels` files. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3479

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
In the FFY2024 measures, the `Deviations from Measure Specifications` section should be updated to look like this:

![Screenshot 2024-04-05 at 2 33 06 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/99458559/a53e4a4a-5d8f-4f2b-8965-64363990f588)

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
