### PR TITLE
Improve resource tagging

### DIFF
--- a/run
+++ b/run
@@ -8,6 +8,7 @@ set -eu -o pipefail
 # this script checks for all the prereqs and then calls run.ts
 
 export REGION_A=us-east-1
+export PROJECT=qmr
 
 # check node exists
 if ! which node > /dev/null ; then

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -18,6 +18,7 @@ plugins:
   - serverless-dotenv-plugin
 
 custom:
+  project: "qmr"
   serverless-offline-ssm:
     stages:
       - local
@@ -62,6 +63,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: us-east-1
+  stackTags:
+    PROJECT: ${self:custom.project}
+    SERVICE: ${self:service}
   tracing:
     apiGateway: true
   logs:

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -8,6 +8,7 @@ plugins:
   - serverless-s3-bucket-helper
 
 custom:
+  project: "qmr"
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   serverlessTerminationProtection:
@@ -31,6 +32,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: us-east-1
+  stackTags:
+    PROJECT: ${self:custom.project}
+    SERVICE: ${self:service}  
 
 resources:
   Resources:

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -10,6 +10,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: us-east-1
+  stackTags:
+    PROJECT: ${self:custom.project}
+    SERVICE: ${self:service}  
   iam:
     role:
       path: ${ssm:/configuration/${self:custom.stage}/iam/path, ssm:/configuration/default/iam/path, "/"}
@@ -28,6 +31,7 @@ plugins:
   - serverless-s3-bucket-helper
 
 custom:
+  project: "qmr"
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   serverlessTerminationProtection:

--- a/services/ui-src/serverless.yml
+++ b/services/ui-src/serverless.yml
@@ -13,8 +13,12 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: us-east-1
+  stackTags:
+    PROJECT: ${self:custom.project}
+    SERVICE: ${self:service}  
 
 custom:
+  project: "qmr"
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   serverlessTerminationProtection:

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -7,6 +7,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: us-east-1
+  stackTags:
+    PROJECT: ${self:custom.project}
+    SERVICE: ${self:service}    
   iam:
     role:
       path: ${ssm:/configuration/${self:custom.stage}/iam/path, ssm:/configuration/default/iam/path, "/"}
@@ -20,6 +23,7 @@ plugins:
   - "@enterprise-cmcs/serverless-waf-plugin"
 
 custom:
+  project: "qmr"
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   serverlessTerminationProtection:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -15,6 +15,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: us-east-1
+  stackTags:
+    PROJECT: ${self:custom.project}
+    SERVICE: ${self:service}  
   iam:
     role:
       path: ${ssm:/configuration/${self:custom.stage}/iam/path, ssm:/configuration/default/iam/path, "/"}
@@ -40,6 +43,7 @@ provider:
           Resource: "*"
 
 custom:
+  project: "qmr"
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   serverless-offline-ssm:

--- a/src/run.ts
+++ b/src/run.ts
@@ -116,12 +116,21 @@ async function destroy_stage(options: {
   verify: boolean;
 }) {
   let destroyer = new ServerlessStageDestroyer();
-  //filters enable filtering by resource tags but we aren't leveraging any tags other than
-  //the STAGE tag automatically applied by the serverless framework.  Adding PROJECT and SERVICE
-  //tags would be a good idea.
+  let filters = [
+    {
+      Key: "PROJECT",
+      Value: `${process.env.PROJECT}`,
+    },
+  ];
+  if (options.service) {
+    filters.push({
+      Key: "SERVICE",
+      Value: `${options.service}`,
+    });
+  }
   await destroyer.destroy(`${process.env.REGION_A}`, options.stage, {
     wait: options.wait,
-    filters: [],
+    filters: filters,
     verify: options.verify,
   });
 }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The pull request introduces additional tags to each serverless service, which for the moment will largely appear as a noop change for most individuals, but it does pave the groundwork for future work items such as deploying multiple distinct projects into a single AWS account while avoiding conflicts.

But for the purpose of this PR, the main change is that destroy operations better target resources, and the `run destroy` command can now target specific services.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3642

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
This was tested in one environment by executing the destroy workflow against an ephem using the branch the changes were applied to.  It was also tested running from a workstation against a single service ('ui-src').

To destroy a single service, execute the following from a workstation:
`./run destroy --stage [some_branch] --service [some_service]`

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [X] I have performed a self-review of my code
- [X] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
