### PR TITLE
CPU-AD Update Performance Measure Text Formatting 

### DIFF
--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -20,6 +20,14 @@ body,
   flex-direction: column;
 }
 
+li::marker {
+  font-weight: bold;
+}
+
+.default-li-marker li::marker {
+  font-weight: normal;
+}
+
 a:focus {
   box-shadow: none;
 }

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -20,10 +20,6 @@ body,
   flex-direction: column;
 }
 
-li::marker {
-  font-weight: bold;
-}
-
 a:focus {
   box-shadow: none;
 }

--- a/services/ui-src/src/measures/2024/CPUAD/data.ts
+++ b/services/ui-src/src/measures/2024/CPUAD/data.ts
@@ -7,11 +7,11 @@ export const { categories, qualifiers } = getCatQualLabels("CPU-AD");
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
     "Percentage of beneficiaries receiving long-term services and supports (LTSS) services ages 18 and older who have documentation of a comprehensive long-term services and supports (LTSS) care plan in a specified time frame that includes core elements. The following rates are reported:",
+    'In addition, states should report the number of exclusions by type: "Could Not Be Reached for Care Planning", and "Refusal to Participate in Care Planning."',
   ],
   questionListItems: [
     "Care Plan with Core Elements Documented. Beneficiaries who had a comprehensive LTSS care plan with 9 core elements documented within 120 days of enrollment (for new beneficiaries) or during the measurement year (for established beneficiaries).",
     "Care Plan with Supplemental Elements Documented. Beneficiaries who had a comprehensive LTSS care plan with 9 core elements and at least 4 supplemental elements documented within 120 days of enrollment (for new beneficiaries) or during the measurement year (for established beneficiaries).",
-    "In addition, states should report the number of exclusions by type as follows: (1)Could Not Be Reached for Care Planning, and (2)Refusal to Participate in Care Planning.",
   ],
   categories,
   qualifiers,

--- a/services/ui-src/src/measures/2024/CPUAD/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2024/CPUAD/questions/PerformanceMeasure.tsx
@@ -148,9 +148,9 @@ export const CPUADPerformanceMeasure = ({
       testid="performance-measure"
       label="Performance Measure"
     >
-      <CUI.Text mb={5}>{data.questionText}</CUI.Text>
+      <CUI.Text mb={5}>{data.questionText![0]}</CUI.Text>
       {data.questionListItems && (
-        <CUI.UnorderedList m="5" ml="10" spacing={5}>
+        <CUI.OrderedList m="5" ml="10" spacing={5}>
           {data.questionListItems.map((item, idx) => {
             return (
               <CUI.ListItem key={`performanceMeasureListItem.${idx}`}>
@@ -163,8 +163,9 @@ export const CPUADPerformanceMeasure = ({
               </CUI.ListItem>
             );
           })}
-        </CUI.UnorderedList>
+        </CUI.OrderedList>
       )}
+      <CUI.Text mb={5}>{data.questionText![1]}</CUI.Text>
       <QMR.TextArea
         label="If this measure has been reported by the state previously and there has been a substantial change in the rate or measure-eligible population, please provide any available context below:"
         {...register("PerformanceMeasure.explanation")}

--- a/services/ui-src/src/measures/2024/CPUAD/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2024/CPUAD/questions/PerformanceMeasure.tsx
@@ -150,7 +150,12 @@ export const CPUADPerformanceMeasure = ({
     >
       <CUI.Text mb={5}>{data.questionText![0]}</CUI.Text>
       {data.questionListItems && (
-        <CUI.OrderedList m="5" ml="10" spacing={5}>
+        <CUI.OrderedList
+          className="default-li-marker"
+          m="5"
+          ml="10"
+          spacing={5}
+        >
           {data.questionListItems.map((item, idx) => {
             return (
               <CUI.ListItem key={`performanceMeasureListItem.${idx}`}>

--- a/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/data.ts
+++ b/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/data.ts
@@ -10,6 +10,7 @@ export interface PerformanceMeasureData {
   customPrompt?: string; // Default: "Enter a number for the numerator and the denominator. Rate will auto-calculate:"
   questionText?: string[];
   questionListItems?: string[];
+  questionItem?: string;
   questionListOrderedItems?: string[];
   questionListTitles?: string[];
   questionSubtext?: string[];

--- a/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/data.ts
+++ b/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/data.ts
@@ -10,7 +10,6 @@ export interface PerformanceMeasureData {
   customPrompt?: string; // Default: "Enter a number for the numerator and the denominator. Rate will auto-calculate:"
   questionText?: string[];
   questionListItems?: string[];
-  questionItem?: string;
   questionListOrderedItems?: string[];
   questionListTitles?: string[];
   questionSubtext?: string[];


### PR DESCRIPTION
### Description
Updated Performance Measure question text for CPU-AD measure

Previous
<img width="738" alt="Screenshot 2024-05-21 at 11 38 26 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/14514294/6eeef856-b858-4be9-b478-545172f68cf8">


Updated Screenshot:
<img width="991" alt="Screenshot 2024-05-21 at 11 22 51 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/14514294/f9f4974f-04fb-4d6a-ab93-ee7862ecec2b">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT- https://jiraent.cms.gov/browse/CMDCT-3622

---
### How to test
1. Go to CPU-AD measure 
2. Select Measurement Specification
3. Scroll down to see Performance Measure section. (Text should be updated to look like screenshot)


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
