### PR TITLE
Global Change - Removal of Add Attachment 

### DIFF
--- a/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
@@ -9,8 +9,6 @@ export const commonQuestionsLabel = {
       isReportingText:
         "Please add any additional notes or comments on the measure not otherwise captured above (<em>text in this field is included in publicly-reported state-specific comments</em>):",
     },
-    upload:
-      "If you need additional space to include comments or supplemental information, please attach further documentation below.",
   },
   CombinedRates: {
     header: "Combined Rate(s) from Multiple Reporting Units",

--- a/services/ui-src/src/shared/commonQuestions/AdditionalNotes.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/AdditionalNotes.test.tsx
@@ -31,11 +31,6 @@ describe("Test AdditionalNotes component for 2024", () => {
     expect(
       screen.getByText("Additional Notes/Comments on the measure (optional)")
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "If you need additional space to include comments or supplemental information, please attach further documentation below."
-      )
-    ).toBeInTheDocument();
   });
 
   it("accepts input", async () => {
@@ -105,6 +100,17 @@ describe("Test AdditionalNotes component for 2023", () => {
         <AdditionalNotes />
       </SharedContext.Provider>
     );
+  });
+
+  it("component renders", () => {
+    expect(
+      screen.getByText("Additional Notes/Comments on the measure (optional)")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "If you need additional space to include comments or supplemental information, please attach further documentation below."
+      )
+    ).toBeInTheDocument();
   });
 
   it("shows the same text regardless of reporting status", async () => {

--- a/services/ui-src/src/shared/commonQuestions/AdditionalNotes.tsx
+++ b/services/ui-src/src/shared/commonQuestions/AdditionalNotes.tsx
@@ -35,9 +35,11 @@ export const AdditionalNotes = () => {
         label={parseLabelToHTML(textAreaLabel)}
         {...register(DC.ADDITIONAL_NOTES)}
       />
-      <CUI.Box marginTop={10}>
-        <Upload label={upload} {...register(DC.ADDITIONAL_NOTES_UPLOAD)} />
-      </CUI.Box>
+      {upload && (
+        <CUI.Box marginTop={10}>
+          <Upload label={upload} {...register(DC.ADDITIONAL_NOTES_UPLOAD)} />
+        </CUI.Box>
+      )}
     </QMR.CoreQuestionWrapper>
   );
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR is for removing the attachment upload in the additional notes section 

No more this
![Screenshot 2024-05-22 at 2 29 30 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/c56aa10e-29bb-4922-b12b-f1755150f30e)

Looks like this now
![Screenshot 2024-05-22 at 2 30 12 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/87e0fd18-7eeb-4d60-9fbb-c3c311f9868b)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3625

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any user
2) Stay in reporting year 2024
3) Go into any measure
4) Scroll down and you should not see the upload box anymore
5) Check that the box still exist in 2021 - 2023 

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
