### PR TITLE
Remove cypress steps for tests that have been deleted

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,54 +238,6 @@ jobs:
       cypress-user4: ${{ secrets.CYPRESS_TEST_USER_4 }}
       cypress-password: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}
 
-  child-e2e-measure-tests:
-    name: "Child End To End Tests"
-    uses: ./.github/workflows/cypress-workflow.yml
-    needs:
-      - e2e-tests-init
-      - setup-tests
-    with:
-      test-path: "measures/child"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
-    secrets:
-      cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
-      cypress-user2: ${{ secrets.CYPRESS_TEST_USER_2 }}
-      cypress-user3: ${{ secrets.CYPRESS_TEST_USER_3 }}
-      cypress-user4: ${{ secrets.CYPRESS_TEST_USER_4 }}
-      cypress-password: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}
-
-  adult-e2e-measure-tests:
-    name: "Adult End To End Tests"
-    uses: ./.github/workflows/cypress-workflow.yml
-    needs:
-      - e2e-tests-init
-      - setup-tests
-    with:
-      test-path: "measures/adult"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
-    secrets:
-      cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
-      cypress-user2: ${{ secrets.CYPRESS_TEST_USER_2 }}
-      cypress-user3: ${{ secrets.CYPRESS_TEST_USER_3 }}
-      cypress-user4: ${{ secrets.CYPRESS_TEST_USER_4 }}
-      cypress-password: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}
-
-  health-home-e2e-measure-tests:
-    name: "Health Home End To End Measure Tests"
-    uses: ./.github/workflows/cypress-workflow.yml
-    needs:
-      - e2e-tests-init
-      - setup-tests
-    with:
-      test-path: "measures/healthhome"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
-    secrets:
-      cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
-      cypress-user2: ${{ secrets.CYPRESS_TEST_USER_2 }}
-      cypress-user3: ${{ secrets.CYPRESS_TEST_USER_3 }}
-      cypress-user4: ${{ secrets.CYPRESS_TEST_USER_4 }}
-      cypress-password: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}
-
   e2e-feature-tests:
     name: End To End Feature Tests
     uses: ./.github/workflows/cypress-workflow.yml
@@ -294,21 +246,6 @@ jobs:
       - setup-tests
     with:
       test-path: "features"
-      test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
-    secrets:
-      cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}
-      cypress-user2: ${{ secrets.CYPRESS_TEST_USER_2 }}
-      cypress-user3: ${{ secrets.CYPRESS_TEST_USER_3 }}
-      cypress-user4: ${{ secrets.CYPRESS_TEST_USER_4 }}
-      cypress-password: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}
-
-  a11y-tests:
-    name: Accessibility Tests
-    needs:
-      - e2e-tests-init
-    uses: ./.github/workflows/cypress-workflow.yml
-    with:
-      test-path: "a11y"
       test-endpoint: "${{ needs.e2e-tests-init.outputs.application_endpoint }}"
     secrets:
       cypress-user1: ${{ secrets.CYPRESS_TEST_USER_1 }}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Completing work in removing cypress tests by deleting the steps to run them in CI

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3379
CMDCT-3380
CMDCT-3381
CMDCT-3382

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Cypress steps for adult, child, health home, and a11y don't try to run

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
We'll need to make sure to add something like this back when we add new tests as part of CMDCT-3529

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment
