### PR TITLE
Global Change - Performance Measure Missing Text Box

### DIFF
--- a/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2024/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -201,6 +201,7 @@ export const PerformanceMeasure = ({
   customNumeratorLabel,
   customDenominatorLabel,
   customRateLabel,
+  showtextbox = true,
   rateCalc,
   RateComponent = QMR.Rate, // Default to QMR.Rate
 }: Props) => {
@@ -280,6 +281,12 @@ export const PerformanceMeasure = ({
             );
           })}
         </CUI.OrderedList>
+      )}
+      {showtextbox && (
+        <QMR.TextArea
+          label="If this measure has been reported by the state previously and there has been a substantial change in the rate or measure-eligible population, please provide any available context below:"
+          {...register(`${DC.PERFORMANCE_MEASURE}.${DC.EXPLAINATION}`)}
+        />
       )}
       {hybridMeasure && pheIsCurrent && (
         <CUI.Box my="5">


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The performance measure section has a textbox that went missing during a change we made. This just adds it back in.
![Screenshot 2024-05-22 at 2 41 27 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/308a6a95-2291-418b-bef2-8e438e9e0212)

✅ product

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3626

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://dy4e0cun8m9mb.cloudfront.net/

1) Sign into QMR, any user
2) Select any measure, BCS-AD is the one being used in the ticket as the example
3) In the Measure Specification, select the first radio button
4) Scroll down to the performance measure section and you should see the textbox.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
