### PR TITLE
Change text in OUD-AD

### DIFF
--- a/services/ui-src/src/measures/2024/OUDAD/data.ts
+++ b/services/ui-src/src/measures/2024/OUDAD/data.ts
@@ -6,7 +6,7 @@ export const { categories, qualifiers } = getCatQualLabels("OUD-AD");
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
     "Percentage of Medicaid beneficiaries ages 18 to 64 with an opioid use disorder (OUD) who filled a prescription for or were administered or dispensed an FDA-approved medication for the disorder during the measurement year. Five rates are reported:",
-    "A total (overall) rate capturing any medication used in medication assistance treatment of opioid dependence and addiction (Rate 1).",
+    "A total (overall) rate capturing any medication used in medication assisted treatment of opioid dependence and addiction (Rate 1).",
     "Four separate rates representing the following types of FDA-approved drug products:",
   ],
   questionListItems: [


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Change "assistance" to "assisted"

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3561

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deployed url: https://d2jnwq276p7qy.cloudfront.net/
- Log in as a state user
- Navigate to Adult core sets -> OUD-AD
- Select the first radio option for "Measurement Specification"
- Scroll down and see the "Performance Measure" section
- Verify the paragraph that starts with "A total (overall) rate" says "medication assisted treatment" (instead of 'assistance')

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
