### PR TITLE
[QMR] Combined Rates Measurement Page - Initial

### DIFF
--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -128,6 +128,7 @@ export function useMeasureRoutes(): MeasureRoute[] {
               path: `:state/${year}/combined-rates/:measure`,
               element: (
                 <CombinedRatesMeasure
+                  measureName={foundMeasureDescription}
                   year={year}
                   measureId={measure}
                 ></CombinedRatesMeasure>

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -124,8 +124,8 @@ export function useMeasureRoutes(): MeasureRoute[] {
             });
             //creating the routes for the combined rates measures
             measureRoutes.push({
-              key: `:state/${year}/combined-rates/:measure`,
-              path: `:state/${year}/combined-rates/:measure`,
+              key: `:state/${year}/combined-rates/${measure}`,
+              path: `:state/${year}/combined-rates/${measure}`,
               element: (
                 <CombinedRatesMeasure
                   measureName={foundMeasureDescription}

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.test.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.test.tsx
@@ -17,10 +17,18 @@ describe("Test CombinedRatesMeasure", () => {
   it("renders", () => {
     render(
       <RouterWrappedComp>
-        <CombinedRatesMeasure year={"2024"} measureId={"AAB-AD"} />
+        <CombinedRatesMeasure
+          year={"2024"}
+          measureId={"AAB-AD"}
+          measureName={
+            "Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis: Age 18 And Older"
+          }
+        />
       </RouterWrappedComp>
     );
-    expect(screen.getByText("TBD")).toBeVisible();
+    expect(
+      screen.getByText("Measures used to calculate combined rates:")
+    ).toBeVisible();
   });
 });
 
@@ -29,7 +37,13 @@ describe("Test accessibility", () => {
     useApiMock({});
     const { container } = render(
       <RouterWrappedComp>
-        <CombinedRatesMeasure year={"2024"} measureId={"AAB-AD"} />
+        <CombinedRatesMeasure
+          year={"2024"}
+          measureId={"AAB-AD"}
+          measureName={
+            "Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis: Age 18 And Older"
+          }
+        />
       </RouterWrappedComp>
     );
     expect(await axe(container)).toHaveNoViolations();

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -8,8 +8,12 @@ interface Props {
   measureName: string;
 }
 
-export const CombinedRatesMeasure = ({ year, measureName }: Props) => {
-  const { state, measure } = useParams();
+export const CombinedRatesMeasure = ({
+  year,
+  measureName,
+  measureId: measure,
+}: Props) => {
+  const { state } = useParams();
   const typeSuffix = measure?.slice(-2); // used to determine if measure is adult or child type
 
   return (

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -1,6 +1,6 @@
 import * as QMR from "components";
 import * as CUI from "@chakra-ui/react";
-import { useParams, Link } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 interface Props {
   year: string;

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -29,7 +29,9 @@ export const CombinedRatesMeasure = ({
       <CUI.Heading fontSize="xl" mt="2" mb="2">
         {measure} - {measureName}
       </CUI.Heading>
-      <body> TO-DO: replace placeholder text</body>
+      <CUI.Heading size="sm" as="body" fontWeight="400" mt="4">
+        TO-DO: replace placeholder text
+      </CUI.Heading>
       <CUI.Heading size="sm" as="h2" fontWeight="400" mt="4">
         Measures used to calculate combined rates:
       </CUI.Heading>

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -1,14 +1,16 @@
 import * as QMR from "components";
 import * as CUI from "@chakra-ui/react";
-import { useParams } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 
 interface Props {
   year: string;
   measureId: string;
+  measureName: string;
 }
 
-export const CombinedRatesMeasure = ({ year }: Props) => {
-  const { state, measure } = useParams();
+export const CombinedRatesMeasure = ({ year, measureName }: Props) => {
+  const { state, measure, coreSetId } = useParams();
+  const chipPath = `/${state}/${year}/ACSC/${measure}`;
 
   return (
     <QMR.StateLayout
@@ -20,7 +22,25 @@ export const CombinedRatesMeasure = ({ year }: Props) => {
         },
       ]}
     >
-      <CUI.Text>TBD</CUI.Text>
+      <CUI.Heading fontSize="xl" mt="2" mb="2">
+        {measure} - {measureName}
+      </CUI.Heading>
+      <body> TO-DO: replace placeholder text</body>
+      <CUI.Heading size="sm" as="h2" fontWeight="400" mt="4">
+        Measures used to calculate combined rates:
+      </CUI.Heading>
+      <CUI.UnorderedList m="5" ml="10">
+        <CUI.ListItem>
+          <Link to={chipPath} aria-label="" className="">
+            CHIP - {measure} - {measureName}
+          </Link>
+        </CUI.ListItem>
+        <CUI.ListItem>
+          <Link to={chipPath} aria-label="" className="">
+            Medicaid - {measure} - {measureName}
+          </Link>
+        </CUI.ListItem>
+      </CUI.UnorderedList>
     </QMR.StateLayout>
   );
 };

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -9,8 +9,8 @@ interface Props {
 }
 
 export const CombinedRatesMeasure = ({ year, measureName }: Props) => {
-  const { state, measure, coreSetId } = useParams();
-  const chipPath = `/${state}/${year}/ACSC/${measure}`;
+  const { state, measure } = useParams();
+  const typeSuffix = measure?.slice(-2); // used to determine if measure is adult or child type
 
   return (
     <QMR.StateLayout
@@ -31,14 +31,25 @@ export const CombinedRatesMeasure = ({ year, measureName }: Props) => {
       </CUI.Heading>
       <CUI.UnorderedList m="5" ml="10">
         <CUI.ListItem>
-          <Link to={chipPath} aria-label="" className="">
+          <CUI.Link
+            href={`/${state}/${year}/${typeSuffix}SC/${measure}`}
+            aria-label="Link to CHIP measure"
+            target="_blank"
+            color="blue.600"
+          >
             CHIP - {measure} - {measureName}
-          </Link>
+          </CUI.Link>
         </CUI.ListItem>
         <CUI.ListItem>
-          <Link to={chipPath} aria-label="" className="">
+          <CUI.Link
+            href={`/${state}/${year}/${typeSuffix}SM/${measure}`}
+            aria-label="Link to Medicaid measure"
+            className="link"
+            target="_blank"
+            color="blue.600"
+          >
             Medicaid - {measure} - {measureName}
-          </Link>
+          </CUI.Link>
         </CUI.ListItem>
       </CUI.UnorderedList>
     </QMR.StateLayout>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This page will display the combined rates for a QMR user that are associated with the separated or combined measures. This story only covers the initial sections (Header, Copy, Links back to the measures).

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3637

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. In FFY 2024, go to the "View Combined Rates" section 
2. Click into one of the measures and make sure that the layout looks correct, specifically the header and a section with h2 and two links, one that redirects to the chip coreset measure page and another to the medicaid coreset measure page. Confirm that the links are redirecting to the correct pages.  
3. The body text is a placeholder and there's a followup ticket that will address that. 

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
