### PR TITLE
Fix disabled submit core set on completion

### DIFF
--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -243,9 +243,10 @@ const useMeasureTableDataBuilder = () => {
           numCompleteItems++;
         }
       }
+      const numberOfCoreSets = 1;
 
       const coreStatus =
-        measureTableData.length === numCompleteItems
+        filteredItems.length + numberOfCoreSets === numCompleteItems
           ? CoreSetTableItem.Status.COMPLETED
           : CoreSetTableItem.Status.IN_PROGRESS;
       setCoreSetStatus(coreStatus);

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -179,7 +179,6 @@ const useMeasureTableDataBuilder = () => {
         // filter out the coreset qualifiers
         (item) => item.measure && item.measure !== "CSQ"
       );
-
       const measureTableData = (filteredItems as MeasureData[])
         .filter(
           (item) =>
@@ -245,12 +244,11 @@ const useMeasureTableDataBuilder = () => {
         }
       }
 
-      const numberOfCoreSets = 1;
-      const coreSetStatus =
-        measureTableData.length + numberOfCoreSets === numCompleteItems
+      const coreStatus =
+        measureTableData.length === numCompleteItems
           ? CoreSetTableItem.Status.COMPLETED
           : CoreSetTableItem.Status.IN_PROGRESS;
-      setCoreSetStatus(coreSetStatus);
+      setCoreSetStatus(coreStatus);
     }
 
     return () => {

--- a/tests/cypress/cypress/e2e/userflow_healthhome.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_healthhome.spec.ts
@@ -66,8 +66,7 @@ describe("Add custom measure", () => {
   });
 });
 
-// TODO: unskip when hh submit is fixed
-describe.skip("submit coreset", () => {
+describe("submit coreset", () => {
   beforeEach(() => {
     cy.loginHealthHome();
     cy.selectYear(testingYear);


### PR DESCRIPTION
### Description
Complete All Measure is now enabled when Health Home core set is completed.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-https://jiraent.cms.gov/browse/CMDCT-3550#

---
### How to test
1. Log in as stateuserWA@test.com
2. Create a Health Home core set
3. Fill out all measures in core set and submit
4. 


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
