### PR TITLE
[QMR] ADD-CH - Content Change 

### DIFF
--- a/services/ui-src/src/measures/2023/ADDCH/data.ts
+++ b/services/ui-src/src/measures/2023/ADDCH/data.ts
@@ -14,7 +14,7 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
   ],
   questionSubtext: [
     "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication, who had one follow-up visit with a practitioner with prescribing authority during the 30-day Initiation Phase.",
-    "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication who remained on the medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.",
+    "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication, who remained on the medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.",
   ],
   categories,
   qualifiers,

--- a/services/ui-src/src/measures/2024/ADDCH/data.ts
+++ b/services/ui-src/src/measures/2024/ADDCH/data.ts
@@ -14,7 +14,7 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
   ],
   questionListOrderedItems: [
     "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication, who had one follow-up visit with a practitioner with prescribing authority during the 30-day Initiation Phase.",
-    "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication who remained on the medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.",
+    "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD medication, who remained on the medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.",
   ],
   categories,
   qualifiers,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Added commas as requested by AC

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-
3564
---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
go to ADD-CH and make sure that the comma after **medication** and before **who** exists: "Percentage of children ages 6 to 12 with a prescription dispensed for ADHD **medication, who** remained on the medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.”

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
