### PR TITLE
CMDCT-3692: adding validation for when selected checkbox array length is 0

### DIFF
--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
@@ -35,6 +35,15 @@ describe("validateOneDataSourceType", () => {
     };
     _check_errors(formData, 1);
   });
+  it("When a Data Source Selected array is empty, a validation warning shows", () => {
+    formData[DC.DATA_SOURCE] = DC.ADMINISTRATIVE_DATA;
+    formData[DC.DATA_SOURCE_SELECTIONS] = {
+      AdministrativeData0: {
+        selected: [],
+      },
+    };
+    _check_errors(formData, 1);
+  });
 
   it("Error message text should match default errorMessage", () => {
     formData[DC.DATA_SOURCE] = [];

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -13,7 +13,10 @@ export const validateAtLeastOneDataSourceType = (
           return typeof s === "object";
         })
         .indexOf(true);
-      if (!Object.values(source[index])[0]) {
+      if (
+        !Object.values(source[index])[0] ||
+        Object.values(source[index])[0].length === 0
+      ) {
         let dataErrorMessage;
         if (
           source.includes("AdministrativeData0-AdministrativeDataOther") ||


### PR DESCRIPTION
### Description
There was an issue where Administrative Data sub checkboxes could be unselected after previously being selected and there would be no validation errors. 

This was happening because the `selected` array would get set from `undefined` to an array containing the checkbox. 
THEN, if you unselected the nested checkbox you had previously selected, it would set the `selected` array to an empty array and not to undefined as it was before. Therefore, on unchecking that box and setting `selected` to an empty array, it was not being caught in validation because the validation was checking for undefined. 

I added a simple fix here to also check for array lengths and if the array length is 0, it will throw an error properly. 

---
### How to test
1. Navigate to any Reporting measure page
2. Under `Data Source`, select Administrative Data checkbox
3. Click the `Validate Measure` button and make sure to get a Data Source error -> this step was previously not working
4. Go back to Data Source and select the first nested checkbox (not other)
5. Click the `Validate Measure` button and make sure to NOT get a Data Source error
6. Go back to Data Source and de-select the first nested checkbox that you previously selected
7. Click the `Validate Measure` button and make sure you do get a Data Source error -> this step was previously not working

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
