### PR TITLE
Add word 'reporting' to autocompleted measure template

### DIFF
--- a/services/ui-src/src/components/AutocompletedMeasureTemplate/index.tsx
+++ b/services/ui-src/src/components/AutocompletedMeasureTemplate/index.tsx
@@ -64,7 +64,7 @@ export const AutocompletedMeasureTemplate = ({
               return <CUI.Text key={`subText.${idx}`}>{text}</CUI.Text>;
             })}
           <CUI.Text fontWeight="700">
-            {`States are not asked to report data for this measure for FFY ${year} Core Set in the online
+            {`States are not asked to report data for this measure for FFY ${year} Core Set reporting in the online
             reporting system.`}
           </CUI.Text>
         </CUI.Stack>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add word 'reporting' to text for auto-completed measures

Note: since this is a shared component it will apply to all years. Product approved ✅ 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3560

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deployed url: https://dqmq01a4f7v3s.cloudfront.net/
- Log in as a state user
- Create child core sets of any flavor
- View the LRCD-CH core set
- Verify the text at the bottom has the word "reporting" added after "Core Set"

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
