### PR TITLE
COL-HH Content Correction

### DIFF
--- a/services/ui-src/src/measures/2024/COLHH/data.ts
+++ b/services/ui-src/src/measures/2024/COLHH/data.ts
@@ -6,7 +6,7 @@ export const { categories, qualifiers } = getCatQualLabels("COL-HH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
-    "Percentage of health home enrollees ages 45 to 75 who had appropriate screening for colorectal cancer. This measure applies to enrollees ages 46 to 75 to account for the look back period. (to ensure that the enrollee was at least age 45 for the entire enrollment period.)",
+    "Percentage of health home enrollees ages 45 to 75 who had appropriate screening for colorectal cancer. This measure applies to enrollees ages 46 to 75 to account for the lookback period (to ensure that the enrollee was at least age 45 for the entire enrollment period).",
   ],
   categories,
   qualifiers,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
**AC**
Please remove the period before the open parenthesis and make sure the final period falls outside the closed parenthesis. Please also make “look back” one word. 

**New Text**
Percentage of health home enrollees ages 45 to 75 who had appropriate screening for colorectal cancer. This measure applies to enrollees ages 46 to 75 to account for the lookback period (to ensure that the enrollee was at least age 45 for the entire enrollment period).  

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3620

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, [stateuserWA@test.com](mailto:stateuserDC@test.com)
2) Add a Health Home Core Set
3) Select COL-HH
4) In Measure Specification, select the first radio button
5) Scroll down to the Performance Measure section and check to make sure the text is updated to match the ticket.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
