### PR TITLE
Add "View Combined Rates" button to state home page

### DIFF
--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -166,13 +166,13 @@ export function AppRoutes() {
         <Route path=":state/:year/add-child" element={<AddChildCoreSet />} />
         <Route path=":state/:year/add-adult" element={<AddAdultCoreSet />} />
         <Route path=":state/:year/add-hh" element={<AddHHCoreSet />} />
+        <Route path=":state/:year/combined-rates" element={<CombinedRatesPage />} />
         <Route path=":state/:year/:coreSetId" element={<CoreSet />} />
         <Route path=":state/:year/:coreSetId/pdf" element={<ExportAll />} />
         <Route
           path=":state/:year/:coreSetId/add-ssm"
           element={<AddStateSpecificMeasure />}
         />
-        <Route path="combined-rates" element={<CombinedRatesPage />} />
         <Route path="api-test" element={<ApiTester />} />
         {measureRoutes.map((m: MeasureRoute) => (
           <Route {...m} />

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -172,7 +172,7 @@ export function AppRoutes() {
           path=":state/:year/:coreSetId/add-ssm"
           element={<AddStateSpecificMeasure />}
         />
-        <Route path="combined-rates" element={<CombinedRatesPage />}/>
+        <Route path="combined-rates" element={<CombinedRatesPage />} />
         <Route path="api-test" element={<ApiTester />} />
         {measureRoutes.map((m: MeasureRoute) => (
           <Route {...m} />

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -166,7 +166,10 @@ export function AppRoutes() {
         <Route path=":state/:year/add-child" element={<AddChildCoreSet />} />
         <Route path=":state/:year/add-adult" element={<AddAdultCoreSet />} />
         <Route path=":state/:year/add-hh" element={<AddHHCoreSet />} />
-        <Route path=":state/:year/combined-rates" element={<CombinedRatesPage />} />
+        <Route
+          path=":state/:year/combined-rates"
+          element={<CombinedRatesPage />}
+        />
         <Route path=":state/:year/:coreSetId" element={<CoreSet />} />
         <Route path=":state/:year/:coreSetId/pdf" element={<ExportAll />} />
         <Route

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -6,6 +6,7 @@ import { useGetMeasureListInfo } from "hooks/api/useGetMeasureListInfo";
 import { useUser } from "hooks/authHooks";
 import { measureDescriptions } from "measures/measureDescriptions";
 import { UserRoles } from "types";
+import { CombinedRatesPage } from "views";
 
 const Home = lazy(() =>
   import("views/Home").then((module) => ({ default: module.Home }))
@@ -171,6 +172,7 @@ export function AppRoutes() {
           path=":state/:year/:coreSetId/add-ssm"
           element={<AddStateSpecificMeasure />}
         />
+        <Route path="combined-rates" element={<CombinedRatesPage />}/>
         <Route path="api-test" element={<ApiTester />} />
         {measureRoutes.map((m: MeasureRoute) => (
           <Route {...m} />

--- a/services/ui-src/src/views/CombinedRatesPage/index.test.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.test.tsx
@@ -5,11 +5,11 @@ expect.extend(toHaveNoViolations);
 
 describe("Test Combined Rates Page", () => {
   it("renders", () => {
-    render(<CombinedRatesPage />)
+    render(<CombinedRatesPage />);
     expect(screen.getByText("TBD")).toBeVisible();
-  })
+  });
   it("passes a11y tests", async () => {
     const { container } = render(<CombinedRatesPage />);
     expect(await axe(container)).toHaveNoViolations();
   });
-})
+});

--- a/services/ui-src/src/views/CombinedRatesPage/index.test.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { CombinedRatesPage } from "views";
+expect.extend(toHaveNoViolations);
+
+describe("Test Combined Rates Page", () => {
+  it("renders", () => {
+    render(<CombinedRatesPage />)
+    expect(screen.getByText("TBD")).toBeVisible();
+  })
+  it("passes a11y tests", async () => {
+    const { container } = render(<CombinedRatesPage />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+})

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -1,5 +1,3 @@
 export const CombinedRatesPage = () => {
-  return (
-    <div>TBD</div>
-  )
-}
+  return <div>TBD</div>;
+};

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -1,0 +1,5 @@
+export const CombinedRatesPage = () => {
+  return (
+    <div>TBD</div>
+  )
+}

--- a/services/ui-src/src/views/StateHome/__tests__/index.test.tsx
+++ b/services/ui-src/src/views/StateHome/__tests__/index.test.tsx
@@ -113,7 +113,9 @@ describe("Test StateHome 2024", () => {
   });
   test("Check that the route is correct when reporting year is changed", () => {
     render(testComponent);
-    const viewCombinedRatesButton = screen.getAllByRole("button", {name: "View Combined Rates"})[0];
+    const viewCombinedRatesButton = screen.getAllByRole("button", {
+      name: "View Combined Rates",
+    })[0];
     userEvent.click(viewCombinedRatesButton);
     expect(global.window.location.pathname).toContain("/combined-rates");
   });

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -19,6 +19,7 @@ import { BannerCard } from "components/Banner/BannerCard";
 import { coreSets, CoreSetField } from "shared/coreSetByYear";
 
 import { useFlags } from "launchdarkly-react-client-sdk";
+import { Link } from "react-router-dom";
 
 interface HandleDeleteData {
   state: string;
@@ -59,8 +60,8 @@ const ReportingYear = () => {
   }
 
   return (
-    <CUI.Box w={{ base: "full", md: "48" }}>
-      <CUI.Text fontSize="sm" fontWeight="600" mb="2">
+    <CUI.Box w={{ base: "full", md: "48" }} display={{md: "flex"}} flexDirection={{md: "column"}} alignItems={{md: "flex-end"}}>
+      <CUI.Text fontSize="sm" fontWeight="600" alignSelf={{md: "flex-start"}}>
         Reporting Year
       </CUI.Text>
       <CUI.Select
@@ -80,6 +81,27 @@ const ReportingYear = () => {
           </option>
         ))}
       </CUI.Select>
+      {year === "2024" && <CUI.Box mt="22px">
+        <Link
+            to={`/combined-rates`}
+            style={{
+              textDecoration: "none",
+              marginTop: "22px"
+            }}
+          >
+            <QMR.ContainedButton
+              buttonText={"View Combined Rates"}
+              buttonProps={{
+                colorScheme: "blue",
+                variant: "outline",
+                color: "blue.500",
+                fontSize: "16px",
+                width: "220px",
+                height: "37px"
+              }}
+            />
+          </Link>
+        </CUI.Box>}
     </CUI.Box>
   );
 };
@@ -88,11 +110,11 @@ const Heading = () => {
   const { year } = useParams();
   return (
     <CUI.Box display={{ base: "block", md: "flex" }}>
-      <CUI.Box maxW="3xl" pb="6">
+      <CUI.Box maxW="3xl" pb="6" pr={{md: "4rem"}}>
         <CUI.Heading size="lg" data-cy="reporting-year-heading">
           {`FFY ${year} Core Set Measures Reporting`}
         </CUI.Heading>
-        <CUI.Text fontWeight="bold" py="6">
+        <CUI.Text fontWeight="bold" pt="6">
           Complete each group of Core Set Measures below. Once a group is
           completed it can be submitted to CMS for review.
         </CUI.Text>

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -60,8 +60,13 @@ const ReportingYear = () => {
   }
 
   return (
-    <CUI.Box w={{ base: "full", md: "48" }} display={{md: "flex"}} flexDirection={{md: "column"}} alignItems={{md: "flex-end"}}>
-      <CUI.Text fontSize="sm" fontWeight="600" alignSelf={{md: "flex-start"}}>
+    <CUI.Box
+      w={{ base: "full", md: "48" }}
+      display={{ md: "flex" }}
+      flexDirection={{ md: "column" }}
+      alignItems={{ md: "flex-end" }}
+    >
+      <CUI.Text fontSize="sm" fontWeight="600" alignSelf={{ md: "flex-start" }}>
         Reporting Year
       </CUI.Text>
       <CUI.Select
@@ -81,12 +86,13 @@ const ReportingYear = () => {
           </option>
         ))}
       </CUI.Select>
-      {year === "2024" && <CUI.Box mt="22px">
-        <Link
+      {year === "2024" && (
+        <CUI.Box mt="22px">
+          <Link
             to={`/combined-rates`}
             style={{
               textDecoration: "none",
-              marginTop: "22px"
+              marginTop: "22px",
             }}
           >
             <QMR.ContainedButton
@@ -97,11 +103,12 @@ const ReportingYear = () => {
                 color: "blue.500",
                 fontSize: "16px",
                 width: "220px",
-                height: "37px"
+                height: "37px",
               }}
             />
           </Link>
-        </CUI.Box>}
+        </CUI.Box>
+      )}
     </CUI.Box>
   );
 };
@@ -110,7 +117,7 @@ const Heading = () => {
   const { year } = useParams();
   return (
     <CUI.Box display={{ base: "block", md: "flex" }}>
-      <CUI.Box maxW="3xl" pb="6" pr={{md: "4rem"}}>
+      <CUI.Box maxW="3xl" pb="6" pr={{ md: "4rem" }}>
         <CUI.Heading size="lg" data-cy="reporting-year-heading">
           {`FFY ${year} Core Set Measures Reporting`}
         </CUI.Heading>

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -89,7 +89,7 @@ const ReportingYear = () => {
       {year === "2024" && (
         <CUI.Box mt="22px">
           <Link
-            to={`/combined-rates`}
+            to={`/${state}/${year}/combined-rates`}
             style={{
               textDecoration: "none",
               marginTop: "22px",

--- a/services/ui-src/src/views/index.tsx
+++ b/services/ui-src/src/views/index.tsx
@@ -10,3 +10,4 @@ export * from "./AddAdultCoreSet";
 export * from "./AddHHCoreSet";
 export * from "./ApiTester";
 export * from "./ExportAll";
+export * from "./CombinedRatesPage";


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add route for combined-rates
- Add button to state home page to view combined rates
- Update styling (open to any better ideas here!)
- Add tests

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3454

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deployed url: https://d313thmob07q2p.cloudfront.net/
- Log in as any state user
- Verify the button "View Combined Rates" shows up below the year dropdown
- Change to any year other than 2024 and verify the button goes away
- Shrink the view to mobile size and make sure the button looks okay
- Check views against [Figma](https://www.figma.com/file/AJweEUn95IZFAN3ldIcZDH/MDCT---General?type=design&node-id=2666-2508&mode=design&t=NrRav96Mrll5wRT4-4)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary