### PR TITLE
Refactor AddCoreSetCards.tsx 

### DIFF
--- a/services/ui-src/src/libs/spaLib.ts
+++ b/services/ui-src/src/libs/spaLib.ts
@@ -254,20 +254,9 @@ export const SPA: { [year: string]: SPAi[] } = {
   ],
   "2023": [
     {
-      id: "19-0037",
-      state: "CA",
-      name: "California Health Home Program (HHP)",
-    },
-    { id: "20-0002", state: "CA", name: "California Behavioral Health Home" },
-    {
       id: "15-014",
       state: "CT",
       name: "Serious and Persistent Mental Illness",
-    },
-    {
-      id: "18-006",
-      state: "DE",
-      name: "Delaware Assertive Community Integration Support Team (ACIST) Health Home",
     },
     {
       id: "18-0006",
@@ -334,8 +323,6 @@ export const SPA: { [year: string]: SPAi[] } = {
       name: "Health Home for High-Cost, High-Needs Enrollees ",
     },
     { id: "22-0073", state: "NY", name: "New York I/DD Health Home Services" },
-    { id: "14-0012", state: "OK", name: "Oklahoma Health Home (Adults)" },
-    { id: "14-0011", state: "OK", name: "Oklahoma Health Home (Children)" },
     {
       id: "18-009",
       state: "RI",
@@ -378,20 +365,9 @@ export const SPA: { [year: string]: SPAi[] } = {
   ],
   "2024": [
     {
-      id: "19-0037",
-      state: "CA",
-      name: "California Health Home Program (HHP)",
-    },
-    { id: "20-0002", state: "CA", name: "California Behavioral Health Home" },
-    {
       id: "15-014",
       state: "CT",
       name: "Serious and Persistent Mental Illness",
-    },
-    {
-      id: "18-006",
-      state: "DE",
-      name: "Delaware Assertive Community Integration Support Team (ACIST) Health Home",
     },
     {
       id: "18-0006",
@@ -459,8 +435,6 @@ export const SPA: { [year: string]: SPAi[] } = {
     },
     { id: "23-0062", state: "NY", name: "New York I/DD Health Home Services" },
     { id: "22-0024", state: "NC", name: "Tailored Care Management" },
-    { id: "14-0012", state: "OK", name: "Oklahoma Health Home (Adults)" },
-    { id: "14-0011", state: "OK", name: "Oklahoma Health Home (Children)" },
     {
       id: "18-009",
       state: "RI",

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -1,11 +1,26 @@
 import { SPA } from "libs/spaLib";
 
+export interface CoreSetFields {
+  [key: string]: CoreSetField[];
+}
+
+export interface CoreSetField {
+  type: string;
+  title?: string;
+  loaded?: boolean;
+  abbr?: string[];
+  path?: string;
+  stateList?: string[];
+  label?: string;
+  exist?: boolean;
+}
+
 //health home isn't always avaliable for every state and sometimes has multiple HH coresets for a single state.
 const getHHStates = (year: string) => {
   return SPA[year].map((item) => item.state);
 };
 
-export const coreSets = {
+export const coreSets: CoreSetFields = {
   "2021": [
     {
       type: "coreSet",

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -1,0 +1,109 @@
+export const coreSets = {
+  "2021": [
+    {
+      type: "coreSet",
+      title: "Adult",
+      loaded: true,
+      abbr: ["ACS"],
+    },
+    {
+      type: "coreSet",
+      title: "Child",
+      path: "add-child",
+      excludedStates: [],
+      abbr: ["CCS", "CCSC", "CCSM"],
+    },
+    {
+      type: "coreSet",
+      title: "Health Home",
+      path: "add-hh",
+      excludedStates: ["CA", "DE", "OK"],
+      abbr: ["HHCS"],
+    },
+    {
+      type: "text-slot",
+      label:
+        "Only one group of Adult Core Set Measures can be submitted per FFY",
+    },
+  ],
+  "2022": [
+    {
+      type: "coreSet",
+      title: "Adult",
+      loaded: true,
+      abbr: ["ACS"],
+    },
+    {
+      type: "coreSet",
+      title: "Child",
+      path: "add-child",
+      excludedStates: [],
+      abbr: ["CCS", "CCSC", "CCSM"],
+    },
+    {
+      type: "coreSet",
+      title: "Health Home",
+      path: "add-hh",
+      excludedStates: ["CA", "DE", "OK"],
+      abbr: ["HHCS"],
+    },
+    {
+      type: "text-slot",
+      label:
+        "Only one group of Adult Core Set Measures can be submitted per FFY",
+    },
+  ],
+  "2023": [
+    {
+      type: "coreSet",
+      title: "Adult",
+      loaded: true,
+      abbr: ["ACS"],
+    },
+    {
+      type: "coreSet",
+      title: "Child",
+      path: "add-child",
+      excludedStates: [],
+      abbr: ["CCS", "CCSC", "CCSM"],
+    },
+    {
+      type: "coreSet",
+      title: "Health Home",
+      path: "add-hh",
+      excludedStates: ["CA", "DE", "OK"],
+      abbr: ["HHCS"],
+    },
+    {
+      type: "text-slot",
+      label:
+        "Only one group of Adult Core Set Measures can be submitted per FFY",
+    },
+  ],
+  "2024": [
+    {
+      type: "coreSet",
+      title: "Adult",
+      path: "add-adult",
+      loaded: false,
+      excludedStates: [],
+      abbr: ["ACS"],
+    },
+    {
+      type: "coreSet",
+      title: "Child",
+      path: "add-child",
+      loaded: false,
+      excludedStates: [],
+      abbr: ["CCS", "CCSC", "CCSM"],
+    },
+    {
+      type: "coreSet",
+      title: "Health Home",
+      path: "add-hh",
+      loaded: false,
+      excludedStates: ["CA", "DE", "OK"],
+      abbr: ["HHCS"],
+    },
+  ],
+};

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -6,13 +6,12 @@ export interface CoreSetFields {
 
 export interface CoreSetField {
   type: string;
-  title?: string;
+  label: string;
   loaded?: boolean;
   abbr?: string[];
   path?: string;
-  stateList?: string[];
-  label?: string;
   exist?: boolean;
+  stateList?: string[];
 }
 
 //health home isn't always avaliable for every state and sometimes has multiple HH coresets for a single state.
@@ -24,19 +23,19 @@ export const coreSets: CoreSetFields = {
   "2021": [
     {
       type: "coreSet",
-      title: "Adult",
+      label: "Adult",
       loaded: true,
       abbr: ["ACS"],
     },
     {
       type: "coreSet",
-      title: "Child",
+      label: "Child",
       path: "add-child",
       abbr: ["CCS", "CCSC", "CCSM"],
     },
     {
       type: "coreSet",
-      title: "Health Home",
+      label: "Health Home",
       path: "add-hh",
       abbr: ["HHCS"],
       stateList: getHHStates("2021"),
@@ -50,19 +49,19 @@ export const coreSets: CoreSetFields = {
   "2022": [
     {
       type: "coreSet",
-      title: "Adult",
+      label: "Adult",
       loaded: true,
       abbr: ["ACS"],
     },
     {
       type: "coreSet",
-      title: "Child",
+      label: "Child",
       path: "add-child",
       abbr: ["CCS", "CCSC", "CCSM"],
     },
     {
       type: "coreSet",
-      title: "Health Home",
+      label: "Health Home",
       path: "add-hh",
       abbr: ["HHCS"],
       stateList: getHHStates("2022"),
@@ -76,19 +75,19 @@ export const coreSets: CoreSetFields = {
   "2023": [
     {
       type: "coreSet",
-      title: "Adult",
+      label: "Adult",
       loaded: true,
       abbr: ["ACS"],
     },
     {
       type: "coreSet",
-      title: "Child",
+      label: "Child",
       path: "add-child",
       abbr: ["CCS", "CCSC", "CCSM"],
     },
     {
       type: "coreSet",
-      title: "Health Home",
+      label: "Health Home",
       path: "add-hh",
       abbr: ["HHCS"],
       stateList: getHHStates("2023"),
@@ -102,21 +101,21 @@ export const coreSets: CoreSetFields = {
   "2024": [
     {
       type: "coreSet",
-      title: "Adult",
+      label: "Adult",
       path: "add-adult",
       loaded: false,
       abbr: ["ACS"],
     },
     {
       type: "coreSet",
-      title: "Child",
+      label: "Child",
       path: "add-child",
       loaded: false,
       abbr: ["CCS", "CCSC", "CCSM"],
     },
     {
       type: "coreSet",
-      title: "Health Home",
+      label: "Health Home",
       path: "add-hh",
       loaded: false,
       abbr: ["HHCS"],

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -1,3 +1,10 @@
+import { SPA } from "libs/spaLib";
+
+//health home isn't always avaliable for every state and sometimes has multiple HH coresets for a single state.
+const getHHStates = (year: string) => {
+  return SPA[year].map((item) => item.state);
+};
+
 export const coreSets = {
   "2021": [
     {
@@ -10,18 +17,17 @@ export const coreSets = {
       type: "coreSet",
       title: "Child",
       path: "add-child",
-      excludedStates: [],
       abbr: ["CCS", "CCSC", "CCSM"],
     },
     {
       type: "coreSet",
       title: "Health Home",
       path: "add-hh",
-      excludedStates: ["CA", "DE", "OK"],
       abbr: ["HHCS"],
+      stateList: getHHStates("2021"),
     },
     {
-      type: "text-slot",
+      type: "text",
       label:
         "Only one group of Adult Core Set Measures can be submitted per FFY",
     },
@@ -37,18 +43,17 @@ export const coreSets = {
       type: "coreSet",
       title: "Child",
       path: "add-child",
-      excludedStates: [],
       abbr: ["CCS", "CCSC", "CCSM"],
     },
     {
       type: "coreSet",
       title: "Health Home",
       path: "add-hh",
-      excludedStates: ["CA", "DE", "OK"],
       abbr: ["HHCS"],
+      stateList: getHHStates("2022"),
     },
     {
-      type: "text-slot",
+      type: "text",
       label:
         "Only one group of Adult Core Set Measures can be submitted per FFY",
     },
@@ -64,18 +69,17 @@ export const coreSets = {
       type: "coreSet",
       title: "Child",
       path: "add-child",
-      excludedStates: [],
       abbr: ["CCS", "CCSC", "CCSM"],
     },
     {
       type: "coreSet",
       title: "Health Home",
       path: "add-hh",
-      excludedStates: ["CA", "DE", "OK"],
       abbr: ["HHCS"],
+      stateList: getHHStates("2023"),
     },
     {
-      type: "text-slot",
+      type: "text",
       label:
         "Only one group of Adult Core Set Measures can be submitted per FFY",
     },
@@ -86,7 +90,6 @@ export const coreSets = {
       title: "Adult",
       path: "add-adult",
       loaded: false,
-      excludedStates: [],
       abbr: ["ACS"],
     },
     {
@@ -94,7 +97,6 @@ export const coreSets = {
       title: "Child",
       path: "add-child",
       loaded: false,
-      excludedStates: [],
       abbr: ["CCS", "CCSC", "CCSM"],
     },
     {
@@ -102,8 +104,8 @@ export const coreSets = {
       title: "Health Home",
       path: "add-hh",
       loaded: false,
-      excludedStates: ["CA", "DE", "OK"],
       abbr: ["HHCS"],
+      stateList: getHHStates("2024"),
     },
   ],
 };

--- a/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
+++ b/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "react-router-dom";
 import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
 import { useUser } from "hooks/authHooks";
+import { coreSets } from "shared/coreSetByYear";
 
 interface AddCoreSetCardProps {
   title: string;
@@ -55,32 +56,35 @@ export const AddCoreSetCard = ({
 };
 
 interface Props {
-  childCoreSetExists: boolean;
-  healthHomesCoreSetExists: boolean;
   renderHealthHomeCoreSet?: boolean;
+  coreSetsInTable?: string[];
 }
 
 export const AddCoreSetCards = ({
-  childCoreSetExists,
-  healthHomesCoreSetExists,
-  renderHealthHomeCoreSet = true,
-}: Props) => {
+  coreSetsInTable,
+}: // renderHealthHomeCoreSet = true,
+Props) => {
   const { year } = useParams();
+
+  const coreSetCards = (
+    coreSets[year as keyof typeof coreSets] as any[]
+  ).filter((set) => !set.loaded && set.type === "coreSet");
+
   return (
     <>
-      <AddCoreSetCard
-        title="Need to report on Child data?"
-        buttonText="Add Child Core Set"
-        to="add-child"
-        coreSetExists={childCoreSetExists}
-      />
-      {renderHealthHomeCoreSet && (
-        <AddCoreSetCard
-          title="Need to report on Health Home data?"
-          buttonText="Add Health Home Core Set"
-          to="add-hh"
-          coreSetExists={healthHomesCoreSetExists}
-        />
+      {coreSetCards.map((coreSet: any) => {
+        return (
+          <AddCoreSetCard
+            title={`Need to report on ${coreSet.title} data?`}
+            buttonText={`Add ${coreSet.title} Core Set`}
+            to={coreSet.path}
+            coreSetExists={coreSet.abbr.some((abbr: string) =>
+              coreSetsInTable?.includes(abbr)
+            )}
+          />
+        );
+      })}
+      {/* 
       )}
       {year && parseInt(year) < 2024 && (
         <CUI.Center w="44" textAlign="center">
@@ -88,7 +92,7 @@ export const AddCoreSetCards = ({
             Only one group of Adult Core Set Measures can be submitted per FFY
           </CUI.Text>
         </CUI.Center>
-      )}
+      )} */}
     </>
   );
 };

--- a/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
+++ b/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "react-router-dom";
 import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
 import { useUser } from "hooks/authHooks";
+import { CoreSetField } from "shared/coreSetByYear";
 
 interface AddCoreSetCardProps {
   title: string;
@@ -55,23 +56,24 @@ export const AddCoreSetCard = ({
 };
 
 interface Props {
-  coreSetCards: any[];
+  coreSetCards: CoreSetField[];
 }
 
-const GetSetCard = (coreSet: any) => {
+const GetSetCard = (coreSet: CoreSetField) => {
   switch (coreSet.type) {
     case "coreSet":
       return (
         <AddCoreSetCard
+          key={coreSet.title}
           title={`Need to report on ${coreSet.title} data?`}
           buttonText={`Add ${coreSet.title} Core Set`}
-          to={coreSet.path}
-          coreSetExists={coreSet.exist}
+          to={coreSet.path!}
+          coreSetExists={coreSet.exist!}
         />
       );
     case "text":
       return (
-        <CUI.Center w="44" textAlign="center">
+        <CUI.Center w="44" textAlign="center" key={coreSet.label}>
           <CUI.Text fontStyle="italic" fontSize="sm">
             {coreSet.label}
           </CUI.Text>

--- a/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
+++ b/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
@@ -64,9 +64,9 @@ const GetSetCard = (coreSet: CoreSetField) => {
     case "coreSet":
       return (
         <AddCoreSetCard
-          key={coreSet.title}
-          title={`Need to report on ${coreSet.title} data?`}
-          buttonText={`Add ${coreSet.title} Core Set`}
+          key={coreSet.label}
+          title={`Need to report on ${coreSet.label} data?`}
+          buttonText={`Add ${coreSet.label} Core Set`}
           to={coreSet.path!}
           coreSetExists={coreSet.exist!}
         />

--- a/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
+++ b/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
@@ -2,7 +2,6 @@ import { Link, useParams } from "react-router-dom";
 import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
 import { useUser } from "hooks/authHooks";
-import { coreSets } from "shared/coreSetByYear";
 
 interface AddCoreSetCardProps {
   title: string;
@@ -56,43 +55,39 @@ export const AddCoreSetCard = ({
 };
 
 interface Props {
-  renderHealthHomeCoreSet?: boolean;
-  coreSetsInTable?: string[];
+  coreSetCards: any[];
 }
 
-export const AddCoreSetCards = ({
-  coreSetsInTable,
-}: // renderHealthHomeCoreSet = true,
-Props) => {
-  const { year } = useParams();
+const GetSetCard = (coreSet: any) => {
+  switch (coreSet.type) {
+    case "coreSet":
+      return (
+        <AddCoreSetCard
+          title={`Need to report on ${coreSet.title} data?`}
+          buttonText={`Add ${coreSet.title} Core Set`}
+          to={coreSet.path}
+          coreSetExists={coreSet.exist}
+        />
+      );
+    case "text":
+      return (
+        <CUI.Center w="44" textAlign="center">
+          <CUI.Text fontStyle="italic" fontSize="sm">
+            {coreSet.label}
+          </CUI.Text>
+        </CUI.Center>
+      );
+    default:
+      return <></>;
+  }
+};
 
-  const coreSetCards = (
-    coreSets[year as keyof typeof coreSets] as any[]
-  ).filter((set) => !set.loaded && set.type === "coreSet");
-
+export const AddCoreSetCards = ({ coreSetCards }: Props) => {
   return (
     <>
       {coreSetCards.map((coreSet: any) => {
-        return (
-          <AddCoreSetCard
-            title={`Need to report on ${coreSet.title} data?`}
-            buttonText={`Add ${coreSet.title} Core Set`}
-            to={coreSet.path}
-            coreSetExists={coreSet.abbr.some((abbr: string) =>
-              coreSetsInTable?.includes(abbr)
-            )}
-          />
-        );
+        return GetSetCard(coreSet);
       })}
-      {/* 
-      )}
-      {year && parseInt(year) < 2024 && (
-        <CUI.Center w="44" textAlign="center">
-          <CUI.Text fontStyle="italic" fontSize="sm">
-            Only one group of Adult Core Set Measures can be submitted per FFY
-          </CUI.Text>
-        </CUI.Center>
-      )} */}
     </>
   );
 };

--- a/services/ui-src/src/views/StateHome/__tests__/AddCoreSetCards.test.tsx
+++ b/services/ui-src/src/views/StateHome/__tests__/AddCoreSetCards.test.tsx
@@ -5,10 +5,7 @@ import { AddCoreSetCards } from "../AddCoreSetCards";
 beforeEach(() => {
   render(
     <RouterWrappedComp>
-      <AddCoreSetCards
-        childCoreSetExists={true}
-        healthHomesCoreSetExists={true}
-      />
+      <AddCoreSetCards coreSetsInTable={["CCS", "HHCS"]} />
     </RouterWrappedComp>
   );
 });

--- a/services/ui-src/src/views/StateHome/__tests__/AddCoreSetCards.test.tsx
+++ b/services/ui-src/src/views/StateHome/__tests__/AddCoreSetCards.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { RouterWrappedComp } from "utils/testing";
 import { AddCoreSetCards } from "../AddCoreSetCards";
+import { coreSets } from "shared/coreSetByYear";
 
 beforeEach(() => {
   render(
     <RouterWrappedComp>
-      <AddCoreSetCards coreSetsInTable={["CCS", "HHCS"]} />
+      <AddCoreSetCards coreSetCards={coreSets["2022"]} />
     </RouterWrappedComp>
   );
 });

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -198,7 +198,7 @@ const StateHome = () => {
   }
 
   const filteredSpas = SPA[year!].filter((s) => s.state === state);
-  const spaIds = filteredSpas.map((s) => `HHCS_${s.id}`);
+  const spaIds = filteredSpas.map((s) => `${CoreSetAbbr.HHCS}_${s.id}`);
 
   const formattedTableItems = formatTableItems({
     items: data.Items,
@@ -225,7 +225,7 @@ const StateHome = () => {
       //spaIds are only checked against healthHome measures
       const spaInTable = spaIds?.every((id) => coreSetInTable.includes(id));
       //once all the spaIds for this state have been added to the table, push 'HHCS' to the array to tell the system to disable the add button
-      if (spaInTable) coreSetInTable.push("HHCS");
+      if (spaInTable) coreSetInTable.push(CoreSetAbbr.HHCS);
       //the key exist is to trigger the disable state of the add core set button
       return {
         ...set,

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -16,7 +16,7 @@ import { useGetReportingYears } from "hooks/api";
 import { useUpdateAllMeasures } from "hooks/useUpdateAllMeasures";
 import { useResetCoreSet } from "hooks/useResetCoreSet";
 import { BannerCard } from "components/Banner/BannerCard";
-import { coreSets } from "shared/coreSetByYear";
+import { coreSets, CoreSetField } from "shared/coreSetByYear";
 
 import { useFlags } from "launchdarkly-react-client-sdk";
 
@@ -214,14 +214,17 @@ const StateHome = () => {
     (item) => item.coreSet
   );
   //filter and format all the coreset down
-  const coreSetCards = (coreSets[year as keyof typeof coreSets] as any[])
+  const coreSetCards = (
+    coreSets[year as keyof typeof coreSets] as CoreSetField[]
+  )
     .filter(
-      (set) => !set.loaded && (!set.stateList || set.stateList?.includes(state))
+      (set) =>
+        !set.loaded && (!set.stateList || set.stateList?.includes(state!))
     )
     .map((set) => {
       //spaIds are only checked against healthHome measures
       const spaInTable = spaIds?.every((id) => coreSetInTable.includes(id));
-      //if the set of spaIds have all been added to the table, that means the HHCS button should become inactive, add the HHCS key to be filterable
+      //once all the spaIds for this state have been added to the table, push 'HHCS' to the array to tell the system to disable the add button
       if (spaInTable) coreSetInTable.push("HHCS");
       //the key exist is to trigger the disable state of the add core set button
       return {

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -208,23 +208,9 @@ const StateHome = () => {
     exportAll,
   });
 
-  const childCoreSetExists = formattedTableItems.some(
-    (v) =>
-      v.coreSet === CoreSetAbbr.CCS ||
-      v.coreSet === CoreSetAbbr.CCSC ||
-      v.coreSet === CoreSetAbbr.CCSM
+  const coreSetInTable = formattedTableItems.map(
+    (item) => item.coreSet.split("_")[0]
   );
-
-  const filteredHealthHomeCoreSets = formattedTableItems.filter(
-    (v) => !!v?.coreSet?.includes(CoreSetAbbr.HHCS)
-  );
-  const allPossibleHealthHomeCoreSetsExist = !!(
-    filteredHealthHomeCoreSets.length &&
-    spaIds.every((s) =>
-      filteredHealthHomeCoreSets.some((v) => !!v?.coreSet?.includes(s))
-    )
-  );
-
   const selectedStates = ["CA", "DE", "OK"];
   const hideHealthHome = year === "2023" && selectedStates.includes(userState);
 
@@ -249,9 +235,8 @@ const StateHome = () => {
       <QMR.Table data={formattedTableItems} columns={QMR.coreSetColumns} />
       <CUI.HStack spacing="6">
         <AddCoreSetCards
-          childCoreSetExists={childCoreSetExists}
-          healthHomesCoreSetExists={allPossibleHealthHomeCoreSetsExist}
           renderHealthHomeCoreSet={!hideHealthHome && !!spaIds?.length}
+          coreSetsInTable={coreSetInTable}
         />
       </CUI.HStack>
     </QMR.StateLayout>


### PR DESCRIPTION
**Deploy Link**
https://d4kbxh9soszcy.cloudfront.net/

### Description
<!-- Detailed description of changes and related context -->
The generation of the add coreSet buttons are now being controlled in coreSetByYear.tsx file (including the text blob).
![Screenshot 2024-04-15 at 9 36 26 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/39637ff0-e8f9-4bd2-a5d0-c462048c17bc)

Here's the data chunk to correlate:
```
"2023": [
    {
      type: "coreSet",
      label: "Adult",
      loaded: true,
      abbr: ["ACS"],
    },
    {
      type: "coreSet",
      label: "Child",
      path: "add-child",
      abbr: ["CCS", "CCSC", "CCSM"],
    },
    {
      type: "coreSet",
      label: "Health Home",
      path: "add-hh",
      abbr: ["HHCS"],
      stateList: getHHStates("2023"),
    },
    {
      type: "text",
      label:
        "Only one group of Adult Core Set Measures can be submitted per FFY",
    },
  ],
```
**So what changed?**
1) **spaLib.ts** - This file wasn't suppose to be part of this PR but some spa ids did not get removed correctly last year, so its being removed now. This was the original source for determining whether a state will have a healthHome or not.
2) **coreSetByYear.tsx** - This file will now be what is used to control what coreSet should be in what state and for what year. Most keys should be self explanatory except `loaded`, this one is use to determine whether the coreSet is already loaded in the state by default, and therefore does not require an add core set button. This instead, means it is required to be in table already.
3) **AddCoreSetCards.tsx** - This component does not do any data formatting, only for rending a coreSet button or text label. The `GetSetCard` function is where any new render type will get added. It should reduce the noise in this script.
4) **StateHome/index.tsx** - This is where the data object in `coreSetByYear.tsx` is called and formatted, before it is rendered in `AddCoreSetCards.tsx`.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3448

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into [stateuserCA@test.com](mailto:stateuserCA@test.com). 
2) Verify that the coreSet selection for each year looks like the screenshot below.

2021 & 2022  
![Screenshot 2024-04-15 at 9 24 18 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/0a71381c-919f-42a2-a23a-b842c9afaf5d)

2023 (Health Home was removed for CA during this year)
![Screenshot 2024-04-15 at 9 24 34 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/f9de1a7b-5476-47f4-b0ac-10b315715ae3)

2024 (Adult coreset will now be added by button, that is why you can see it now but it will be disabled until everything is merged together in a different pr)
![Screenshot 2024-04-15 at 9 24 45 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/46106b95-97d1-480d-84b9-97f73de46df7)

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

3) In reporting year 2022, add a child core set and a health home coreset (there is two in the dropdown, only add one). [Add Child Core Set] button should become inactive but Health Home should still be active. 
4) Add the second health home and the button should become inactive.
5) Delete the child core set, click the 3 dot button on the right and select [Delete]
6) The button should be enable again.
7) This is sufficient to test if the data is being pulled correctly from coreSetByYear.tsx file. You can also go into that file and add a coreset or remove one just to see how it works but that is not necessary for this test.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
