### PR TITLE
Forgot To Bring IETRate Changes to 2023

### DIFF
--- a/services/ui-src/src/measures/2023/IETAD/data.ts
+++ b/services/ui-src/src/measures/2023/IETAD/data.ts
@@ -14,6 +14,7 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
   ],
   categories,
   qualifiers,
+  measureName: "IET-AD",
 };
 
 export const dataSourceData: DataDrivenTypes.DataSource = {

--- a/services/ui-src/src/measures/2023/IETHH/data.ts
+++ b/services/ui-src/src/measures/2023/IETHH/data.ts
@@ -14,6 +14,7 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
   ],
   categories,
   qualifiers,
+  measureName: "IET-HH",
 };
 
 export const dataSourceData: DataDrivenTypes.DataSource = {

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -75,6 +75,10 @@ const CategoryNdrSets = ({
 
         rates = rates?.length ? rates : [{ id: 0 }];
 
+        //temporary check to make IETRate component work again, will be updated during the refactor
+        const registerId = measureName?.includes("IET")
+          ? `${DC.PERFORMANCE_MEASURE}.${DC.RATES}`
+          : `${DC.PERFORMANCE_MEASURE}.${DC.RATES}.${cat.id}`;
         return (
           <CUI.Box key={cat.id}>
             <CUI.Text fontWeight="bold" my="5">
@@ -89,13 +93,15 @@ const CategoryNdrSets = ({
               rateMultiplicationValue={rateScale}
               calcTotal={calcTotal}
               categoryName={cat.label}
+              category={cat}
               categories={categories}
+              qualifiers={qualifiers}
               customMask={customMask}
               customNumeratorLabel={customNumeratorLabel}
               customDenominatorLabel={customDenominatorLabel}
               customRateLabel={customRateLabel}
               rateCalc={rateCalc}
-              {...register(`${DC.PERFORMANCE_MEASURE}.${DC.RATES}.${cat.id}`)}
+              {...register(registerId)}
               allowNumeratorGreaterThanDenominator={
                 allowNumeratorGreaterThanDenominator
               }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
As the title says, I forgot to enable the changes in IETRate for 2023. This is why the same component should not be copied over every year 😭 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3571

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any user
2) Select reporting year 2023
3) Go to IET-AD 
4) In the Measure Specification section, select the first radio button
5) Scroll down to performance measure, you should be able to enter value and trigger summation in the total categories

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
