### PR TITLE
[QMR] NCIIDD-AD Content Change

### DIFF
--- a/services/ui-src/src/measures/2024/NCIIDDAD/index.tsx
+++ b/services/ui-src/src/measures/2024/NCIIDDAD/index.tsx
@@ -10,7 +10,7 @@ export const NCIIDAD = ({ name, year }: Props) => {
     <QMR.AutocompletedMeasureTemplate
       year={year}
       measureTitle={`NCIIDD-AD - ${name}`}
-      performanceMeasureText="The National Core Indicators® – Intellectual and Developmental Disabilities (NCI-IDD) provide information on beneficiaries’ experience and self-reported outcomes of long-term services and supports for individuals with intellectual and/or developmental disabilities (I/DD) and their families. NCI-IDD includes an in-person survey, family surveys for parents and guardians of adults and children who receive I/DD supports, and a State of the Workforce Survey.  For the purposes of the Adult Core Set, only data from the NCI-IDD In-Person Survey will be reported."
+      performanceMeasureText="The National Core Indicators® – Intellectual and Developmental Disabilities (NCI-IDD®) provide information on beneficiaries’ experience and self-reported outcomes of long-term services and supports for individuals with intellectual and/or developmental disabilities (I/DD) and their families. NCI-IDD includes an in-person survey, family surveys for parents and guardians of adults and children who receive I/DD supports, and a State of the Workforce Survey.  For the purposes of the Adult Core Set, only data from the NCI-IDD In-Person Survey will be reported."
       performanceMeasureSubtext="To reduce state burden and streamline reporting, CMS will calculate this measure for states using data that states submitted to NASDDDS/HSRI (the NCI National Team) through the Online Data Entry System (ODESA). CMS will work with the NCI National Team to obtain data for all states that gave permission for data to be released to CMS for the purpose of Adult Core Set reporting."
     />
   );

--- a/services/ui-src/src/measures/2024/NCIIDDAD/index.tsx
+++ b/services/ui-src/src/measures/2024/NCIIDDAD/index.tsx
@@ -10,7 +10,7 @@ export const NCIIDAD = ({ name, year }: Props) => {
     <QMR.AutocompletedMeasureTemplate
       year={year}
       measureTitle={`NCIIDD-AD - ${name}`}
-      performanceMeasureText="The National Core Indicators – Intellectual and Developmental Disabilities (NCI-IDD) provide information on beneficiaries’ experience and self-reported outcomes of long-term services and supports for individuals with intellectual and/or developmental disabilities (I/DD) and their families. NCI-IDD includes an in-person survey, family surveys for parents and guardians of adults and children who receive I/DD supports and a State of the Workforce Survey.  For the purposes of the Adult Core Set, only data from the NCI-IDD In-Person Survey will be reported.  **"
+      performanceMeasureText="The National Core Indicators® – Intellectual and Developmental Disabilities (NCI-IDD) provide information on beneficiaries’ experience and self-reported outcomes of long-term services and supports for individuals with intellectual and/or developmental disabilities (I/DD) and their families. NCI-IDD includes an in-person survey, family surveys for parents and guardians of adults and children who receive I/DD supports, and a State of the Workforce Survey.  For the purposes of the Adult Core Set, only data from the NCI-IDD In-Person Survey will be reported."
       performanceMeasureSubtext="To reduce state burden and streamline reporting, CMS will calculate this measure for states using data that states submitted to NASDDDS/HSRI (the NCI National Team) through the Online Data Entry System (ODESA). CMS will work with the NCI National Team to obtain data for all states that gave permission for data to be released to CMS for the purpose of Adult Core Set reporting."
     />
   );


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
content changes made:
- Add registered icon after "The National Core Indicators"
- Delete two extra **
- Add Comma between  “who receive I/DD supports, and a State of the Workforce Survey.”

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3559

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

sentence should read: "The National Core Indicators® – Intellectual and Developmental Disabilities (NCI-IDD) provide information on beneficiaries’ experience and self-reported outcomes of long-term services and supports for individuals with intellectual and/or developmental disabilities (I/DD) and their families. NCI-IDD includes an in-person survey, family surveys for parents and guardians of adults and children who receive I/DD supports, and a State of the Workforce Survey.  For the purposes of the Adult Core Set, only data from the NCI-IDD In-Person Survey will be reported."

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
