### PR TITLE
Health Home Landing Page Undefined label

### DIFF
--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -318,7 +318,7 @@ export const CoreSet = () => {
         { path: `/${state}/${year}`, name: `FFY ${year}` },
         {
           path: `/${state}/${year}/${coreSetId}`,
-          name: coreSetTitles(year, coreSetId) + spaName,
+          name: coreSetTitles(year, coreSet[0]) + spaName,
         },
       ]}
     >


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I was passing the wrong parameter (HHCS_<random numbers> instead of HHCS) into the coreSetTitles function and it couldn't find the correct label because of that. This is a simple fix for it.

![Screenshot 2024-06-13 at 1 10 44 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/ec11e1ee-949c-4077-a3b8-b789dd3c21b6)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3723

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any stateuser with HHCS (i.e. [stateuserWA@test.com](mailto:stateuserDC@test.com))
2) Add a Health Home CoreSet
3) Click it and make sure that the label on the blue banner looks says Health Homes and not undefined
![Screenshot 2024-06-13 at 1 10 05 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/7f13944b-19ef-42e3-9a09-d991f9a21132)


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
