### PR TITLE
Assert failure when matrix runners fail to find test files

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -35,10 +35,9 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-test-matrix
         run: |
-          TEST_PATH="tests/cypress/cypress/e2e/${{ inputs.test-path }}/*"
-          [ -n "$(find ${TEST_PATH} -maxdepth 0 -type d -empty 2>/dev/null)" ] && echo "No test definition found...exiting" && exit 1
-          TEST_MATRIX=$(ls -1 "${TEST_PATH}" | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
+          TEST_MATRIX=$(ls -1 "tests/cypress/cypress/e2e/${{ inputs.test-path }}/*" | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
           echo "Test definitions: ${TEST_MATRIX}"
+          [ $(jq length <<< "${TEST_MATRIX}") -lt 1 ] && echo "No test definition found...exiting" && exit 1
           echo "test-matrix=${TEST_MATRIX}" >> $GITHUB_OUTPUT
     outputs:
       test-matrix: ${{ steps.set-test-matrix.outputs.test-matrix}}

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -37,7 +37,7 @@ jobs:
         # run: |
         #   echo "test-matrix=$(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
         run: |
-          echo $(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/*
+          echo $(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/*)
           echo $(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
           echo "test-matrix=$(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
     outputs:

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -34,10 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-test-matrix
+        # run: |
+        #   echo "test-matrix=$(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
         run: |
-          echo $(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/*)
-          test-matrix=$(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
-          echo "test-matrix=$test-matrix" >> $GITHUB_OUTPUT
+          echo $(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/*
+          echo $(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
+          echo "test-matrix=$(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
     outputs:
       test-matrix: ${{ steps.set-test-matrix.outputs.test-matrix}}
   e2e-tests:

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -36,7 +36,7 @@ jobs:
       - id: set-test-matrix
         run: |
           TEST_PATH="tests/cypress/cypress/e2e/${{ inputs.test-path }}/*"
-          [ -z "$(find "${TEST_PATH}" -maxdepth 0 -type d -empty 2>/dev/null)" ] && echo "No test definition found...exiting" && exit 1
+          [ -n "$(find ${TEST_PATH} -maxdepth 0 -type d -empty 2>/dev/null)" ] && echo "No test definition found...exiting" && exit 1
           TEST_MATRIX=$(ls -1 "${TEST_PATH}" | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
           echo "Test definitions: ${TEST_MATRIX}"
           echo "test-matrix=${TEST_MATRIX}" >> $GITHUB_OUTPUT

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -34,12 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-test-matrix
-        # run: |
-        #   echo "test-matrix=$(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
         run: |
-          echo $(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/*)
-          echo $(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
-          echo "test-matrix=$(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          TEST_PATH="tests/cypress/cypress/e2e/${{ inputs.test-path }}/*"
+          [ -z "$(find "${TEST_PATH}" -maxdepth 0 -type d -empty 2>/dev/null)" ] && echo "No test definition found...exiting" && exit 1
+          TEST_MATRIX=$(ls -1 "${TEST_PATH}" | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
+          echo "Test definitions: ${TEST_MATRIX}"
+          echo "test-matrix=${TEST_MATRIX}" >> $GITHUB_OUTPUT
     outputs:
       test-matrix: ${{ steps.set-test-matrix.outputs.test-matrix}}
   e2e-tests:

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -35,7 +35,9 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-test-matrix
         run: |
-          echo "test-matrix=$(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          echo $(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/*)
+          test-matrix=$(ls -1 tests/cypress/cypress/e2e/${{ inputs.test-path }}/* | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1]')
+          echo "test-matrix=$test-matrix" >> $GITHUB_OUTPUT
     outputs:
       test-matrix: ${{ steps.set-test-matrix.outputs.test-matrix}}
   e2e-tests:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,55 +21,55 @@ jobs:
     if: github.ref_name == 'master'
     secrets:
       CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
-  # deploy:
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: set branch_name # Some integrations (Snyk) build very long branch names. This is a switch to make long branch names shorter.
-  #       run: |
-  #         BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
-  #         echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
-  #     - name: Validate branch name
-  #       run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
-  #     - name: set branch specific variable names
-  #       run: ./.github/build_vars.sh set_names
-  #     - name: set variable values
-  #       run: ./.github/build_vars.sh set_values
-  #       env:
-  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-  #         AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
-  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-  #         CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
-  #     - name: Configure AWS credentials for GitHub Actions
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
-  #         aws-region: ${{ env.AWS_DEFAULT_REGION }}
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version-file: ".nvmrc"
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: "**/node_modules"
-  #         key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
-  #     - name: set path
-  #       run: |
-  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-  #     - name: deploy
-  #       run: |
-  #         # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
-  #         # This can optionally be set as an GitHub Actions Secret
-  #         ./deploy.sh $STAGE_PREFIX$branch_name
-  #     - name: Endpoint
-  #       id: endpoint
-  #       run: |
-  #         APPLICATION_ENDPOINT=$(./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name)
-  #         echo "application_endpoint=$APPLICATION_ENDPOINT" >> $GITHUB_OUTPUT
-  #         echo "## Application Endpoint" >> $GITHUB_STEP_SUMMARY
-  #         echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
-  #       working-directory: services
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
+    steps:
+      - uses: actions/checkout@v4
+      - name: set branch_name # Some integrations (Snyk) build very long branch names. This is a switch to make long branch names shorter.
+        run: |
+          BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
+      - name: Validate branch name
+        run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
+      - name: set branch specific variable names
+        run: ./.github/build_vars.sh set_names
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+          CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+      - uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
+      - name: set path
+        run: |
+          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+      - name: deploy
+        run: |
+          # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
+          # This can optionally be set as an GitHub Actions Secret
+          ./deploy.sh $STAGE_PREFIX$branch_name
+      - name: Endpoint
+        id: endpoint
+        run: |
+          APPLICATION_ENDPOINT=$(./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name)
+          echo "application_endpoint=$APPLICATION_ENDPOINT" >> $GITHUB_OUTPUT
+          echo "## Application Endpoint" >> $GITHUB_STEP_SUMMARY
+          echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
+        working-directory: services
     outputs:
       application_endpoint: ${{ steps.endpoint.outputs.application_endpoint}}
       BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,55 +21,55 @@ jobs:
     if: github.ref_name == 'master'
     secrets:
       CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
-  deploy:
-    runs-on: ubuntu-latest
-    env:
-      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
-    steps:
-      - uses: actions/checkout@v4
-      - name: set branch_name # Some integrations (Snyk) build very long branch names. This is a switch to make long branch names shorter.
-        run: |
-          BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
-          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
-      - name: Validate branch name
-        run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
-      - name: set branch specific variable names
-        run: ./.github/build_vars.sh set_names
-      - name: set variable values
-        run: ./.github/build_vars.sh set_values
-        env:
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-          AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
-          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-          CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
-      - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-      - uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
-      - name: set path
-        run: |
-          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-      - name: deploy
-        run: |
-          # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
-          # This can optionally be set as an GitHub Actions Secret
-          ./deploy.sh $STAGE_PREFIX$branch_name
-      - name: Endpoint
-        id: endpoint
-        run: |
-          APPLICATION_ENDPOINT=$(./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name)
-          echo "application_endpoint=$APPLICATION_ENDPOINT" >> $GITHUB_OUTPUT
-          echo "## Application Endpoint" >> $GITHUB_STEP_SUMMARY
-          echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
-        working-directory: services
+  # deploy:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: set branch_name # Some integrations (Snyk) build very long branch names. This is a switch to make long branch names shorter.
+  #       run: |
+  #         BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
+  #         echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
+  #     - name: Validate branch name
+  #       run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
+  #     - name: set branch specific variable names
+  #       run: ./.github/build_vars.sh set_names
+  #     - name: set variable values
+  #       run: ./.github/build_vars.sh set_values
+  #       env:
+  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+  #         CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
+  #     - name: Configure AWS credentials for GitHub Actions
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ env.AWS_DEFAULT_REGION }}
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version-file: ".nvmrc"
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: "**/node_modules"
+  #         key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
+  #     - name: set path
+  #       run: |
+  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+  #     - name: deploy
+  #       run: |
+  #         # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
+  #         # This can optionally be set as an GitHub Actions Secret
+  #         ./deploy.sh $STAGE_PREFIX$branch_name
+  #     - name: Endpoint
+  #       id: endpoint
+  #       run: |
+  #         APPLICATION_ENDPOINT=$(./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name)
+  #         echo "application_endpoint=$APPLICATION_ENDPOINT" >> $GITHUB_OUTPUT
+  #         echo "## Application Endpoint" >> $GITHUB_STEP_SUMMARY
+  #         echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
+  #       working-directory: services
     outputs:
       application_endpoint: ${{ steps.endpoint.outputs.application_endpoint}}
       BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION }}


### PR DESCRIPTION
### Description
This gave me a mild panic attack yesterday....

I found some Snyk PRs that were automerged that were indicated to have failed tests.  After playing with this quite a bit, it seems that the failures for the matrix are produced asynchronously, so a build will go green when the matrix runners fail to build, then go red a few seconds later, which was enabling PRs to merge in that interim, and in the case of Snyk PRs, they are set to auto-merge when all checks pass, so this little blip let them slip through.  

This little change just asserts that the files are identified before the cypress-workflow passes off the config to the deploy workflow.  An example of it successfully failing can be seen here:  [deploy workflow](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/runs/8710353652)

### Related ticket(s)

There isn't a ticket, but it goes hand in hand with this:  [Remove cypress steps for tests that have been deleted ](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2184)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
