### PR TITLE
Update additional notes text area label logic

### DIFF
--- a/services/ui-src/src/labels/2021/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2021/commonQuestionsLabel.tsx
@@ -3,8 +3,12 @@ import * as DC from "dataConstants";
 export const commonQuestionsLabel = {
   AdditionalNotes: {
     header: "Additional Notes/Comments on the measure (optional)",
-    section:
-      "Please add any additional notes or comments on the measure not otherwise captured above:",
+    section: {
+      isReportingText:
+        "Please add any additional notes or comments on the measure not otherwise captured above:",
+      isNotReportingText:
+        "Please add any additional notes or comments on the measure not otherwise captured above:",
+    },
     upload:
       "If you need additional space to include comments or supplemental information, please attach further documentation below.",
   },

--- a/services/ui-src/src/labels/2021/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2021/commonQuestionsLabel.tsx
@@ -1,7 +1,7 @@
 import * as DC from "dataConstants";
 
 export const commonQuestionsLabel = {
-  AdditonalNotes: {
+  AdditionalNotes: {
     header: "Additional Notes/Comments on the measure (optional)",
     section:
       "Please add any additional notes or comments on the measure not otherwise captured above:",

--- a/services/ui-src/src/labels/2022/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2022/commonQuestionsLabel.tsx
@@ -3,8 +3,12 @@ import * as DC from "dataConstants";
 export const commonQuestionsLabel = {
   AdditionalNotes: {
     header: "Additional Notes/Comments on the measure (optional)",
-    section:
-      "Please add any additional notes or comments on the measure not otherwise captured above:",
+    section: {
+      isReportingText:
+        "Please add any additional notes or comments on the measure not otherwise captured above:",
+      isNotReportingText:
+        "Please add any additional notes or comments on the measure not otherwise captured above:",
+    },
     upload:
       "If you need additional space to include comments or supplemental information, please attach further documentation below.",
   },

--- a/services/ui-src/src/labels/2022/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2022/commonQuestionsLabel.tsx
@@ -1,7 +1,7 @@
 import * as DC from "dataConstants";
 
 export const commonQuestionsLabel = {
-  AdditonalNotes: {
+  AdditionalNotes: {
     header: "Additional Notes/Comments on the measure (optional)",
     section:
       "Please add any additional notes or comments on the measure not otherwise captured above:",

--- a/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
@@ -1,7 +1,7 @@
 import * as DC from "dataConstants";
 
 export const commonQuestionsLabel = {
-  AdditonalNotes: {
+  AdditionalNotes: {
     header: "Additional Notes/Comments on the measure (optional)",
     section:
       "Please add any additional notes or comments on the measure not otherwise captured above (<em>text in this field is included in publicly-reported state-specific comments</em>):",

--- a/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
@@ -3,8 +3,12 @@ import * as DC from "dataConstants";
 export const commonQuestionsLabel = {
   AdditionalNotes: {
     header: "Additional Notes/Comments on the measure (optional)",
-    section:
-      "Please add any additional notes or comments on the measure not otherwise captured above (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+    section: {
+      isReportingText:
+        "Please add any additional notes or comments on the measure not otherwise captured above (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+      isNotReportingText:
+        "Please add any additional notes or comments on the measure not otherwise captured above (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+    },
     upload:
       "If you need additional space to include comments or supplemental information, please attach further documentation below.",
   },

--- a/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
@@ -1,10 +1,14 @@
 import * as DC from "dataConstants";
 
 export const commonQuestionsLabel = {
-  AdditonalNotes: {
+  AdditionalNotes: {
     header: "Additional Notes/Comments on the measure (optional)",
-    section:
-      "Please add any additional notes or comments on the measure not otherwise captured above (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+    section: {
+      isNotReportingText:
+        "Please add any additional notes or comments on the measure not otherwise captured above:",
+      isReportingText:
+        "Please add any additional notes or comments on the measure not otherwise captured above (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+    },
     upload:
       "If you need additional space to include comments or supplemental information, please attach further documentation below.",
   },

--- a/services/ui-src/src/shared/commonQuestions/AdditionalNotes.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/AdditionalNotes.test.tsx
@@ -4,12 +4,23 @@ import { Reporting } from "./Reporting";
 import { screen } from "@testing-library/react";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import SharedContext from "shared/SharedContext";
-import commonQuestionsLabel from "labels/2024/commonQuestionsLabel";
+import { commonQuestionsLabel as commonQuestionsLabels2024 } from "labels/2024/commonQuestionsLabel";
+import { commonQuestionsLabel as commonQuestionsLabels2023 } from "labels/2023/commonQuestionsLabel";
+import { usePathParams } from "hooks/api/usePathParams";
 
-describe("Test AdditionalNotes component", () => {
+jest.mock("hooks/api/usePathParams");
+const mockUsePathParams = usePathParams as jest.Mock;
+
+const isReportingTextAreaLabel =
+  "Please add any additional notes or comments on the measure not otherwise captured above (text in this field is included in publicly-reported state-specific comments):";
+const isNotReportingTextAreaLabel =
+  "Please add any additional notes or comments on the measure not otherwise captured above:";
+
+describe("Test AdditionalNotes component for 2024", () => {
   beforeEach(() => {
+    mockUsePathParams.mockReturnValue({ year: "2024" });
     renderWithHookForm(
-      <SharedContext.Provider value={commonQuestionsLabel}>
+      <SharedContext.Provider value={commonQuestionsLabels2024}>
         <Reporting
           measureName="My Test Measure"
           reportingYear="2024"
@@ -33,9 +44,7 @@ describe("Test AdditionalNotes component", () => {
   });
 
   it("accepts input", async () => {
-    const textArea = await screen.findByLabelText(
-      "Please add any additional notes or comments on the measure not otherwise captured above (text in this field is included in publicly-reported state-specific comments):"
-    );
+    const textArea = await screen.findByLabelText(isReportingTextAreaLabel);
     fireEvent.type(textArea, "This is the test text");
     expect(textArea).toHaveDisplayValue("This is the test text");
   });
@@ -45,9 +54,7 @@ describe("Test AdditionalNotes component", () => {
       "No, I am not reporting My Test Measure (MTM) for FFY 2024 quality measure reporting."
     );
 
-    const textArea = await screen.findByLabelText(
-      "Please add any additional notes or comments on the measure not otherwise captured above (text in this field is included in publicly-reported state-specific comments):"
-    );
+    const textArea = await screen.findByLabelText(isReportingTextAreaLabel);
 
     fireEvent.click(reportingNo);
     fireEvent.type(textArea, "This is the test text");
@@ -60,5 +67,76 @@ describe("Test AdditionalNotes component", () => {
 
     fireEvent.click(reportingYes);
     expect(textArea).toHaveDisplayValue("");
+  });
+
+  it("shows different text if you are not reporting", async () => {
+    expect(screen.getByLabelText(isReportingTextAreaLabel)).toBeInTheDocument();
+
+    const reportingNo = await screen.findByLabelText(
+      "No, I am not reporting My Test Measure (MTM) for FFY 2024 quality measure reporting."
+    );
+
+    fireEvent.click(reportingNo);
+    expect(
+      screen.getByLabelText(isNotReportingTextAreaLabel)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(isReportingTextAreaLabel)
+    ).not.toBeInTheDocument();
+
+    // change reporting radio button option from no to yes
+    const reportingYes = await screen.findByLabelText(
+      "Yes, I am reporting My Test Measure (MTM) for FFY 2024 quality measure reporting."
+    );
+
+    fireEvent.click(reportingYes);
+    expect(screen.getByLabelText(isReportingTextAreaLabel)).toBeInTheDocument();
+    expect(
+      screen.queryByText(isNotReportingTextAreaLabel)
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Test AdditionalNotes component for 2023", () => {
+  beforeEach(() => {
+    mockUsePathParams.mockReturnValue({ year: "2023" });
+    renderWithHookForm(
+      <SharedContext.Provider value={commonQuestionsLabels2023}>
+        <Reporting
+          measureName="My Test Measure"
+          reportingYear="2023"
+          measureAbbreviation="MTM"
+        />
+        ,
+        <AdditionalNotes />
+      </SharedContext.Provider>
+    );
+  });
+
+  it("shows the same text regardless of reporting status", async () => {
+    expect(screen.getByLabelText(isReportingTextAreaLabel)).toBeInTheDocument();
+
+    const reportingNo = await screen.findByLabelText(
+      "No, I am not reporting My Test Measure (MTM) for FFY 2023 quality measure reporting."
+    );
+
+    fireEvent.click(reportingNo);
+    // should show the same text
+    expect(screen.getByLabelText(isReportingTextAreaLabel)).toBeInTheDocument();
+    expect(
+      screen.queryByText(isNotReportingTextAreaLabel)
+    ).not.toBeInTheDocument();
+
+    // change reporting radio button option from no to yes
+    const reportingYes = await screen.findByLabelText(
+      "Yes, I am reporting My Test Measure (MTM) for FFY 2023 quality measure reporting."
+    );
+
+    fireEvent.click(reportingYes);
+    // should show the same text
+    expect(screen.getByLabelText(isReportingTextAreaLabel)).toBeInTheDocument();
+    expect(
+      screen.queryByText(isNotReportingTextAreaLabel)
+    ).not.toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/shared/commonQuestions/AdditionalNotes.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/AdditionalNotes.test.tsx
@@ -6,10 +6,6 @@ import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import SharedContext from "shared/SharedContext";
 import { commonQuestionsLabel as commonQuestionsLabels2024 } from "labels/2024/commonQuestionsLabel";
 import { commonQuestionsLabel as commonQuestionsLabels2023 } from "labels/2023/commonQuestionsLabel";
-import { usePathParams } from "hooks/api/usePathParams";
-
-jest.mock("hooks/api/usePathParams");
-const mockUsePathParams = usePathParams as jest.Mock;
 
 const isReportingTextAreaLabel =
   "Please add any additional notes or comments on the measure not otherwise captured above (text in this field is included in publicly-reported state-specific comments):";
@@ -18,7 +14,6 @@ const isNotReportingTextAreaLabel =
 
 describe("Test AdditionalNotes component for 2024", () => {
   beforeEach(() => {
-    mockUsePathParams.mockReturnValue({ year: "2024" });
     renderWithHookForm(
       <SharedContext.Provider value={commonQuestionsLabels2024}>
         <Reporting
@@ -99,7 +94,6 @@ describe("Test AdditionalNotes component for 2024", () => {
 
 describe("Test AdditionalNotes component for 2023", () => {
   beforeEach(() => {
-    mockUsePathParams.mockReturnValue({ year: "2023" });
     renderWithHookForm(
       <SharedContext.Provider value={commonQuestionsLabels2023}>
         <Reporting

--- a/services/ui-src/src/shared/commonQuestions/AdditionalNotes.tsx
+++ b/services/ui-src/src/shared/commonQuestions/AdditionalNotes.tsx
@@ -1,7 +1,6 @@
 import * as QMR from "components";
 import * as CUI from "@chakra-ui/react";
 import { useCustomRegister } from "hooks/useCustomRegister";
-import { usePathParams } from "hooks/api/usePathParams";
 import { Upload } from "components/Upload";
 import * as Types from "shared/types";
 import * as DC from "dataConstants";
@@ -13,24 +12,20 @@ import SharedContext from "shared/SharedContext";
 export const AdditionalNotes = () => {
   const register = useCustomRegister<Types.AdditionalNotes>();
   const { getValues, resetField } = useFormContext();
-  const { year } = usePathParams();
   //WIP: using form context to get the labels for this component temporarily.
   const labels: any = useContext(SharedContext);
   const { header, section, upload } = labels?.AdditionalNotes ?? {};
+  const [textAreaLabel, setTextAreaLabel] = useState<string>(
+    section.isReportingText
+  );
   const didReport = getValues()["DidReport"];
-  const [textAreaLabel, setTextAreaLabel] = useState<string>(section);
 
   useEffect(() => {
     resetField("AdditionalNotes-AdditionalNotes");
-    // 2024 uses different text depending on reporting status
-    if (Number(year) >= 2024) {
-      if (didReport === "no") {
-        setTextAreaLabel(section.isNotReportingText);
-      } else {
-        setTextAreaLabel(section.isReportingText);
-      }
+    if (didReport === "no") {
+      setTextAreaLabel(section.isNotReportingText);
     } else {
-      setTextAreaLabel(section);
+      setTextAreaLabel(section.isReportingText);
     }
   }, [didReport, resetField]);
 

--- a/services/ui-src/src/shared/commonQuestions/AdditionalNotes.tsx
+++ b/services/ui-src/src/shared/commonQuestions/AdditionalNotes.tsx
@@ -27,7 +27,7 @@ export const AdditionalNotes = () => {
     } else {
       setTextAreaLabel(section.isReportingText);
     }
-  }, [didReport, resetField]);
+  }, [didReport, resetField]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <QMR.CoreQuestionWrapper testid="additional-notes" label={header}>

--- a/services/ui-src/src/shared/commonQuestions/AdditionalNotes.tsx
+++ b/services/ui-src/src/shared/commonQuestions/AdditionalNotes.tsx
@@ -1,40 +1,47 @@
 import * as QMR from "components";
 import * as CUI from "@chakra-ui/react";
 import { useCustomRegister } from "hooks/useCustomRegister";
+import { usePathParams } from "hooks/api/usePathParams";
 import { Upload } from "components/Upload";
 import * as Types from "shared/types";
 import * as DC from "dataConstants";
 import { useFormContext } from "react-hook-form";
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useState } from "react";
 import { parseLabelToHTML } from "utils/parser";
 import SharedContext from "shared/SharedContext";
 
 export const AdditionalNotes = () => {
   const register = useCustomRegister<Types.AdditionalNotes>();
   const { getValues, resetField } = useFormContext();
+  const { year } = usePathParams();
+  //WIP: using form context to get the labels for this component temporarily.
+  const labels: any = useContext(SharedContext);
+  const { header, section, upload } = labels?.AdditionalNotes ?? {};
   const didReport = getValues()["DidReport"];
+  const [textAreaLabel, setTextAreaLabel] = useState<string>(section);
 
   useEffect(() => {
     resetField("AdditionalNotes-AdditionalNotes");
+    // 2024 uses different text depending on reporting status
+    if (Number(year) >= 2024) {
+      if (didReport === "no") {
+        setTextAreaLabel(section.isNotReportingText);
+      } else {
+        setTextAreaLabel(section.isReportingText);
+      }
+    } else {
+      setTextAreaLabel(section);
+    }
   }, [didReport, resetField]);
 
-  //WIP: using form context to get the labels for this component temporarily.
-  const labels: any = useContext(SharedContext);
-
   return (
-    <QMR.CoreQuestionWrapper
-      testid="additional-notes"
-      label={labels?.AdditonalNotes?.header}
-    >
+    <QMR.CoreQuestionWrapper testid="additional-notes" label={header}>
       <QMR.TextArea
-        label={parseLabelToHTML(labels?.AdditonalNotes?.section)}
+        label={parseLabelToHTML(textAreaLabel)}
         {...register(DC.ADDITIONAL_NOTES)}
       />
       <CUI.Box marginTop={10}>
-        <Upload
-          label={labels?.AdditonalNotes?.upload}
-          {...register(DC.ADDITIONAL_NOTES_UPLOAD)}
-        />
+        <Upload label={upload} {...register(DC.ADDITIONAL_NOTES_UPLOAD)} />
       </CUI.Box>
     </QMR.CoreQuestionWrapper>
   );


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

The Additional Notes section now shows different label text for the text area depending on if the user is reporting that measure. This only applies to 2024 and beyond.

I decided to move all of the `section` labels to objects. Even though 2021-2023 have duplicates for that text, it removes the need to check `year` in the component, and it simplifies the branching logic for the display text.

Disabled eslint for `react-hooks/exhaustive-deps` on the useEffect, which wanted to depend on `section`, because our text files won't change once deployed

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3570

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deployed url: https://dsrfviz68nar1.cloudfront.net/
- Log in as a state user
- Select any measure that needs information in 2024
- Verify the Additional Comments box at the end has the label
`Please add any additional notes or comments on the measure not otherwise captured above (text in this field is included in publicly-reported state-specific comments):`
- Select "No" to the first question, about whether or not you are reporting
- Verify the Additional Comments label shortens to
`Please add any additional notes or comments on the measure not otherwise captured above:`
- Verify that 2021-2023 uses the same text regardless of whether or not you are reporting.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary
