### PR TITLE
Global Data Source - Validation content correction

### DIFF
--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -14,21 +14,19 @@ export const validateAtLeastOneDataSourceType = (
         })
         .indexOf(true);
       if (!Object.values(source[index])[0]) {
+        let dataErrorMessage;
         if (source.includes("AdministrativeData0-AdministrativeDataOther")) {
-          const dataErrorMessage = "admin data source test";
-          errorArray.push({
-            errorLocation: "Data Source",
-            errorMessage: errorMessage ?? dataErrorMessage,
-          });
+          dataErrorMessage =
+            "Please describe the Administrative Other Data Source";
+        } else if (source.includes("OtherDataSource")) {
+          dataErrorMessage = "Please describe the Other Data Source";
         } else {
-          const dataErrorMessage = source.includes("OtherDataSource")
-            ? "Please describe the Other Data Source"
-            : "You must select a data source";
-          errorArray.push({
-            errorLocation: "Data Source",
-            errorMessage: errorMessage ?? dataErrorMessage,
-          });
+          dataErrorMessage = "You must select a data source";
         }
+        errorArray.push({
+          errorLocation: "Data Source",
+          errorMessage: errorMessage ?? dataErrorMessage,
+        });
       }
     });
   }

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -15,7 +15,12 @@ export const validateAtLeastOneDataSourceType = (
         .indexOf(true);
       if (!Object.values(source[index])[0]) {
         let dataErrorMessage;
-        if (source.includes("AdministrativeData0-AdministrativeDataOther")) {
+        if (
+          source.includes("AdministrativeData0-AdministrativeDataOther") ||
+          source.includes(
+            "HybridAdministrativeandMedicalRecordsData0-AdministrativeDataOther"
+          )
+        ) {
           dataErrorMessage =
             "Please describe the Administrative Other Data Source";
         } else if (source.includes("OtherDataSource")) {

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -14,13 +14,21 @@ export const validateAtLeastOneDataSourceType = (
         })
         .indexOf(true);
       if (!Object.values(source[index])[0]) {
-        const dataErrorMessage = source.includes("OtherDataSource")
-          ? "Please describe the Other Data Source"
-          : "You must select a data source";
-        errorArray.push({
-          errorLocation: "Data Source",
-          errorMessage: errorMessage ?? dataErrorMessage,
-        });
+        if (source.includes("AdministrativeData0-AdministrativeDataOther")) {
+          const dataErrorMessage = "admin data source test";
+          errorArray.push({
+            errorLocation: "Data Source",
+            errorMessage: errorMessage ?? dataErrorMessage,
+          });
+        } else {
+          const dataErrorMessage = source.includes("OtherDataSource")
+            ? "Please describe the Other Data Source"
+            : "You must select a data source";
+          errorArray.push({
+            errorLocation: "Data Source",
+            errorMessage: errorMessage ?? dataErrorMessage,
+          });
+        }
       }
     });
   }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3630

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
For FFY 2024, go to HBD- AD --> data source section. Click "Administrative Data Other" for both **Administrative Data** and **Hybrid (Administrative and Medical Records Data)**, but do not type anything in either text box. 

Validate the measure and confirm that the new validation error message is showing up for each text box: "Data Source Error: Please describe the Administrative Other Data Source".

Also confirm that this validation error label is not affecting any other existing error message.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
