### PR TITLE
Nvmrc mismatch

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -33,6 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"      
       - name: set branch_name
         run: |
           BRANCH_NAME=$(./.github/setBranchName.sh ${{ inputs.environment || github.event.ref }})

--- a/run
+++ b/run
@@ -15,6 +15,9 @@ if ! which node > /dev/null ; then
 	exit 1
 fi
 
+echo NVMRC $(cat .nvmrc)
+echo NODE VERSION $(node -v)
+
 # check node version
 if ! diff .nvmrc <(node -v) > /dev/null ; then
 	echo "Uh Oh! The current node version does not match the version required in .nvmrc"

--- a/run
+++ b/run
@@ -15,9 +15,6 @@ if ! which node > /dev/null ; then
 	exit 1
 fi
 
-echo NVMRC $(cat .nvmrc)
-echo NODE VERSION $(node -v)
-
 # check node version
 if ! diff .nvmrc <(node -v) > /dev/null ; then
 	echo "Uh Oh! The current node version does not match the version required in .nvmrc"


### PR DESCRIPTION
### Description
After merging in the destroy fix, a bug popped up because we weren't using node for destroy before, and the node upgrade made the .nvmrc file not agree with the default packaged node version on the GHA runner.  This just asserts that the destroy action uses the same version as the code base.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-
There is no ticket, this a bush fix.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[Here](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/runs/9083010808/job/24960739138) is proof that this fix worked.  This is a manually dispatched event using this fix against `improve-destroy` branch.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
