### PR TITLE
[QMR] FAU-AD - Add Space

### DIFF
--- a/services/ui-src/src/measures/2024/FUAAD/data.ts
+++ b/services/ui-src/src/measures/2024/FUAAD/data.ts
@@ -5,7 +5,7 @@ export const { categories, qualifiers } = getCatQualLabels("FUA-AD");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
-    "Percentage of emergency department (ED) visits for beneficiaries age 18 and Older with a principal diagnosis of Substance Use Disorder(SUD), or any diagnosis of drug overdose, for which there was follow-up. Two rates are reported:",
+    "Percentage of emergency department (ED) visits for beneficiaries age 18 and Older with a principal diagnosis of Substance Use Disorder (SUD), or any diagnosis of drug overdose, for which there was follow-up. Two rates are reported:",
   ],
   questionListItems: [
     "Percentage of ED visits for which the beneficiary received follow-up within 30 days of the ED visit (31 total days)",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3563

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Confirm that in FUA-AD (2024) there is a space before (SUD), so the text now says: "....principal diagnosis of Substance Use **Disorder (SUD)**, or any diagnosis..."

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
