### PR TITLE
Lock serverless version to 3 in run actions

### DIFF
--- a/run
+++ b/run
@@ -33,7 +33,7 @@ fi
 # check serverless is installed globally.
 if ! which serverless > /dev/null ; then
 	echo "installing serverless globally"
-	yarn global add serverless
+	yarn global add serverless@3.38.0
 fi
 
 # have to ensure that yarn install is up to date.


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I noticed a recent [destroy step installed serverless 4.1.0](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/runs/9569334659/job/26381646603#step:8:24). Let's lock this to v3.38.0 to prevent breaking changes from affecting us until we decide if we are migrating to v4