### PR TITLE
Cypress Dropdown Fix

### DIFF
--- a/tests/cypress/cypress/e2e/userflow_adult.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_adult.spec.ts
@@ -66,7 +66,10 @@ describe("submit coreset", () => {
     cy.login();
     cy.selectYear(testingYear);
     cy.get('[data-cy="adult-kebab-menu"]').click();
-    cy.get('[aria-label="Reset All Measures for ACS"]').click();
+    cy.get('[aria-label="Reset All Measures for ACS"]').click({
+      force: true,
+      waitForAnimations: false,
+    });
     cy.wait(1000);
     // confirm reset
     cy.get('[data-cy="Status-WY2024ACS"]').should(

--- a/tests/cypress/cypress/e2e/userflow_adult.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_adult.spec.ts
@@ -81,7 +81,10 @@ describe("submit coreset", () => {
   it("submit and confirm submission", () => {
     // complete core set
     cy.get('[data-cy="adult-kebab-menu"]').click();
-    cy.get('[aria-label="Complete All Measures for ACS"]').click();
+    cy.get('[aria-label="Complete All Measures for ACS"]').click({
+      force: true,
+      waitForAnimations: false,
+    });
     cy.wait(4000);
     cy.get('[data-cy="Status-WY2024ACS"]').should(
       "contain.text",

--- a/tests/cypress/cypress/e2e/userflow_adult.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_adult.spec.ts
@@ -66,7 +66,7 @@ describe("submit coreset", () => {
     cy.login();
     cy.selectYear(testingYear);
     cy.get('[data-cy="adult-kebab-menu"]').click();
-    cy.get('[data-cy="Reset All Measures"]').first().click();
+    cy.get('[aria-label="Reset All Measures for ACS"]').click();
     cy.wait(1000);
     // confirm reset
     cy.get('[data-cy="Status-WY2024ACS"]').should(
@@ -78,7 +78,7 @@ describe("submit coreset", () => {
   it("submit and confirm submission", () => {
     // complete core set
     cy.get('[data-cy="adult-kebab-menu"]').click();
-    cy.get('[data-cy="Complete All Measures"]').first().click();
+    cy.get('[aria-label="Complete All Measures for ACS"]').click();
     cy.wait(4000);
     cy.get('[data-cy="Status-WY2024ACS"]').should(
       "contain.text",
@@ -115,7 +115,7 @@ describe("Export All Measures", () => {
 
   it("Test Adult Core Set", () => {
     cy.get('[data-cy="adult-kebab-menu"]').click();
-    cy.get('[data-cy="Export"]').first().click();
+    cy.get('[aria-label="Export for ACS"]').click();
 
     // Check all measures + CSQ present
     for (const measureAbbr of measureAbbrList2024.ADULT) {

--- a/tests/cypress/cypress/e2e/userflow_child.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_child.spec.ts
@@ -75,7 +75,10 @@ describe("submit coreset", () => {
   it("submit and confirm submission", () => {
     // complete core set
     cy.get('[data-cy="child-kebab-menu"]').click();
-    cy.get('[aria-label="Complete All Measures for CCS"]').click();
+    cy.get('[aria-label="Complete All Measures for CCS"]').click({
+      force: true,
+      waitForAnimations: false,
+    });
     cy.wait(4000);
     cy.get('[data-cy="Status-WY2024CCS"]').should(
       "contain.text",

--- a/tests/cypress/cypress/e2e/userflow_child.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_child.spec.ts
@@ -9,7 +9,7 @@ describe(`Child Core Sets Should be able to be deleted and created for ${testing
   });
   // create a child core set
   it("Creates separate child core-set", () => {
-    cy.deleteSeperatedChildCoreSets();
+    cy.deleteChildCoreSets();
     cy.get('[data-cy="add-childbutton"]').click(); // clicking on adding child core set measures
     cy.get("#ChildCoreSet-ReportType-separate").click(); //selecting combined core set
     cy.get('[data-cy="Create"]').click(); //clicking create
@@ -61,7 +61,10 @@ describe("submit coreset", () => {
     cy.login();
     cy.selectYear(testingYear);
     cy.get('[data-cy="child-kebab-menu"]').click();
-    cy.get('[aria-label="Reset All Measures for CCS"]').click();
+    cy.get('[aria-label="Reset All Measures for CCS"]').click({
+      force: true,
+      waitForAnimations: false,
+    });
     cy.wait(1000);
     // confirm reset
     cy.get('[data-cy="Status-WY2024CCS"]').should(

--- a/tests/cypress/cypress/e2e/userflow_child.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_child.spec.ts
@@ -9,7 +9,7 @@ describe(`Child Core Sets Should be able to be deleted and created for ${testing
   });
   // create a child core set
   it("Creates separate child core-set", () => {
-    cy.deleteChildCoreSets();
+    cy.deleteSeperatedChildCoreSets();
     cy.get('[data-cy="add-childbutton"]').click(); // clicking on adding child core set measures
     cy.get("#ChildCoreSet-ReportType-separate").click(); //selecting combined core set
     cy.get('[data-cy="Create"]').click(); //clicking create

--- a/tests/cypress/helper.d.ts
+++ b/tests/cypress/helper.d.ts
@@ -36,6 +36,9 @@ declare namespace Cypress {
     displaysSectionsWhenUserNotReporting(): Chainable<Element>;
 
     // removes child core set from main page
+    deleteSeperatedChildCoreSets(): Chainable<Element>;
+
+    // removes child core set from main page
     deleteChildCoreSets(): Chainable<Element>;
 
     // removes adult core set from main page

--- a/tests/cypress/helper.d.ts
+++ b/tests/cypress/helper.d.ts
@@ -36,9 +36,6 @@ declare namespace Cypress {
     displaysSectionsWhenUserNotReporting(): Chainable<Element>;
 
     // removes child core set from main page
-    deleteSeperatedChildCoreSets(): Chainable<Element>;
-
-    // removes child core set from main page
     deleteChildCoreSets(): Chainable<Element>;
 
     // removes adult core set from main page

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -145,25 +145,31 @@ Cypress.Commands.add("displaysSectionsWhenUserNotReporting", () => {
   ).should("be.visible");
 });
 
-// helper recursive function to remove added core sets
-const removeCoreSetElements = (kebab: string) => {
+const clickCoreSetAction = (kebab: string, action: string) => {
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find(kebab).length > 0) {
       cy.get(kebab).first().click();
       cy.wait(3000);
-      cy.get('[data-cy="Delete"]').first().click({ force: true });
-      cy.get('[data-cy="delete-table-item-input"]').type("delete{enter}");
-      cy.wait(3000);
-      removeCoreSetElements(kebab);
+      cy.get(action).click();
     }
   });
+};
+
+// helper recursive function to remove added core sets
+const removeCoreSetElements = (kebab: string, action: string) => {
+  clickCoreSetAction(kebab, action);
+  cy.wait(3000);
+  cy.get('[data-cy="delete-table-item-input"]').type("delete{enter}");
 };
 
 // removes adult core set from main page
 Cypress.Commands.add("deleteAdultCoreSets", () => {
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find('[data-cy="adult-kebab-menu"]').length > 0) {
-      removeCoreSetElements('[data-cy="adult-kebab-menu"]');
+      removeCoreSetElements(
+        '[data-cy="adult-kebab-menu"]',
+        '[aria-label="Delete for ACS"]'
+      );
     }
   });
 });
@@ -172,7 +178,25 @@ Cypress.Commands.add("deleteAdultCoreSets", () => {
 Cypress.Commands.add("deleteChildCoreSets", () => {
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find('[data-cy="child-kebab-menu"]').length > 0) {
-      removeCoreSetElements('[data-cy="child-kebab-menu"]');
+      removeCoreSetElements(
+        '[data-cy="child-kebab-menu"]',
+        '[aria-label="Delete for CCS"]'
+      );
+    }
+  });
+});
+
+Cypress.Commands.add("deleteSeperatedChildCoreSets", () => {
+  cy.get('[data-cy="tableBody"]').then(($tbody) => {
+    if ($tbody.find('[data-cy="child-kebab-menu"]').length > 0) {
+      removeCoreSetElements(
+        '[data-cy="child-kebab-menu"]',
+        '[aria-label="Delete for CCSC"]'
+      );
+      removeCoreSetElements(
+        '[data-cy="child-kebab-menu"]',
+        '[aria-label="Delete for CCSM"]'
+      );
     }
   });
 });
@@ -181,7 +205,10 @@ Cypress.Commands.add("deleteChildCoreSets", () => {
 Cypress.Commands.add("deleteHealthHomeSets", () => {
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
     if ($tbody.find('[data-cy="health home-kebab-menu"]').length > 0) {
-      removeCoreSetElements('[data-cy="health home-kebab-menu"]');
+      removeCoreSetElements(
+        '[data-cy="health home-kebab-menu"]',
+        '[aria-label="Delete for HHCS_15-014"]'
+      );
     }
   });
 });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -177,25 +177,15 @@ Cypress.Commands.add("deleteAdultCoreSets", () => {
 // removes child core set from main page
 Cypress.Commands.add("deleteChildCoreSets", () => {
   cy.get('[data-cy="tableBody"]').then(($tbody) => {
-    if ($tbody.find('[data-cy="child-kebab-menu"]').length > 0) {
+    if ($tbody.find('[data-cy="child-kebab-menu"]').length === 1) {
       removeCoreSetElements(
         '[data-cy="child-kebab-menu"]',
         '[aria-label="Delete for CCS"]'
       );
-    }
-  });
-});
-
-Cypress.Commands.add("deleteSeperatedChildCoreSets", () => {
-  cy.get('[data-cy="tableBody"]').then(($tbody) => {
-    if ($tbody.find('[data-cy="child-kebab-menu"]').length > 0) {
+    } else if ($tbody.find('[data-cy="child-kebab-menu"]').length > 1) {
       removeCoreSetElements(
         '[data-cy="child-kebab-menu"]',
         '[aria-label="Delete for CCSC"]'
-      );
-      removeCoreSetElements(
-        '[data-cy="child-kebab-menu"]',
-        '[aria-label="Delete for CCSM"]'
       );
     }
   });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -150,7 +150,7 @@ const clickCoreSetAction = (kebab: string, action: string) => {
     if ($tbody.find(kebab).length > 0) {
       cy.get(kebab).first().click();
       cy.wait(3000);
-      cy.get(action).click();
+      cy.get(action).click({ force: true });
     }
   });
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Due to the addition of a deletable Adult Core Set, the cypress test have started to fail. The delete code we were using only had to worry about one core set per user as there would only be one set of deletes in the system. Because adult measures have a delete option now, if both adult and child cypress is run at the same time and is generated at the same time, it creates an issue.

We were using:  `cy.get('[data-cy="Delete"]').first().click({ force: true });` to delete the first in the stack order, but this is indifferent to whether the button is visible or not. So it didn't matter if the child menu or the adult menu was made visible, we would still delete the adult measure as that menu still exist even if it is hidden; it will usually be the first in the stack. 

![Screenshot 2024-05-10 at 12 53 35 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/5a6a60c1-aa29-4ec1-9099-a38b74b42cc5)

Another issue is that things would be animating while trying to click reset / complete all the measure buttons, which would cause misfires to the wrong button in the menu. So this code was added to some of the buttons
```
{
      force: true,
      waitForAnimations: false,
}
```

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
If the cypress test passes, we should be good.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
