### PR TITLE
remove unit test branch lock

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
   unit-tests:
     name: Unit Tests
     uses: ./.github/workflows/unittest-workflow.yml
-    if: github.ref_name == 'master'
     secrets:
       CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
   deploy:

--- a/.github/workflows/unittest-workflow.yml
+++ b/.github/workflows/unittest-workflow.yml
@@ -23,8 +23,7 @@ jobs:
         with:
           path: |
             **/node_modules
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Our unit tests workflow was only running on `master`

Now it will run in feature branches, val, and prod as well.

It runs alongside the deploy command so there is no time spent waiting for unit tests to finish before deploying

See [this branch's deploy action](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/runs/9500897568) as an example

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3575
CMDCT-3576

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
See [this branch's deploy action](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/runs/9500897568) as an example

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment