### PR TITLE
CMCDT-3604: adding higher z-index to horizontal kebab menu so that it…

### DIFF
--- a/services/ui-src/src/components/KebabMenu/index.tsx
+++ b/services/ui-src/src/components/KebabMenu/index.tsx
@@ -67,7 +67,7 @@ export const HorizontalKebabMenu = ({
           <BsThreeDotsVertical />
         </CUI.MenuButton>
       </CUI.Tooltip>
-      <CUI.MenuList bg="blue.500" maxW="40px" p="0">
+      <CUI.MenuList zIndex={10} bg="blue.500" maxW="40px" p="0">
         {menuItems.map((i) => (
           <KebabMenuItem
             menuLabel={menuLabel}


### PR DESCRIPTION
### Description
Adding higher z-index to horizontal kebab menu so that it is always the topmost element

Before:
![Screenshot 2024-06-03 at 11 43 14 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/16945230/f4725755-c0ce-4ddd-bef5-0d38116faff2)

After:
![Screenshot 2024-06-03 at 11 42 48 AM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/16945230/9a0ad774-3628-4d21-b905-4f31fff294ea)


---
### How to test
1. Reduce the screen width to 800px
2. On the main page for any given state, click on the bottom "Core Set Actions" menu button to open the kebab menu
3. Make sure that the kebab menu covers the text that is at the bottom of the table

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
