### PR TITLE
CMDCT-3724; CMDCT-3725: capitalizing health home program in the health home measures

### DIFF
--- a/services/ui-src/src/components/SupportInfo/index.tsx
+++ b/services/ui-src/src/components/SupportInfo/index.tsx
@@ -96,16 +96,16 @@ export const SupportInfo = () => (
 export const HealthHomeInfo = () => (
   <>
     <CUI.Text paddingTop="4" color="gray.700" line-height="normal">
-      The health home provision, authorized by section 2703 of the Affordable
+      The Health Home provision, authorized by section 2703 of the Affordable
       Care Act (section 1945 of the Social Security Act), provides an
       opportunity to build a person-centered care delivery model that focuses on
       improving outcomes and disease management for beneficiaries with chronic
       conditions. The Health Home Core Set of quality measures will be used to
-      evaluate care across all state health home programs. Specifically, section
-      2703 requires health home providers to report health care quality measures
+      evaluate care across all state Health Home Programs. Specifically, section
+      2703 requires Health Home providers to report health care quality measures
       in order to receive payment. The recommended Health Home Core Set will
-      require reporting at the health home provider level which the state will
-      collect and aggregate at the health home program level.
+      require reporting at the Health Home provider level which the state will
+      collect and aggregate at the Health Home Program level.
     </CUI.Text>
   </>
 );

--- a/services/ui-src/src/measures/2021/Qualifiers/Common/administrativeQuestions.tsx
+++ b/services/ui-src/src/measures/2021/Qualifiers/Common/administrativeQuestions.tsx
@@ -27,7 +27,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>adults</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -55,7 +55,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>children</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -83,7 +83,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>individuals</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -97,7 +97,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>providers</i>
             </b>{" "}
-            operating under the Health Home program?
+            operating under the Health Home Program?
           </>
         }
       />

--- a/services/ui-src/src/measures/2022/shared/Qualifiers/Common/administrativeQuestions.tsx
+++ b/services/ui-src/src/measures/2022/shared/Qualifiers/Common/administrativeQuestions.tsx
@@ -27,7 +27,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>adults</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -55,7 +55,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>children</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -83,7 +83,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>individuals</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -97,7 +97,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>providers</i>
             </b>{" "}
-            operating under the Health Home program?
+            operating under the Health Home Program?
           </>
         }
       />

--- a/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.tsx
+++ b/services/ui-src/src/measures/2023/shared/Qualifiers/Common/administrativeQuestions.tsx
@@ -54,7 +54,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>adults</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -83,7 +83,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>children</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -111,7 +111,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>individuals</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -125,7 +125,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>providers</i>
             </b>{" "}
-            operating under the Health Home program?
+            operating under the Health Home Program?
           </>
         }
       />

--- a/services/ui-src/src/measures/2024/shared/Qualifiers/Common/administrativeQuestions.tsx
+++ b/services/ui-src/src/measures/2024/shared/Qualifiers/Common/administrativeQuestions.tsx
@@ -54,7 +54,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>adults</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -83,7 +83,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>children</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -111,7 +111,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>individuals</i>
             </b>{" "}
-            in the Health Home program?
+            in the Health Home Program?
           </>
         }
       />
@@ -125,7 +125,7 @@ export const AdministrativeQuestions = () => {
             <b>
               <i>providers</i>
             </b>{" "}
-            operating under the Health Home program?
+            operating under the Health Home Program?
           </>
         }
       />


### PR DESCRIPTION
### Description
Super simple PR to capitalize Health Home in the health home qualifier questions view

---
### How to test
1. Log into a state that has Health Home such as DC
2. Add a health home core set and then click on the core set
3. Click on the `Health Home Core Set Questions` link in the Core Set Qualifiers box 
4. In the Health Home Core Set Qualifiers paragraph, make sure that every instance of `Health Home` or `Health Home Program` is capitalized
5. In the Administrative Questions section, make sure that all instances of `Health Home Program` are capitalized

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
