### PR TITLE
Combined Rates Landing Page 

### DIFF
--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -6,7 +6,7 @@ import { useGetMeasureListInfo } from "hooks/api/useGetMeasureListInfo";
 import { useUser } from "hooks/authHooks";
 import { measureDescriptions } from "measures/measureDescriptions";
 import { UserRoles } from "types";
-import { CombinedRatesPage } from "views";
+import { CombinedRatesPage, CombinedRatesMeasure } from "views";
 
 const Home = lazy(() =>
   import("views/Home").then((module) => ({ default: module.Home }))
@@ -120,6 +120,17 @@ export function useMeasureRoutes(): MeasureRoute[] {
                   measure={createElement(Comp)}
                   autocompleteOnCreation={autocompleteOnCreation ?? false}
                 />
+              ),
+            });
+            //creating the routes for the combined rates measures
+            measureRoutes.push({
+              key: `:state/${year}/combined-rates/:measure`,
+              path: `:state/${year}/combined-rates/:measure`,
+              element: (
+                <CombinedRatesMeasure
+                  year={year}
+                  measureId={measure}
+                ></CombinedRatesMeasure>
               ),
             });
           }

--- a/services/ui-src/src/components/Table/index.tsx
+++ b/services/ui-src/src/components/Table/index.tsx
@@ -11,14 +11,14 @@ export const VerticalTable = <T extends TableData>({
   return (
     <>
       <CUI.VStack my="8" align="stretch">
-        {data?.map((row) => {
+        {data?.map((row, idx) => {
           return (
-            <CUI.Stack key={row.id} align="flex-start" spacing="4">
+            <CUI.Stack key={`${row.id}-${idx}`} align="flex-start" spacing="4">
               <CUI.Divider borderColor="gray.500"></CUI.Divider>
-              {columns.map((column) => {
+              {columns.map((column, col_idx) => {
                 const element = column.cell(row);
                 return (
-                  <CUI.Box>
+                  <CUI.Box key={`column-${col_idx}`}>
                     <CUI.Text
                       key={column.id}
                       data-cy={column.header}
@@ -29,7 +29,7 @@ export const VerticalTable = <T extends TableData>({
                       {column.header}
                     </CUI.Text>
                     <CUI.Text
-                      data-cy={`${column.header}-${row.id}`}
+                      data-cy={`${column.header}-${col_idx}`}
                       key={column.id + "_td"}
                     >
                       {element}
@@ -107,8 +107,12 @@ export const Table = <T extends TableData>({
 }: TableProps<T>) => {
   return (
     <>
-      <Hide below="md">{HorizontalTable({ columns, data })}</Hide>
-      <Show below="md">{VerticalTable({ columns, data })}</Show>
+      <Hide below="md" key="table">
+        {HorizontalTable({ columns, data })}
+      </Hide>
+      <Show below="md" key="table-mobile">
+        {VerticalTable({ columns, data })}
+      </Show>
     </>
   );
 };

--- a/services/ui-src/src/hooks/api/useGetMeasures.tsx
+++ b/services/ui-src/src/hooks/api/useGetMeasures.tsx
@@ -17,13 +17,15 @@ const getMeasures = async ({ state, year, coreSet }: GetMeasures) => {
   });
 };
 
-export const useGetMeasures = () => {
+export const useGetMeasures = (coreSetAbbr?: string) => {
   const {
     state: statePath,
     year: yearPath,
     coreSet: coreSetPath,
   } = usePathParams();
-  const { state, year, coreSetId } = useParams();
+  let { state, year, coreSetId } = useParams();
+
+  coreSetId = coreSetAbbr ?? coreSetId;
 
   if (
     (state || statePath) &&

--- a/services/ui-src/src/theme.ts
+++ b/services/ui-src/src/theme.ts
@@ -23,6 +23,25 @@ export const theme = extendTheme({
         },
       },
     },
+    Tabs: {
+      variants: {
+        unstyled: {
+          tab: {
+            fontWeight: "bold",
+            borderWidth: "1px 1px 0 1px",
+            borderColor: "gray.200",
+            fontSize: "sm",
+            _selected: {
+              color: "blue.500",
+              borderTopColor: "blue.500",
+              borderBottomColor: "white",
+              margin: "0 0 -1px 0",
+              borderWidth: "6px 1px 2px 1px",
+            },
+          },
+        },
+      },
+    },
     Button: {
       variants: {
         "link-white": {

--- a/services/ui-src/src/types.ts
+++ b/services/ui-src/src/types.ts
@@ -8,6 +8,16 @@ export enum CoreSetAbbr {
   HHCS = "HHCS",
 }
 
+export enum coreSetType {
+  ACS = "Adult",
+  ACSM = "Adult - Medicaid",
+  ACSC = "Adult - CHIP",
+  CCS = "Child",
+  CCSM = "Child - Medicaid",
+  CCSC = "Child - CHIP",
+  HHCS = "Health Home",
+}
+
 export enum UserRoles {
   ADMIN = "mdctqmr-bor", // "MDCT QMR ADMIN"
   APPROVER = "mdctqmr-approver", // "MDCT QMR APPROVER"

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.test.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { useApiMock } from "utils/testUtils/useApiMock";
+import { RouterWrappedComp } from "utils/testing";
+import { CombinedRatesMeasure } from "views";
+expect.extend(toHaveNoViolations);
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: () => ({
+    year: "2024",
+    state: "OH",
+  }),
+}));
+
+describe("Test CombinedRatesMeasure", () => {
+  it("renders", () => {
+    render(
+      <RouterWrappedComp>
+        <CombinedRatesMeasure year={"2024"} measureId={"AAB-AD"} />
+      </RouterWrappedComp>
+    );
+    expect(screen.getByText("TBD")).toBeVisible();
+  });
+});
+
+describe("Test accessibility", () => {
+  it("passes a11y tests", async () => {
+    useApiMock({});
+    const { container } = render(
+      <RouterWrappedComp>
+        <CombinedRatesMeasure year={"2024"} measureId={"AAB-AD"} />
+      </RouterWrappedComp>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -1,0 +1,26 @@
+import * as QMR from "components";
+import * as CUI from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
+
+interface Props {
+  year: string;
+  measureId: string;
+}
+
+export const CombinedRatesMeasure = ({ year }: Props) => {
+  const { state, measure } = useParams();
+
+  return (
+    <QMR.StateLayout
+      breadcrumbItems={[
+        { path: `/${state}/${year}/combined-rates`, name: `FFY ${year}` },
+        {
+          path: `/${state}/${year}`,
+          name: `${measure} Combined Rates`,
+        },
+      ]}
+    >
+      <CUI.Text>TBD</CUI.Text>
+    </QMR.StateLayout>
+  );
+};

--- a/services/ui-src/src/views/CombinedRatesPage/index.test.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.test.tsx
@@ -1,15 +1,99 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
+import { useApiMock } from "utils/testUtils/useApiMock";
+import { RouterWrappedComp } from "utils/testing";
 import { CombinedRatesPage } from "views";
 expect.extend(toHaveNoViolations);
 
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: () => ({
+    year: "2024",
+    state: "OH",
+  }),
+}));
+
+const useGetMeasuresValues = {
+  isLoading: false,
+  error: undefined,
+  isError: undefined,
+  data: {
+    Items: [
+      {
+        autoCompleted: false,
+        coreSet: "ACS",
+        createdAt: 1642167976771,
+        lastAltered: 1642167976771,
+        compoundKey: "AL2024ACSIET-AD",
+        measure: "IET-AD",
+        description:
+          "Initiation and Engagement of Alcohol and Other Drug Abuse or Dependence Treatment",
+        state: "AL",
+        status: "incomplete",
+        year: 2024,
+      },
+      {
+        autoCompleted: false,
+        coreSet: "ACS",
+        createdAt: 1642167976771,
+        lastAltered: 1642167976771,
+        compoundKey: "AL2024ACSAAB-AD",
+        measure: "AAB-AD",
+        description:
+          "Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis: Ages 3 Months to 17 Years",
+        state: "AL",
+        status: "incomplete",
+        year: 2024,
+      },
+    ],
+  },
+};
+
 describe("Test Combined Rates Page", () => {
-  it("renders", () => {
-    render(<CombinedRatesPage />);
-    expect(screen.getByText("TBD")).toBeVisible();
+  beforeEach(() => {
+    const apiData = { useGetMeasuresValues: useGetMeasuresValues };
+    useApiMock(apiData);
+    render(
+      <RouterWrappedComp>
+        <CombinedRatesPage />
+      </RouterWrappedComp>
+    );
   });
+  it("renders", () => {
+    expect(screen.getByText("Core Set Measures Combined Rates")).toBeVisible();
+    //check that tabs are on the page
+    expect(screen.getByText("Child Core Set"));
+    expect(screen.getByText("Adult Core Set"));
+  });
+  it("check table of tabs has mock data", () => {
+    //it will exist twice as the same data is populated in the table for both child and adult
+    expect(
+      screen.getAllByText(useGetMeasuresValues.data.Items[0].measure)
+    ).toHaveLength(2);
+    expect(
+      screen.getAllByText(useGetMeasuresValues.data.Items[0].description)
+    ).toHaveLength(2);
+  });
+  it("check tabs functionality", () => {
+    const childTab = screen.getByText("Child Core Set");
+    fireEvent.click(childTab);
+    expect(childTab).toHaveAttribute("aria-selected", "true");
+
+    const adultTab = screen.getByText("Adult Core Set");
+    fireEvent.click(adultTab);
+    expect(adultTab).toHaveAttribute("aria-selected", "true");
+  });
+});
+
+describe("Test accessibility", () => {
   it("passes a11y tests", async () => {
-    const { container } = render(<CombinedRatesPage />);
+    const apiData = {};
+    useApiMock(apiData);
+    const { container } = render(
+      <RouterWrappedComp>
+        <CombinedRatesPage />
+      </RouterWrappedComp>
+    );
     expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -16,7 +16,7 @@ const GetColumns = () => {
       styleProps: { textAlign: "center", width: "10%" },
       cell: (data: MeasureTableItem.Data) => {
         return (
-          <Link to={data.path}>
+          <Link to={data.path} aria-label={data.abbr}>
             <CUI.Text fontWeight="bold" color="blue.600" data-cy={data.abbr}>
               {data.abbr}
             </CUI.Text>
@@ -29,7 +29,7 @@ const GetColumns = () => {
       id: "title_column_header",
       cell: (data: MeasureTableItem.Data) => {
         return (
-          <Link to={data.path}>
+          <Link to={data.path} aria-label={data.title}>
             <CUI.Text fontWeight="bold" color="blue.600" data-cy={data.path}>
               {data.title}
             </CUI.Text>
@@ -40,7 +40,7 @@ const GetColumns = () => {
   ];
 };
 
-const GetMeasuresByCoreSet = (coreSet: string, year: string) => {
+const GetMeasuresByCoreSet = (coreSet: string, state: string, year: string) => {
   const { data } = useGetMeasures(coreSet);
   const measures = data?.Items as MeasureData[];
   const formatted = measures
@@ -55,7 +55,7 @@ const GetMeasuresByCoreSet = (coreSet: string, year: string) => {
       id: item.measure,
       abbr: item.measure,
       title: measureDescriptions[year][item.measure],
-      path: "/",
+      path: `/${state}/${year}/combined-rates/${item.measure}`,
     } as MeasureTableItem.Data;
   });
 };
@@ -84,7 +84,7 @@ export const CombinedRatesPage = () => {
   const coreSetTabs = GetCoreSetTabs(coreSetsAbbr);
   const { state, year } = useParams();
   let coreSetData = coreSetTabs.map((coreSet) =>
-    GetMeasuresByCoreSet(coreSet.abbr, year!)
+    GetMeasuresByCoreSet(coreSet.abbr, state!, year!)
   );
 
   if (isLoading || !data.Items) {

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -59,12 +59,12 @@ const GetMeasuresByCoreSet = (coreSet: string, year: string) => {
 };
 
 export const CombinedRatesPage = () => {
-  const coreSetAbbr = [
+  const coreSetTabs = [
     { abbr: "CCSC", title: "Child Core Set" },
     { abbr: "ACSC", title: "Adult Core Set" },
   ];
   const { state, year } = useParams();
-  let data = coreSetAbbr.map((coreSet) =>
+  let data = coreSetTabs.map((coreSet) =>
     GetMeasuresByCoreSet(coreSet.abbr, year!)
   );
 
@@ -81,7 +81,6 @@ export const CombinedRatesPage = () => {
       <CUI.VStack
         maxW="7xl"
         pb="6"
-        pr={{ md: "4rem" }}
         alignItems="flex-start"
         spacing="6"
         padding="2rem"
@@ -95,7 +94,7 @@ export const CombinedRatesPage = () => {
         </CUI.Text>
         <CUI.Tabs width="100%" variant="unstyled">
           <CUI.TabList>
-            {coreSetAbbr.map((coreSet) => (
+            {coreSetTabs.map((coreSet) => (
               <CUI.Tab
                 key={coreSet.title + "tab"}
                 padding={{ base: "2% 10%", md: "10px 40px" }}

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -3,25 +3,71 @@ import * as QMR from "components";
 import { useGetMeasures } from "hooks/api";
 import { MeasureData } from "types";
 import { measureDescriptions } from "measures/measureDescriptions";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
+import { MeasureTableItem } from "components/Table/types";
 
-const GetCoreSetPanel = (coreSet: string) => {
+const GetColumns = () => {
+  return [
+    {
+      header: "Abbreviation",
+      id: "aabr_column_header",
+      styleProps: { textAlign: "center", width: "10%" },
+      cell: (data: MeasureTableItem.Data) => {
+        return (
+          <Link to={data.path}>
+            <CUI.Text fontWeight="bold" color="blue.600" data-cy={data.abbr}>
+              {data.abbr}
+            </CUI.Text>
+          </Link>
+        );
+      },
+    },
+    {
+      header: "Measure",
+      id: "title_column_header",
+      cell: (data: MeasureTableItem.Data) => {
+        return (
+          <Link to={data.path}>
+            <CUI.Text fontWeight="bold" color="blue.600" data-cy={data.path}>
+              {data.title}
+            </CUI.Text>
+          </Link>
+        );
+      },
+    },
+  ];
+};
+
+const GetMeasuresByCoreSet = (coreSet: string, year: string) => {
   const { data } = useGetMeasures(coreSet);
-  const items = data?.Items as MeasureData[];
-  return items
+  const measures = data?.Items as MeasureData[];
+  const formatted = measures
     ?.filter(
       // filter out the coreset qualifiers
       (item) => item.measure && item.measure !== "CSQ"
     )
     .sort((a, b) => a?.measure?.localeCompare(b?.measure));
+
+  return formatted?.map((item) => {
+    return {
+      id: item.measure,
+      abbr: item.measure,
+      title: measureDescriptions[year][item.measure],
+      path: "/",
+    } as MeasureTableItem.Data;
+  });
 };
 
 export const CombinedRatesPage = () => {
-  const coreSetAbbr = ["ACSC", "CCSC"];
-  let panelItems = coreSetAbbr.map((coreSet) => GetCoreSetPanel(coreSet));
+  const coreSetAbbr = [
+    { abbr: "CCSC", title: "Child Core Set" },
+    { abbr: "ACSC", title: "Adult Core Set" },
+  ];
   const { state, year } = useParams();
+  let data = coreSetAbbr.map((coreSet) =>
+    GetMeasuresByCoreSet(coreSet.abbr, year!)
+  );
 
-  // const tableData = [];
   return (
     <QMR.StateLayout
       breadcrumbItems={[
@@ -47,24 +93,22 @@ export const CombinedRatesPage = () => {
           Instructions for the user - includes how to interpret the page and
           what they need to do to see rates (i.e. complete all measures)
         </CUI.Text>
-        <CUI.Tabs variant="enclosed">
+        <CUI.Tabs variant="enclosed" width="100%">
           <CUI.TabList>
             {coreSetAbbr.map((coreSet) => (
-              <CUI.Tab>{coreSet}</CUI.Tab>
+              <CUI.Tab key={coreSet.title + "tab"}>{coreSet.title}</CUI.Tab>
             ))}
           </CUI.TabList>
-          <CUI.TabPanels>
-            {panelItems?.map((items) => (
-              <CUI.TabPanel>
-                {/* <QMR.Table data={measures} columns={QMR.measuresColumns(year)} /> */}
-                {items?.map((item: any) => (
-                  <CUI.Link to={`combined-rates`}>
-                    <CUI.Text>{item?.measure}</CUI.Text>
-                    <CUI.Text>
-                      {measureDescriptions?.[year!]?.[item?.measure]}
-                    </CUI.Text>
-                  </CUI.Link>
-                ))}
+          <CUI.TabPanels border="1px">
+            {data?.map((measures, idx) => (
+              <CUI.TabPanel key={"panel" + idx}>
+                {measures?.length > 0 ? (
+                  <QMR.Table data={measures} columns={GetColumns()} />
+                ) : (
+                  <CUI.Text textAlign="center" padding="16">
+                    No core sets have been added
+                  </CUI.Text>
+                )}
               </CUI.TabPanel>
             ))}
           </CUI.TabPanels>

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -1,3 +1,75 @@
+import * as CUI from "@chakra-ui/react";
+import * as QMR from "components";
+import { useGetMeasures } from "hooks/api";
+import { MeasureData } from "types";
+import { measureDescriptions } from "measures/measureDescriptions";
+import { useParams } from "react-router-dom";
+
+const GetCoreSetPanel = (coreSet: string) => {
+  const { data } = useGetMeasures(coreSet);
+  const items = data?.Items as MeasureData[];
+  return items
+    ?.filter(
+      // filter out the coreset qualifiers
+      (item) => item.measure && item.measure !== "CSQ"
+    )
+    .sort((a, b) => a?.measure?.localeCompare(b?.measure));
+};
+
 export const CombinedRatesPage = () => {
-  return <div>TBD</div>;
+  const coreSetAbbr = ["ACSC", "CCSC"];
+  let panelItems = coreSetAbbr.map((coreSet) => GetCoreSetPanel(coreSet));
+  const { state, year } = useParams();
+
+  // const tableData = [];
+  return (
+    <QMR.StateLayout
+      breadcrumbItems={[
+        { path: `/${state}/${year}`, name: `FFY ${year}` },
+        {
+          path: `/${state}/${year}`,
+          name: "Combined Rates",
+        },
+      ]}
+    >
+      <CUI.VStack
+        maxW="7xl"
+        pb="6"
+        pr={{ md: "4rem" }}
+        alignItems="flex-start"
+        spacing="6"
+        padding="2rem"
+      >
+        <CUI.Heading size="lg" data-cy="combined-rates-heading">
+          Core Set Measures Combined Rates
+        </CUI.Heading>
+        <CUI.Text>
+          Instructions for the user - includes how to interpret the page and
+          what they need to do to see rates (i.e. complete all measures)
+        </CUI.Text>
+        <CUI.Tabs variant="enclosed">
+          <CUI.TabList>
+            {coreSetAbbr.map((coreSet) => (
+              <CUI.Tab>{coreSet}</CUI.Tab>
+            ))}
+          </CUI.TabList>
+          <CUI.TabPanels>
+            {panelItems?.map((items) => (
+              <CUI.TabPanel>
+                {/* <QMR.Table data={measures} columns={QMR.measuresColumns(year)} /> */}
+                {items?.map((item: any) => (
+                  <CUI.Link to={`combined-rates`}>
+                    <CUI.Text>{item?.measure}</CUI.Text>
+                    <CUI.Text>
+                      {measureDescriptions?.[year!]?.[item?.measure]}
+                    </CUI.Text>
+                  </CUI.Link>
+                ))}
+              </CUI.TabPanel>
+            ))}
+          </CUI.TabPanels>
+        </CUI.Tabs>
+      </CUI.VStack>
+    </QMR.StateLayout>
+  );
 };

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -93,13 +93,19 @@ export const CombinedRatesPage = () => {
           Instructions for the user - includes how to interpret the page and
           what they need to do to see rates (i.e. complete all measures)
         </CUI.Text>
-        <CUI.Tabs variant="enclosed" width="100%">
+        <CUI.Tabs width="100%" variant="unstyled">
           <CUI.TabList>
             {coreSetAbbr.map((coreSet) => (
-              <CUI.Tab key={coreSet.title + "tab"}>{coreSet.title}</CUI.Tab>
+              <CUI.Tab
+                key={coreSet.title + "tab"}
+                padding={{ base: "2% 10%", md: "10px 40px" }}
+                width={{ base: "100%", md: "fit-content" }}
+              >
+                {coreSet.title}
+              </CUI.Tab>
             ))}
           </CUI.TabList>
-          <CUI.TabPanels border="1px">
+          <CUI.TabPanels border="1px" borderColor="gray.200">
             {data?.map((measures, idx) => (
               <CUI.TabPanel key={"panel" + idx}>
                 {measures?.length > 0 ? (

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -1,7 +1,7 @@
 import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
 import { AddSSMCard } from "./AddSSMCard";
-import { CoreSetAbbr, MeasureStatus, MeasureData } from "types";
+import { CoreSetAbbr, MeasureStatus, MeasureData, coreSetType } from "types";
 import { CoreSetTableItem } from "components/Table/types";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { HiCheckCircle } from "react-icons/hi";
@@ -24,16 +24,6 @@ interface HandleDeleteMeasureData {
   measure: string;
   state: string;
   year: string;
-}
-
-enum coreSetType {
-  ACS = "Adult",
-  ACSM = "Adult - Medicaid",
-  ACSC = "Adult - CHIP",
-  CCS = "Child",
-  CCSM = "Child - Medicaid",
-  CCSC = "Child - CHIP",
-  HHCS = "Health Home",
 }
 
 interface MeasureTableItem {

--- a/services/ui-src/src/views/index.tsx
+++ b/services/ui-src/src/views/index.tsx
@@ -11,3 +11,4 @@ export * from "./AddHHCoreSet";
 export * from "./ApiTester";
 export * from "./ExportAll";
 export * from "./CombinedRatesPage";
+export * from "./CombinedRatesPage/CombinedRatesMeasure";


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR sets up the landing page for the combined rates for the Adult and Child coresets. 
This also sets up the routes for the individual measures within the combined rates page. 

Known Issues:
1) This does not prevent manually go to combined rates route for 2023, I still need to figure out how to stop that.
2) For some reason AAB-AD goes to the measure, will fix in another branch focused on the routes

✅ Product & Design

![Screenshot 2024-05-30 at 2 36 56 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/d1c48a0a-c364-4f6f-8a24-44be8c3362c8)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3633

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d3u4ms57g8dvwk.cloudfront.net/

1) Sign into QMR, any user
2) In reporting year 2024, select the Combined Rates button
3) You should now be able to see a table with toggles for Child & Adult Core Set
4) Click on any of them and it will take you to a route similar to, "MA/2024/combined-rates/AAB-CH" and the page should say TBD.
![Screenshot 2024-05-30 at 4 31 44 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/29288ebc-0cbb-445c-8242-c78ce145c4cc)



### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
