### PR TITLE
Cmdct 3450

### DIFF
--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -49,8 +49,9 @@ export interface Banner {
 
 export const enum CoreSetAbbr {
   ACS = "ACS", // adult
-  ACSM = "ACSM", // adult multiple
-  ACSC = "ACSC", // adult combined
+  // TODO: update ACSM and ACSC
+  ACSM = "ACS", // adult multiple
+  ACSC = "ACS", // adult combined
   CCS = "CCS", // child combined
   CCSM = "CCSM", // child medicaid
   CCSC = "CCSC", // child chip

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -49,6 +49,8 @@ export interface Banner {
 
 export const enum CoreSetAbbr {
   ACS = "ACS", // adult
+  ACSM = "ACSM", // adult multiple
+  ACSC = "ACSC", // adult combined
   CCS = "CCS", // child combined
   CCSM = "CCSM", // child medicaid
   CCSC = "CCSC", // child chip

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -33,11 +33,13 @@ const AddChildCoreSet = lazy(() =>
     default: module.AddChildCoreSet,
   }))
 );
+/**
 const AddAdultCoreSet = lazy(() =>
   import("views/AddAdultCoreSet").then((module) => ({
     default: module.AddAdultCoreSet,
   }))
 );
+ */
 const AddStateSpecificMeasure = lazy(() =>
   import("views/AddStateSpecificMeasure").then((module) => ({
     default: module.AddStateSpecificMeasure,

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -33,13 +33,11 @@ const AddChildCoreSet = lazy(() =>
     default: module.AddChildCoreSet,
   }))
 );
-/**
 const AddAdultCoreSet = lazy(() =>
   import("views/AddAdultCoreSet").then((module) => ({
     default: module.AddAdultCoreSet,
   }))
 );
- */
 const AddStateSpecificMeasure = lazy(() =>
   import("views/AddStateSpecificMeasure").then((module) => ({
     default: module.AddStateSpecificMeasure,
@@ -165,6 +163,7 @@ export function AppRoutes() {
           }
         />
         <Route path=":state/:year/add-child" element={<AddChildCoreSet />} />
+        <Route path=":state/:year/add-adult" element={<AddAdultCoreSet />} />
         <Route path=":state/:year/add-hh" element={<AddHHCoreSet />} />
         <Route path=":state/:year/:coreSetId" element={<CoreSet />} />
         <Route path=":state/:year/:coreSetId/pdf" element={<ExportAll />} />

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -33,6 +33,11 @@ const AddChildCoreSet = lazy(() =>
     default: module.AddChildCoreSet,
   }))
 );
+const AddAdultCoreSet = lazy(() =>
+  import("views/AddAdultCoreSet").then((module) => ({
+    default: module.AddAdultCoreSet,
+  }))
+);
 const AddStateSpecificMeasure = lazy(() =>
   import("views/AddStateSpecificMeasure").then((module) => ({
     default: module.AddStateSpecificMeasure,

--- a/services/ui-src/src/types.ts
+++ b/services/ui-src/src/types.ts
@@ -1,5 +1,7 @@
 export enum CoreSetAbbr {
   ACS = "ACS",
+  ACSM = "ACSM",
+  ACSC = "ACSC",
   CCS = "CCS",
   CCSM = "CCSM",
   CCSC = "CCSC",

--- a/services/ui-src/src/types.ts
+++ b/services/ui-src/src/types.ts
@@ -1,7 +1,8 @@
 export enum CoreSetAbbr {
   ACS = "ACS",
-  ACSM = "ACSM",
-  ACSC = "ACSC",
+  // TODO: update ACSM and ACSC
+  ACSM = "ACS",
+  ACSC = "ACS",
   CCS = "CCS",
   CCSM = "CCSM",
   CCSC = "CCSC",

--- a/services/ui-src/src/views/AddAdultCoreSet/index.test.tsx
+++ b/services/ui-src/src/views/AddAdultCoreSet/index.test.tsx
@@ -62,10 +62,4 @@ describe("Test Add Adult Core Set Component", () => {
       )
     ).toBeChecked();
   });
-
-  it("creates the new adult core set", () => {
-    const mockSubmit = jest.fn();
-    userEvent.click(screen.getByRole("button", { name: "Create" }));
-    expect(mockSubmit.mock.calls.length).toEqual(1);
-  });
 });

--- a/services/ui-src/src/views/AddAdultCoreSet/index.test.tsx
+++ b/services/ui-src/src/views/AddAdultCoreSet/index.test.tsx
@@ -48,4 +48,24 @@ describe("Test Add Adult Core Set Component", () => {
       )
     ).toBeChecked();
   });
+
+  it("Form properly interactable, combined selection", () => {
+    userEvent.click(
+      screen.getByText(
+        /Reporting Medicaid and CHIP measures in combined Core Sets/i
+      )
+    );
+
+    expect(
+      screen.getByLabelText(
+        /Reporting Medicaid and CHIP measures in combined Core Sets/i
+      )
+    ).toBeChecked();
+  });
+
+  it("creates the new adult core set", () => {
+    const mockSubmit = jest.fn();
+    userEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(mockSubmit.mock.calls.length).toEqual(1);
+  });
 });

--- a/services/ui-src/src/views/AddAdultCoreSet/index.test.tsx
+++ b/services/ui-src/src/views/AddAdultCoreSet/index.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RouterWrappedComp } from "utils/testing";
+import { AddAdultCoreSet } from ".";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { useApiMock } from "utils/testUtils/useApiMock";
+
+const queryClient = new QueryClient();
+
+describe("Test Add Adult Core Set Component", () => {
+  beforeEach(() => {
+    useApiMock({});
+    render(
+      <QueryClientProvider client={queryClient}>
+        <RouterWrappedComp>
+          <AddAdultCoreSet />
+        </RouterWrappedComp>
+      </QueryClientProvider>
+    );
+  });
+
+  test("Check that the nav renders", () => {
+    expect(screen.getByTestId("state-layout-container")).toBeVisible();
+  });
+
+  it("Renders the correct adult components", () => {
+    expect(
+      screen.getByText(/How are you reporting Adult Core Set measures/i)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        /Remember to complete all Adult Core Set Questions and Adult Core Set Measures to submit for CMS review./i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("Form properly interactable", () => {
+    userEvent.click(
+      screen.getByText(
+        /Reporting Medicaid and CHIP measures in separate Core Sets/i
+      )
+    );
+
+    expect(
+      screen.getByLabelText(
+        /Reporting Medicaid and CHIP measures in separate Core Sets/i
+      )
+    ).toBeChecked();
+  });
+});

--- a/services/ui-src/src/views/AddAdultCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddAdultCoreSet/index.tsx
@@ -50,7 +50,7 @@ export const AddAdultCoreSet = () => {
       case ReportType.SEPARATE:
         mutation.mutate(CoreSetAbbr.ACSM, {
           onSuccess: () => {
-            mutation.mutate(CoreSetAbbr.ACS, {
+            mutation.mutate(CoreSetAbbr.ACSC, {
               onSuccess: () => {
                 queryClient.refetchQueries(["coreSets", state, year]);
                 navigate(`/${state}/${year}`);
@@ -60,7 +60,7 @@ export const AddAdultCoreSet = () => {
         });
         break;
       case ReportType.COMBINED:
-        mutation.mutate(CoreSetAbbr.ACSC, {
+        mutation.mutate(CoreSetAbbr.ACS, {
           onSuccess: () => {
             queryClient.refetchQueries(["coreSets", state, year]);
             navigate(`/${state}/${year}`);

--- a/services/ui-src/src/views/AddAdultCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddAdultCoreSet/index.tsx
@@ -1,0 +1,137 @@
+import * as CUI from "@chakra-ui/react";
+import * as QMR from "components";
+import { useParams, useNavigate } from "react-router-dom";
+import { FormProvider, useForm } from "react-hook-form";
+import { useCustomRegister } from "hooks/useCustomRegister";
+import * as Api from "hooks/api";
+import { useQueryClient } from "react-query";
+import { CoreSetAbbr, UserRoles } from "types";
+import { useUser } from "hooks/authHooks";
+
+enum ReportType {
+  SEPARATE = "separate",
+  COMBINED = "combined",
+}
+
+interface AdultCoreSetReportType {
+  "AdultCoreSet-ReportType": ReportType;
+}
+
+export const AddAdultCoreSet = () => {
+  const mutation = Api.useAddCoreSet();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { userState, userRole } = useUser();
+
+  const methods = useForm({
+    shouldUnregister: true,
+    mode: "all",
+  });
+
+  const watchReportType = methods.watch("AdultCoreSet-ReportType");
+
+  const { state, year } = useParams();
+  const register = useCustomRegister<AdultCoreSetReportType>();
+
+  // block display from state users without permissions for the corresponding state
+  if (userState && userState !== state && userRole === UserRoles.STATE_USER) {
+    return (
+      <CUI.Box data-testid="unauthorized-container">
+        <QMR.Notification
+          alertStatus="error"
+          alertTitle="You are not authorized to view this page"
+        />
+      </CUI.Box>
+    );
+  }
+
+  const handleSubmit = (data: AdultCoreSetReportType) => {
+    switch (data["AdultCoreSet-ReportType"]) {
+      case ReportType.SEPARATE:
+        mutation.mutate(CoreSetAbbr.ACSM, {
+          onSuccess: () => {
+            mutation.mutate(CoreSetAbbr.ACS, {
+              onSuccess: () => {
+                queryClient.refetchQueries(["coreSets", state, year]);
+                navigate(`/${state}/${year}`);
+              },
+            });
+          },
+        });
+        break;
+      case ReportType.COMBINED:
+        mutation.mutate(CoreSetAbbr.ACSC, {
+          onSuccess: () => {
+            queryClient.refetchQueries(["coreSets", state, year]);
+            navigate(`/${state}/${year}`);
+          },
+        });
+    }
+  };
+
+  return (
+    <QMR.StateLayout
+      breadcrumbItems={[
+        { path: `/${state}/${year}`, name: `FFY ${year}` },
+        { path: `/${state}/${year}/add-adult`, name: "Add Adult Core Set" },
+      ]}
+    >
+      <CUI.Stack spacing="5">
+        <CUI.Heading fontSize="2xl">Adult Core Set Details</CUI.Heading>
+        <CUI.Text>
+          Complete the details below and when finished create the additional
+          Adult Core Set report(s).
+        </CUI.Text>
+        <FormProvider {...methods}>
+          <form onSubmit={methods.handleSubmit(handleSubmit)}>
+            <CUI.Container maxW="container.xl" as="section">
+              <CUI.Stack spacing="10">
+                <QMR.RadioButton
+                  formLabelProps={{ fontWeight: 600 }}
+                  label="1. How are you reporting Adult Core Set measures?"
+                  {...register("AdultCoreSet-ReportType")}
+                  options={[
+                    {
+                      displayValue:
+                        "Reporting Medicaid and CHIP measures in separate Core Sets",
+                      value: ReportType.SEPARATE,
+                    },
+                    {
+                      displayValue:
+                        "Reporting Medicaid and CHIP measures in combined Core Sets",
+                      value: ReportType.COMBINED,
+                    },
+                  ]}
+                />
+                <CUI.Box>
+                  <CUI.Text fontWeight="600">
+                    2. Finish to create the Adult Core Set report(s)
+                  </CUI.Text>
+                  <CUI.Text pl={4} pt={1}>
+                    Remember to complete all Adult Core Set Questions and Adult
+                    Core Set Measures to submit for CMS review.
+                  </CUI.Text>
+
+                  <CUI.HStack paddingTop="5">
+                    <QMR.ContainedButton
+                      buttonProps={{ type: "submit", background: "blue.500" }}
+                      buttonText={mutation.isLoading ? "Loading" : "Create"}
+                      disabledStatus={!watchReportType || mutation.isLoading}
+                    />
+                    <QMR.ContainedButton
+                      buttonProps={{ color: "blue", colorScheme: "white" }}
+                      buttonText="Cancel"
+                      onClick={() => {
+                        navigate(`/${state}/${year}`);
+                      }}
+                    />
+                  </CUI.HStack>
+                </CUI.Box>
+              </CUI.Stack>
+            </CUI.Container>
+          </form>
+        </FormProvider>
+      </CUI.Stack>
+    </QMR.StateLayout>
+  );
+};

--- a/services/ui-src/src/views/AddChildCoreSet/index.test.tsx
+++ b/services/ui-src/src/views/AddChildCoreSet/index.test.tsx
@@ -4,11 +4,27 @@ import { RouterWrappedComp } from "utils/testing";
 import { AddChildCoreSet } from ".";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { useApiMock } from "utils/testUtils/useApiMock";
+import { UserRoles } from "types";
+import { useUser } from "hooks/authHooks";
+
+jest.mock("hooks/authHooks");
+const mockUseUser = useUser as jest.Mock;
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: () => ({
+    year: "2024",
+    state: "OH",
+  }),
+}));
 
 const queryClient = new QueryClient();
 
 describe("Test Add Child Core Set Component", () => {
   beforeEach(() => {
+    mockUseUser.mockImplementation(() => {
+      return { userState: "OH", userRole: UserRoles.STATE_USER };
+    });
     useApiMock({});
     render(
       <QueryClientProvider client={queryClient}>
@@ -47,5 +63,21 @@ describe("Test Add Child Core Set Component", () => {
         /Reporting Medicaid and CHIP measures in separate Core Sets/i
       )
     ).toBeChecked();
+  });
+
+  test("Unauthorized state user sees unauthorized message", () => {
+    mockUseUser.mockImplementation(() => {
+      return { userState: "DC", userRole: UserRoles.STATE_USER };
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <RouterWrappedComp>
+          <AddChildCoreSet />
+        </RouterWrappedComp>
+      </QueryClientProvider>
+    );
+    expect(
+      screen.getByText(/You are not authorized to view this page/i)
+    ).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/views/AddHHCoreSet/index.test.tsx
+++ b/services/ui-src/src/views/AddHHCoreSet/index.test.tsx
@@ -3,29 +3,36 @@ import { RouterWrappedComp } from "utils/testing";
 import { AddHHCoreSet } from ".";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { useApiMock } from "utils/testUtils/useApiMock";
+import { UserRoles } from "types";
+import { useUser } from "hooks/authHooks";
 
-const queryClient = new QueryClient();
+jest.mock("hooks/authHooks");
+const mockUseUser = useUser as jest.Mock;
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useParams: () => ({
-    year: "2021",
-    state: "DC",
+    year: "2024",
+    state: "OH",
   }),
 }));
 
-beforeEach(() => {
-  useApiMock({});
-  render(
-    <QueryClientProvider client={queryClient}>
-      <RouterWrappedComp>
-        <AddHHCoreSet />
-      </RouterWrappedComp>
-    </QueryClientProvider>
-  );
-});
+const queryClient = new QueryClient();
 
 describe("Test HealthHome coreset component", () => {
+  beforeEach(() => {
+    mockUseUser.mockImplementation(() => {
+      return { userState: "OH", userRole: UserRoles.STATE_USER };
+    });
+    useApiMock({});
+    render(
+      <QueryClientProvider client={queryClient}>
+        <RouterWrappedComp>
+          <AddHHCoreSet />
+        </RouterWrappedComp>
+      </QueryClientProvider>
+    );
+  });
   test("Check that the nav renders", () => {
     expect(screen.getByTestId("state-layout-container")).toBeVisible();
   });
@@ -41,6 +48,22 @@ describe("Test HealthHome coreset component", () => {
       screen.getByText(
         /remember to complete all Health Home Core Set Questions and Health Home Core Set Measures to submit for CMS review./i
       )
+    ).toBeInTheDocument();
+  });
+
+  test("Unauthorized state user sees unauthorized message", () => {
+    mockUseUser.mockImplementation(() => {
+      return { userState: "DC", userRole: UserRoles.STATE_USER };
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <RouterWrappedComp>
+          <AddHHCoreSet />
+        </RouterWrappedComp>
+      </QueryClientProvider>
+    );
+    expect(
+      screen.getByText(/You are not authorized to view this page/i)
     ).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -27,6 +27,8 @@ interface HandleDeleteMeasureData {
 
 enum coreSetType {
   ACS = "Adult",
+  ACSM = "Adult - Multiple",
+  ACSC = "Adult - Combined",
   CCS = "Child",
   CCSM = "Child - Medicaid",
   CCSC = "Child - CHIP",
@@ -35,6 +37,8 @@ enum coreSetType {
 
 export enum coreSetMeasureTitle {
   ACS = "Adult Core Set Measures",
+  ACSM = "Adult Core Set Multiple",
+  ACSC = "Adult Core Set Combined",
   CCS = "Child Core Set Measures: Medicaid & CHIP",
   CCSM = "Child Core Set Measures: Medicaid",
   CCSC = "Child Core Set Measures: CHIP",
@@ -43,6 +47,8 @@ export enum coreSetMeasureTitle {
 
 enum coreSetQuestionsText {
   ACS = "Adult Core Set Questions",
+  ACSM = "Adult Core Set Questions - Multiple",
+  ACSC = "Adult Core Set Questions - Combined",
   CCS = "Child Core Set Questions: Medicaid & CHIP",
   CCSM = "Child Core Set Questions: Medicaid",
   CCSC = "Child Core Set Questions: CHIP",

--- a/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
+++ b/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
@@ -82,6 +82,12 @@ export const AddCoreSetCards = ({
           coreSetExists={healthHomesCoreSetExists}
         />
       )}
+      <AddCoreSetCard
+        title="Need to report on Adult data?"
+        buttonText="Add Adult Core Set"
+        to="add-adult"
+        coreSetExists={childCoreSetExists}
+      />
       {year && parseInt(year) < 2024 && (
         <CUI.Center w="44" textAlign="center">
           <CUI.Text fontStyle="italic" fontSize="sm">

--- a/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
+++ b/services/ui-src/src/views/StateHome/AddCoreSetCards.tsx
@@ -70,15 +70,6 @@ const GetSetCard = (coreSet: CoreSetField) => {
           to={coreSet.path!}
           coreSetExists={coreSet.exist!}
         />
-      )}
-      <AddCoreSetCard
-        title="Need to report on Adult data?"
-        buttonText="Add Adult Core Set"
-        to="add-adult"
-        coreSetExists={childCoreSetExists}
-      />
-      {year && parseInt(year) < 2024 && (
-        <CUI.Center w="44" textAlign="center">
       );
     case "text":
       return (

--- a/services/ui-src/src/views/index.tsx
+++ b/services/ui-src/src/views/index.tsx
@@ -6,6 +6,7 @@ export * from "./MeasuresLoading";
 export * from "./NotFound";
 export * from "./StateHome";
 export * from "./AddChildCoreSet";
+export * from "./AddAdultCoreSet";
 export * from "./AddHHCoreSet";
 export * from "./ApiTester";
 export * from "./ExportAll";


### PR DESCRIPTION
### Description
just the route for the new adult core sets


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3450

---
### How to test
In `AddCoreSetCards.tsx`, add a new `AddCoreSetCard` component, you should see the option appear and it will take you to the new page route.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
