### PR TITLE
Migrate type from String[] to LabelData[] (2022)

### DIFF
--- a/services/ui-src/src/measures/2022/AMBHH/index.tsx
+++ b/services/ui-src/src/measures/2022/AMBHH/index.tsx
@@ -56,7 +56,7 @@ export const AMBHH = ({
               />
               <CMQ.DeviationFromMeasureSpec
                 categories={PMD.categories}
-                customTotalLabel={PMD.qualifiers[4]}
+                customTotalLabel={PMD.qualifiers[4].label}
               />
             </>
           )}

--- a/services/ui-src/src/measures/2022/AMMAD/validation.ts
+++ b/services/ui-src/src/measures/2022/AMMAD/validation.ts
@@ -1,7 +1,6 @@
 import * as DC from "dataConstants";
 import * as GV from "measures/2022/shared/globalValidations";
 import * as PMD from "./data";
-import { cleanString } from "utils/cleanString";
 import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
 //form type
 import { DefaultFormData as FormData } from "measures/2022/shared/CommonQuestions/types";
@@ -17,13 +16,12 @@ const sameDenominatorSets: GV.Types.OmsValidationCallback = ({
   if (isOPM) return [];
   const errorArray: FormError[] = [];
 
-  for (const qual of qualifiers.map((s) => cleanString(s))) {
+  for (const qual of qualifiers.map((s) => s.id)) {
     for (let initiation = 0; initiation < categories.length; initiation += 2) {
       const engagement = initiation + 1;
-      const initRate =
-        rateData.rates?.[qual]?.[cleanString(categories[initiation])]?.[0];
+      const initRate = rateData.rates?.[qual]?.[categories[initiation].id]?.[0];
       const engageRate =
-        rateData.rates?.[qual]?.[cleanString(categories[engagement])]?.[0];
+        rateData.rates?.[qual]?.[categories[engagement].id]?.[0];
 
       if (
         initRate &&
@@ -35,8 +33,8 @@ const sameDenominatorSets: GV.Types.OmsValidationCallback = ({
             [...label, qual]
           )}`,
           errorMessage: `Denominators must be the same for ${locationDictionary(
-            [categories[initiation]]
-          )} and ${locationDictionary([categories[engagement]])}.`,
+            [categories[initiation].label]
+          )} and ${locationDictionary([categories[engagement].label])}.`,
         });
       }
     }

--- a/services/ui-src/src/measures/2022/CBPAD/validation.ts
+++ b/services/ui-src/src/measures/2022/CBPAD/validation.ts
@@ -38,7 +38,7 @@ const CBPValidation = (data: FormData) => {
       OPM,
       age65PlusIndex,
       DefinitionOfDenominator,
-      PMD.qualifiers[1]
+      PMD.qualifiers[1].label
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2022/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2022/CBPHH/index.tsx
@@ -50,7 +50,7 @@ export const CBPHH = ({
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure calcTotal />
               <CMQ.DeviationFromMeasureSpec
                 categories={PMD.categories}
-                customTotalLabel={PMD.qualifiers[2]}
+                customTotalLabel={PMD.qualifiers[2].label}
               />
             </>
           )}

--- a/services/ui-src/src/measures/2022/CBPHH/validation.ts
+++ b/services/ui-src/src/measures/2022/CBPHH/validation.ts
@@ -37,7 +37,7 @@ const CBPValidation = (data: FormData) => {
       OPM,
       age65PlusIndex,
       DefinitionOfDenominator,
-      PMD.qualifiers[1]
+      PMD.qualifiers[1].label
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2022/CCWAD/validation.ts
+++ b/services/ui-src/src/measures/2022/CCWAD/validation.ts
@@ -51,7 +51,13 @@ const CCWADValidation = (data: FormData) => {
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       [memeRates, larcRates],
-      [""],
+      [
+        {
+          id: "",
+          label: "",
+          text: "",
+        },
+      ],
       deviationArray,
       didCalculationsDeviate
     ),

--- a/services/ui-src/src/measures/2022/CCWAD/validation.ts
+++ b/services/ui-src/src/measures/2022/CCWAD/validation.ts
@@ -1,7 +1,6 @@
 import * as DC from "dataConstants";
 import * as GV from "measures/2022/shared/globalValidations";
 import * as PMD from "./data";
-import { cleanString } from "utils";
 import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
 //form type
 import { DefaultFormData as FormData } from "measures/2022/shared/CommonQuestions/types";
@@ -19,9 +18,9 @@ const CCWADValidation = (data: FormData) => {
   );
 
   const memeRates =
-    data.PerformanceMeasure?.rates?.[cleanString(PMD.categories[0])] ?? [];
+    data.PerformanceMeasure?.rates?.[PMD.categories[0].id] ?? [];
   const larcRates =
-    data.PerformanceMeasure?.rates?.[cleanString(PMD.categories[1])] ?? [];
+    data.PerformanceMeasure?.rates?.[PMD.categories[1].id] ?? [];
 
   let errorArray: any[] = [];
   if (data[DC.DID_REPORT] === DC.NO) {

--- a/services/ui-src/src/measures/2022/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUHHH/index.tsx
@@ -50,7 +50,7 @@ export const FUHHH = ({
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
               <CMQ.DeviationFromMeasureSpec
                 categories={PMD.categories}
-                customTotalLabel={PMD.qualifiers[3]}
+                customTotalLabel={PMD.qualifiers[3].label}
               />
             </>
           )}

--- a/services/ui-src/src/measures/2022/HPCMIAD/validation.ts
+++ b/services/ui-src/src/measures/2022/HPCMIAD/validation.ts
@@ -40,7 +40,7 @@ const HPCMIADValidation = (data: FormData) => {
       OPM,
       age65PlusIndex,
       DefinitionOfDenominator,
-      PMD.qualifiers[1]
+      PMD.qualifiers[1].label
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2022/IETAD/validation.ts
+++ b/services/ui-src/src/measures/2022/IETAD/validation.ts
@@ -1,7 +1,6 @@
 import * as DC from "dataConstants";
 import * as GV from "measures/2022/shared/globalValidations";
 import * as PMD from "./data";
-import { cleanString } from "utils/cleanString";
 import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
 //form type
 import { DefaultFormData as FormData } from "measures/2022/shared/CommonQuestions/types";
@@ -18,13 +17,12 @@ const sameDenominatorSets: GV.Types.OmsValidationCallback = ({
   if (isOPM) return [];
   const errorArray: FormError[] = [];
 
-  for (const qual of qualifiers.map((s) => cleanString(s))) {
+  for (const qual of qualifiers.map((s) => s.id)) {
     for (let initiation = 0; initiation < categories.length; initiation += 2) {
       const engagement = initiation + 1;
-      const initRate =
-        rateData.rates?.[qual]?.[cleanString(categories[initiation])]?.[0];
+      const initRate = rateData.rates?.[qual]?.[categories[initiation].id]?.[0];
       const engageRate =
-        rateData.rates?.[qual]?.[cleanString(categories[engagement])]?.[0];
+        rateData.rates?.[qual]?.[categories[engagement].id]?.[0];
 
       if (
         initRate &&
@@ -36,8 +34,8 @@ const sameDenominatorSets: GV.Types.OmsValidationCallback = ({
             [...label, qual]
           )}`,
           errorMessage: `Denominators must be the same for ${locationDictionary(
-            [categories[initiation]]
-          )} and ${locationDictionary([categories[engagement]])}.`,
+            [categories[initiation].label]
+          )} and ${locationDictionary([categories[engagement].label])}.`,
         });
       }
     }
@@ -85,7 +83,9 @@ const IETValidation = (data: FormData) => {
         (qual) =>
           `Denominators must be the same for ${locationDictionary([
             qual,
-          ])} for ${PMD.categories[i]} and ${PMD.categories[i + 1]}.`
+          ])} for ${PMD.categories[i].label} and ${
+            PMD.categories[i + 1].label
+          }.`
       ),
     ];
   }

--- a/services/ui-src/src/measures/2022/IETHH/validation.ts
+++ b/services/ui-src/src/measures/2022/IETHH/validation.ts
@@ -5,8 +5,6 @@ import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
 //form type
 import { DefaultFormData as FormData } from "measures/2022/shared/CommonQuestions/types";
 
-const cleanString = (s: string) => s.replace(/[^\w]/g, "");
-
 /** For each qualifier the denominators neeed to be the same for both Initiaion and Engagement of the same category. */
 const sameDenominatorSets: GV.Types.OmsValidationCallback = ({
   rateData,
@@ -19,13 +17,12 @@ const sameDenominatorSets: GV.Types.OmsValidationCallback = ({
   if (isOPM) return [];
   const errorArray: FormError[] = [];
 
-  for (const qual of qualifiers.map((s) => cleanString(s))) {
+  for (const qual of qualifiers.map((s) => s.id)) {
     for (let initiation = 0; initiation < categories.length; initiation += 2) {
       const engagement = initiation + 1;
-      const initRate =
-        rateData.rates?.[qual]?.[cleanString(categories[initiation])]?.[0];
+      const initRate = rateData.rates?.[qual]?.[categories[initiation].id]?.[0];
       const engageRate =
-        rateData.rates?.[qual]?.[cleanString(categories[engagement])]?.[0];
+        rateData.rates?.[qual]?.[categories[engagement].id]?.[0];
 
       if (
         initRate &&
@@ -39,8 +36,8 @@ const sameDenominatorSets: GV.Types.OmsValidationCallback = ({
             [...label, qual]
           )}`,
           errorMessage: `Denominators must be the same for ${locationDictionary(
-            [categories[initiation]]
-          )} and ${locationDictionary([categories[engagement]])}.`,
+            [categories[initiation].label]
+          )} and ${locationDictionary([categories[engagement].label])}.`,
         });
       }
     }
@@ -88,7 +85,9 @@ const IETValidation = (data: FormData) => {
         (qual) =>
           `Denominators must be the same for ${locationDictionary([
             qual,
-          ])} for ${PMD.categories[i]} and ${PMD.categories[i + 1]}.`
+          ])} for ${PMD.categories[i].label} and ${
+            PMD.categories[i + 1].label
+          }.`
       ),
     ];
   }

--- a/services/ui-src/src/measures/2022/OEVCH/index.tsx
+++ b/services/ui-src/src/measures/2022/OEVCH/index.tsx
@@ -49,7 +49,7 @@ export const OEVCH = ({
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
               <CMQ.DeviationFromMeasureSpec
                 categories={PMD.categories}
-                customTotalLabel={PMD.qualifiers.slice(-1)[0]} // use the actual Total label
+                customTotalLabel={PMD.qualifiers.slice(-1)[0].label} // use the actual Total label
               />
             </>
           )}

--- a/services/ui-src/src/measures/2022/PCRAD/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2022/PCRAD/questions/PerformanceMeasure.tsx
@@ -5,7 +5,7 @@ import * as Types from "../../shared/CommonQuestions/types";
 import { PerformanceMeasureData } from "../../shared/CommonQuestions/PerformanceMeasure/data";
 import { useWatch } from "react-hook-form";
 import { PCRRate } from "components/PCRRate";
-import { cleanString } from "utils/cleanString";
+import { LabelData } from "utils";
 
 interface Props {
   data: PerformanceMeasureData;
@@ -16,8 +16,8 @@ interface Props {
 }
 
 interface NdrSetProps {
-  categories?: string[];
-  qualifiers?: string[];
+  categories?: LabelData[];
+  qualifiers?: LabelData[];
   rateReadOnly: boolean;
   calcTotal: boolean;
   rateScale?: number;
@@ -38,18 +38,18 @@ const CategoryNdrSets = ({
     <>
       {categories.map((item) => {
         let rates: QMR.IRate[] | undefined = qualifiers?.map((cat, idx) => ({
-          label: cat,
+          label: cat.label,
           id: idx,
         }));
 
         rates = rates?.length ? rates : [{ id: 0 }];
 
-        const cleanedName = cleanString(item);
+        const cleanedName = item.id;
 
         return (
           <>
-            <CUI.Text key={item} fontWeight="bold" my="5">
-              {item}
+            <CUI.Text key={item.id} fontWeight="bold" my="5">
+              {item.label}
             </CUI.Text>
             <QMR.Rate
               readOnly={rateReadOnly}
@@ -74,7 +74,7 @@ const QualifierNdrSets = ({
   const register = useCustomRegister();
 
   const rates: QMR.IRate[] = qualifiers.map((item, idx) => ({
-    label: item,
+    label: item.label,
     id: idx,
   }));
 

--- a/services/ui-src/src/measures/2022/PCRHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2022/PCRHH/questions/PerformanceMeasure.tsx
@@ -5,6 +5,7 @@ import { PerformanceMeasureData } from "measures/2022/shared/CommonQuestions/Per
 import { PCRRate } from "components/PCRRate";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { useWatch } from "react-hook-form";
+import { LabelData } from "utils";
 
 interface Props {
   data: PerformanceMeasureData;
@@ -15,8 +16,8 @@ interface Props {
 }
 
 interface NdrSetProps {
-  categories?: string[];
-  qualifiers?: string[];
+  categories?: LabelData[];
+  qualifiers?: LabelData[];
   rateReadOnly: boolean;
   calcTotal: boolean;
   rateScale?: number;
@@ -35,20 +36,20 @@ const CategoryNdrSets = ({
 
   return (
     <>
-      {categories.map((item) => {
-        let rates: QMR.IRate[] | undefined = qualifiers?.map((cat, idx) => ({
-          label: cat,
+      {categories.map((cat) => {
+        let rates: QMR.IRate[] | undefined = qualifiers?.map((qual, idx) => ({
+          label: qual.label,
           id: idx,
         }));
 
         rates = rates?.length ? rates : [{ id: 0 }];
 
-        const cleanedName = item.replace(/[^\w]/g, "");
+        const cleanedName = cat.id;
 
         return (
           <>
             <CUI.Text key={item} fontWeight="bold" my="5">
-              {item}
+              {cat.label}
             </CUI.Text>
             <QMR.Rate
               readOnly={rateReadOnly}
@@ -73,7 +74,7 @@ const QualifierNdrSets = ({
   const register = useCustomRegister();
 
   const rates: QMR.IRate[] = qualifiers.map((item, idx) => ({
-    label: item,
+    label: item.label,
     id: idx,
   }));
 

--- a/services/ui-src/src/measures/2022/PCRHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2022/PCRHH/questions/PerformanceMeasure.tsx
@@ -48,7 +48,7 @@ const CategoryNdrSets = ({
 
         return (
           <>
-            <CUI.Text key={item} fontWeight="bold" my="5">
+            <CUI.Text key={cat.id} fontWeight="bold" my="5">
               {cat.label}
             </CUI.Text>
             <QMR.Rate

--- a/services/ui-src/src/measures/2022/PQI05AD/validation.ts
+++ b/services/ui-src/src/measures/2022/PQI05AD/validation.ts
@@ -46,7 +46,7 @@ const PQI05Validation = (data: FormData) => {
       validateDualPopInformationArray,
       OPM,
       1,
-      ageGroups
+      ageGroups.map((item) => item.label)
     ),
     ...GV.validateAtLeastOneDeviationFieldFilled(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2022/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2022/PQI92HH/index.tsx
@@ -56,7 +56,7 @@ export const PQI92HH = ({
               />
               <CMQ.DeviationFromMeasureSpec
                 categories={PMD.qualifiers}
-                customTotalLabel={PMD.qualifiers[2]}
+                customTotalLabel={PMD.qualifiers[2].label}
               />
             </>
           )}

--- a/services/ui-src/src/measures/2022/WCCCH/data.ts
+++ b/services/ui-src/src/measures/2022/WCCCH/data.ts
@@ -8,7 +8,7 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
     "The percentage of children ages 3 to 17 who had an outpatient visit with a primary care practitioner (PCP) or obstetrician/gynecologist (OB/GYN) and who had evidence of the following during the measurement year:",
   ],
-  questionListItems: categories,
+  questionListItems: categories.map((item) => item.label),
   categories,
   qualifiers,
 };

--- a/services/ui-src/src/measures/2022/rateLabelText.test.ts
+++ b/services/ui-src/src/measures/2022/rateLabelText.test.ts
@@ -1,0 +1,23 @@
+import { cleanString } from "utils";
+import { data } from "./rateLabelText";
+
+describe("rate label text", () => {
+  it("generated ids should match hardcoded ids", () => {
+    for (let [measureAbbr, groups] of Object.entries(data)) {
+      const mismatches = [];
+      for (let groupType of ["categories", "qualifiers"] as const) {
+        for (let group of groups[groupType]) {
+          const cleanLabel = cleanString(group.label);
+          const id = group.id;
+          if (cleanLabel !== id) {
+            mismatches.push({ measureAbbr, groupType, cleanLabel, id });
+          }
+        }
+      }
+      if (mismatches.length > 0) {
+        console.error(JSON.stringify(mismatches));
+        throw new Error("Mismatch(es) detected! See console output");
+      }
+    }
+  });
+});

--- a/services/ui-src/src/measures/2022/rateLabelText.ts
+++ b/services/ui-src/src/measures/2022/rateLabelText.ts
@@ -4,7 +4,7 @@
  * Changing the text property of these objects will change the text that is displayed to the user.
  */
 
-import { LabelData } from "utils";
+import { LabelData, cleanString } from "utils";
 
 export const data = {
     "AAB-AD": {
@@ -1660,13 +1660,19 @@ export const data = {
 }
 
 export const getCatQualLabels = (measure: keyof typeof data) => {
-    const getLabels = (q: LabelData) => q.label
-
-    const qualifiers = data[measure].qualifiers.map(getLabels);
-    const categories = data[measure].categories.map(getLabels);
+    const qualifiers: LabelData[] = data[measure].qualifiers.map((item) => ({
+        id: cleanString(item.label), //for some reason the system would create the id from the label instead of using the id key that existed
+        label: item.label,
+        text: item.text,
+    }));
+    const categories: LabelData[] = data[measure].categories.map((item) => ({
+        id: cleanString(item.label), //for some reason the system would create the id from the label instead of using the id key that existed
+        label: item.label,
+        text: item.text,
+    }));
   
     return {
       qualifiers,
       categories,
     };
-  };
+};

--- a/services/ui-src/src/measures/2022/rateLabelText.ts
+++ b/services/ui-src/src/measures/2022/rateLabelText.ts
@@ -4,9 +4,9 @@
  * Changing the text property of these objects will change the text that is displayed to the user.
  */
 
-import { LabelData, cleanString } from "utils";
+import { LabelData } from "utils";
 
-export const data = {
+const rawData = {
     "AAB-AD": {
         "qualifiers": [
             {
@@ -674,7 +674,7 @@ export const data = {
             {
                 "label": "Total (Age 13 and older)",
                 "text": "Total (Age 13 and older)",
-                "id": "Total"
+                "id": "TotalAge13andolder"
             }
         ],
         "categories": [
@@ -1659,20 +1659,16 @@ export const data = {
     }
 }
 
-export const getCatQualLabels = (measure: keyof typeof data) => {
-    const qualifiers: LabelData[] = data[measure].qualifiers.map((item) => ({
-        id: cleanString(item.label), //for some reason the system would create the id from the label instead of using the id key that existed
-        label: item.label,
-        text: item.text,
-    }));
-    const categories: LabelData[] = data[measure].categories.map((item) => ({
-        id: cleanString(item.label), //for some reason the system would create the id from the label instead of using the id key that existed
-        label: item.label,
-        text: item.text,
-    }));
-  
-    return {
-      qualifiers,
-      categories,
+type MeasureAbbreviation = keyof typeof rawData;
+type RateLabelDataShape = {
+    [key in MeasureAbbreviation]: {
+        categories: LabelData[];
+        qualifiers: LabelData[];
     };
+};
+
+export const data: RateLabelDataShape = rawData;
+
+export const getCatQualLabels = (measure: MeasureAbbreviation) => {
+    return data[measure];
 };

--- a/services/ui-src/src/measures/2022/shared/CommonQuestions/PerformanceMeasure/data.ts
+++ b/services/ui-src/src/measures/2022/shared/CommonQuestions/PerformanceMeasure/data.ts
@@ -1,8 +1,9 @@
 import { ndrFormula } from "types";
+import { LabelData } from "utils";
 
 export interface PerformanceMeasureData {
-  qualifiers?: string[]; // age ranges, etc
-  categories?: string[]; //performance measure descriptions
+  qualifiers?: LabelData[]; // age ranges, etc
+  categories?: LabelData[]; //performance measure descriptions
   measureName?: string;
   inputFieldNames?: string[];
   ndrFormulas?: ndrFormula[];
@@ -23,15 +24,58 @@ export const exampleData: PerformanceMeasureData = {
     "Initiation of AOD Treatment: Percentage of beneficiaries who initiate treatment through an inpatient AOD admission, outpatient visit, intensive outpatient encounter, or partial hospitalization, telehealth, or medication assisted treatment within 14 days of the diagnosis.",
     "Engagement of AOD Treatment: Percentage of beneficiaries who initiated treatment and who were engaged in ongoing AOD treatment within 34 days of the initiation visit.",
   ],
-  qualifiers: ["Ages 18 to 64", "Age 65 and older"],
+  qualifiers: [
+    {
+      label: "Ages 18 to 64",
+      text: "Ages 18 to 64",
+      id: "Ages18to64",
+    },
+    {
+      label: "Age 65 and older",
+      text: "Age 65 and older",
+      id: "Age65andolder",
+    },
+  ],
   categories: [
-    "Initiation of AOD Treatment: Alcohol Abuse or Dependence",
-    "Engagement of AOD Treatment: Alcohol Abuse or Dependence",
-    "Initiation of AOD Treatment: Opioid Abuse or Dependence",
-    "Engagement of AOD Treatment: Opioid Abuse or Dependence",
-    "Initiation of AOD Treatment: Other Drug Abuse or Dependence",
-    "Engagement of AOD Treatment: Other Drug Abuse or Dependence",
-    "Initiation of AOD Treatment: Total AOD Abuse or Dependence",
-    "Engagement of AOD Treatment: Total AOD Abuse or Dependence",
+    {
+      label: "Initiation of AOD Treatment: Alcohol Abuse or Dependence",
+      text: "Initiation of AOD Treatment: Alcohol Abuse or Dependence",
+      id: "InitiationofAODTreatmentAlcoholAbuseorDependence",
+    },
+    {
+      label: "Engagement of AOD Treatment: Alcohol Abuse or Dependence",
+      text: "Engagement of AOD Treatment: Alcohol Abuse or Dependence",
+      id: "EngagementofAODTreatmentAlcoholAbuseorDependence",
+    },
+    {
+      label: "Initiation of AOD Treatment: Opioid Abuse or Dependence",
+      text: "Initiation of AOD Treatment: Opioid Abuse or Dependence",
+      id: "InitiationofAODTreatmentOpioidAbuseorDependence",
+    },
+    {
+      label: "Engagement of AOD Treatment: Opioid Abuse or Dependence",
+      text: "Engagement of AOD Treatment: Opioid Abuse or Dependence",
+      id: "EngagementofAODTreatmentOpioidAbuseorDependence",
+    },
+    {
+      label: "Initiation of AOD Treatment: Other Drug Abuse or Dependence",
+      text: "Initiation of AOD Treatment: Other Drug Abuse or Dependence",
+      id: "InitiationofAODTreatmentOtherDrugAbuseorDependence",
+    },
+    {
+      label: "Engagement of AOD Treatment: Other Drug Abuse or Dependence",
+      text: "Engagement of AOD Treatment: Other Drug Abuse or Dependence",
+      id: "EngagementofAODTreatmentOtherDrugAbuseorDependence",
+    },
+    {
+      label: "Initiation of AOD Treatment: Total AOD Abuse or Dependence",
+      text: "Initiation of AOD Treatment: Total AOD Abuse or Dependence",
+      id: "InitiationofAODTreatmentTotalAODAbuseorDependence",
+    },
+    {
+      label: "Engagement of AOD Treatment: Total AOD Abuse or Dependence",
+      text: "Engagement of AOD Treatment: Total AOD Abuse or Dependence",
+      id: "EngagementofAODTreatmentTotalAODAbuseorDependence",
+    },
   ],
 };

--- a/services/ui-src/src/measures/2022/shared/CommonQuestions/PerformanceMeasure/index.test.tsx
+++ b/services/ui-src/src/measures/2022/shared/CommonQuestions/PerformanceMeasure/index.test.tsx
@@ -45,12 +45,12 @@ describe("Test the PerformanceMeasure RateComponent prop", () => {
     expect(screen.getByText(exampleData.questionText![0])).toBeVisible();
     expect(screen.getByText(exampleData.questionListItems![0])).toBeVisible();
     expect(screen.getByText(exampleData.questionListItems![1])).toBeVisible();
-    for (const label of exampleData.qualifiers!)
-      expect(screen.queryAllByText(label).length).toBe(
+    for (const qual of exampleData.qualifiers!)
+      expect(screen.queryAllByText(qual.label).length).toBe(
         exampleData.categories!.length
       );
-    for (const label of exampleData.categories!)
-      expect(screen.getByText(label)).toBeVisible;
+    for (const cat of exampleData.categories!)
+      expect(screen.getByText(cat.label)).toBeVisible;
 
     const numeratorTextBox = screen.queryAllByLabelText("Numerator")[0];
     const denominatorTextBox = screen.queryAllByLabelText("Denominator")[0];
@@ -111,7 +111,9 @@ describe("Test the PerformanceMeasure RateComponent prop", () => {
 
   test("(PCR-XX) Ensure component renders", () => {
     // modifying data to be easier to check
-    PCRData.qualifiers = PCRData.qualifiers!.map((qual) => `qual ${qual}`);
+    PCRData.qualifiers = PCRData.qualifiers!.map((qual) => {
+      return { id: qual.id, label: `qual ${qual.label}`, text: qual.text };
+    });
 
     props.component = PCRRate;
     props.data = PCRData;
@@ -122,14 +124,16 @@ describe("Test the PerformanceMeasure RateComponent prop", () => {
     expect(screen.getByText(PCRData.questionText![0])).toBeVisible();
     expect(screen.getByText(PCRData.questionListItems![0])).toBeVisible();
     expect(screen.getByText(PCRData.questionListItems![1])).toBeVisible();
-    for (const label of PCRData.qualifiers!) {
-      expect(screen.getByText(label)).toBeVisible();
+    for (const qual of PCRData.qualifiers!) {
+      expect(screen.getByText(qual.label)).toBeVisible();
     }
 
     // rates should be editable by default
-    const numeratorTextBox = screen.getByLabelText(PCRData.qualifiers[1]);
-    const denominatorTextBox = screen.getByLabelText(PCRData.qualifiers[0]);
-    const rateTextBox = screen.getByLabelText(PCRData.qualifiers[2]);
+    const numeratorTextBox = screen.getByLabelText(PCRData.qualifiers[1].label);
+    const denominatorTextBox = screen.getByLabelText(
+      PCRData.qualifiers[0].label
+    );
+    const rateTextBox = screen.getByLabelText(PCRData.qualifiers[2].label);
     fireEvent.type(numeratorTextBox, "123");
     fireEvent.type(denominatorTextBox, "123");
     expect(numeratorTextBox).toHaveDisplayValue("123");
@@ -148,12 +152,14 @@ describe("Test the PerformanceMeasure RateComponent prop", () => {
 
     // rates should not be editable
     const numeratorTextBox = screen.queryAllByLabelText(
-      PCRData.qualifiers![1]
+      PCRData.qualifiers![1].label
     )[0];
     const denominatorTextBox = screen.queryAllByLabelText(
-      PCRData.qualifiers![0]
+      PCRData.qualifiers![0].label
     )[0];
-    const rateTextBox = screen.getByText(PCRData.qualifiers![2]).nextSibling;
+    const rateTextBox = screen.getByText(
+      PCRData.qualifiers![2].label
+    ).nextSibling;
     fireEvent.type(numeratorTextBox, "123");
     fireEvent.type(denominatorTextBox, "123");
     expect(numeratorTextBox).toHaveDisplayValue("123");

--- a/services/ui-src/src/measures/2022/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2022/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -5,7 +5,7 @@ import * as Types from "../types";
 import * as DC from "dataConstants";
 import { PerformanceMeasureData } from "./data";
 import { useWatch } from "react-hook-form";
-import { cleanString, getLabelText } from "utils";
+import { LabelData, cleanString, getLabelText } from "utils";
 import { ndrFormula } from "types";
 
 interface Props {
@@ -25,8 +25,8 @@ interface Props {
 }
 
 interface NdrSetProps {
-  categories?: string[];
-  qualifiers?: string[];
+  categories?: LabelData[];
+  qualifiers?: LabelData[];
   measureName?: string;
   inputFieldNames?: string[];
   ndrFormulas?: ndrFormula[];
@@ -67,18 +67,18 @@ const CategoryNdrSets = ({
     <>
       {categories.map((item) => {
         let rates: QMR.IRate[] | undefined = qualifiers?.map((cat, idx) => ({
-          label: cat,
+          label: cat.label,
           id: idx,
         }));
 
         rates = rates?.length ? rates : [{ id: 0 }];
 
-        const cleanedName = cleanString(item);
+        const cleanedName = item.id;
 
         return (
-          <CUI.Box key={item}>
+          <CUI.Box key={item.id}>
             <CUI.Text fontWeight="bold" my="5">
-              {labelText[item] ?? item}
+              {labelText[item.label] ?? item.label}
             </CUI.Text>
             <RateComponent
               readOnly={rateReadOnly}
@@ -88,7 +88,7 @@ const CategoryNdrSets = ({
               ndrFormulas={ndrFormulas}
               rateMultiplicationValue={rateScale}
               calcTotal={calcTotal}
-              categoryName={item}
+              categoryName={item.label}
               customMask={customMask}
               customNumeratorLabel={customNumeratorLabel}
               customDenominatorLabel={customDenominatorLabel}
@@ -128,7 +128,7 @@ const QualifierNdrSets = ({
   const register = useCustomRegister();
 
   const rates: QMR.IRate[] = qualifiers.map((item, idx) => ({
-    label: item,
+    label: item.label,
     id: idx,
   }));
   return (

--- a/services/ui-src/src/measures/2022/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2022/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -5,7 +5,7 @@ import * as Types from "../types";
 import * as DC from "dataConstants";
 import { PerformanceMeasureData } from "./data";
 import { useWatch } from "react-hook-form";
-import { LabelData, cleanString, getLabelText } from "utils";
+import { LabelData, getLabelText } from "utils";
 import { ndrFormula } from "types";
 
 interface Props {

--- a/services/ui-src/src/measures/2022/shared/CommonQuestions/types.ts
+++ b/services/ui-src/src/measures/2022/shared/CommonQuestions/types.ts
@@ -2,6 +2,7 @@ import { OmsNode } from "shared/types";
 import { PerformanceMeasureData } from "./PerformanceMeasure/data";
 import * as DC from "dataConstants";
 import * as Types from "shared/types";
+import { LabelData } from "utils";
 
 type YesNo = typeof DC.YES | typeof DC.NO;
 
@@ -232,11 +233,11 @@ export namespace OmsNodes {
 }
 
 export interface Qualifiers {
-  [DC.QUALIFIERS]?: string[];
+  [DC.QUALIFIERS]?: LabelData[];
 }
 
 export interface Categories {
-  [DC.CATEGORIES]?: string[];
+  [DC.CATEGORIES]?: LabelData[];
 }
 
 export interface OptionalMeasureStratification {

--- a/services/ui-src/src/measures/2022/shared/globalValidations/ComplexValidations/ComplexValidateNDRTotals/index.tsx
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/ComplexValidations/ComplexValidateNDRTotals/index.tsx
@@ -1,4 +1,4 @@
-import { cleanString } from "utils";
+import { LabelData } from "utils";
 
 interface NDRforumla {
   numerator: number;
@@ -19,7 +19,7 @@ interface Field {
 /* At least one NDR set must be complete (OMS) */
 export const ComplexValidateNDRTotalsOMS = (
   rateData: any,
-  categories: string[],
+  categories: LabelData[],
   ndrFormulas: NDRforumla[],
   errorLocation: string
 ) => {
@@ -31,7 +31,7 @@ export const ComplexValidateNDRTotalsOMS = (
 
   // build performanceMeasureArray
   let performanceMeasureArray = [];
-  const cleanedCategories = categories.map((cat) => cleanString(cat));
+  const cleanedCategories = categories.map((cat) => cat.id);
   if (cleanedCategories.length !== 0) {
     for (const cat of cleanedCategories) {
       let row = [];
@@ -75,7 +75,7 @@ export const ComplexValidateNDRTotalsOMS = (
  */
 export const ComplexValidateNDRTotals = (
   performanceMeasureArray: any,
-  categories: string[],
+  categories: LabelData[],
   ndrFormulas: NDRforumla[],
   errorLocation: string = "Performance Measure Total"
 ) => {
@@ -106,10 +106,10 @@ export const ComplexValidateNDRTotals = (
     ) {
       errorArray.push({
         errorLocation: `${errorLocation} - ${
-          categories[i] ? categories[i] : ""
+          categories[i].label ? categories[i].label : ""
         }`,
         errorMessage: `Total ${
-          categories[i] ? categories[i] : ""
+          categories[i].label ? categories[i].label : ""
         } must contain values if other fields are filled.`,
       });
     } else {
@@ -121,12 +121,12 @@ export const ComplexValidateNDRTotals = (
         ) {
           errorArray.push({
             errorLocation: `${errorLocation} - ${
-              categories[i] ? categories[i] : ""
+              categories[i].label ? categories[i].label : ""
             }`,
             errorMessage: `Total ${
               field.label
             } is not equal to the sum of other "${field.label}" fields in ${
-              categories[i] ? categories[i] : ""
+              categories[i].label ? categories[i].label : ""
             } section.`,
           });
         }

--- a/services/ui-src/src/measures/2022/shared/globalValidations/ComplexValidations/ComplexValidateNDRTotals/index.tsx
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/ComplexValidations/ComplexValidateNDRTotals/index.tsx
@@ -106,10 +106,10 @@ export const ComplexValidateNDRTotals = (
     ) {
       errorArray.push({
         errorLocation: `${errorLocation} - ${
-          categories[i].label ? categories[i].label : ""
+          categories[i]?.label ? categories[i].label : ""
         }`,
         errorMessage: `Total ${
-          categories[i].label ? categories[i].label : ""
+          categories[i]?.label ? categories[i].label : ""
         } must contain values if other fields are filled.`,
       });
     } else {
@@ -121,12 +121,12 @@ export const ComplexValidateNDRTotals = (
         ) {
           errorArray.push({
             errorLocation: `${errorLocation} - ${
-              categories[i].label ? categories[i].label : ""
+              categories[i]?.label ? categories[i].label : ""
             }`,
             errorMessage: `Total ${
               field.label
             } is not equal to the sum of other "${field.label}" fields in ${
-              categories[i].label ? categories[i].label : ""
+              categories[i]?.label ? categories[i].label : ""
             } section.`,
           });
         }

--- a/services/ui-src/src/measures/2022/shared/globalValidations/ComplexValidations/ComplexValueSameCrossCategory/index.tsx
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/ComplexValidations/ComplexValueSameCrossCategory/index.tsx
@@ -1,9 +1,9 @@
-import { cleanString } from "utils";
+import { LabelData, cleanString } from "utils";
 
 export const ComplexValueSameCrossCategoryOMS = (
   rateData: any,
-  categories: string[],
-  qualifiers: string[],
+  categories: LabelData[],
+  qualifiers: LabelData[],
   errorLocation: string
 ) => {
   // Using a subset of rateData as iterator to be sure that Total
@@ -14,10 +14,10 @@ export const ComplexValueSameCrossCategoryOMS = (
 
   const qualifierLabels: any = {};
   for (const q of qualifiers) {
-    const qCleaned = cleanString(q);
+    const qCleaned = q.id;
     qualifierLabels[qCleaned] = q;
   }
-  const cleanedCategories = categories.map((cat) => cleanString(cat));
+  const cleanedCategories = categories.map((cat) => cat.id);
 
   // build performanceMeasureArray
   let performanceMeasureArray = [];

--- a/services/ui-src/src/measures/2022/shared/globalValidations/PCRValidations/PCRatLeastOneRateComplete/index.tsx
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/PCRValidations/PCRatLeastOneRateComplete/index.tsx
@@ -1,10 +1,11 @@
+import { LabelData } from "utils";
 import { validatePartialRateCompletionPM } from "../../validatePartialRateCompletion";
 
 /* At least one NDR set must be complete (OPM or PM) */
 export const PCRatLeastOneRateComplete = (
   performanceMeasureArray: any,
   OPM: any,
-  ageGroups: string[],
+  ageGroups: LabelData[],
   errorLocation: string = "Performance Measure/Other Performance Measure",
   omsFlag = false
 ) => {

--- a/services/ui-src/src/measures/2022/shared/globalValidations/dataDrivenTools.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/dataDrivenTools.test.ts
@@ -1,10 +1,11 @@
+import { LabelData } from "utils/getLabelText";
 import { SINGLE_CATEGORY, PERFORMANCE_MEASURE } from "dataConstants";
 import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
 import {
   generateOmsQualifierRateData,
   generatePmQualifierRateData,
   simpleRate,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
 import {
   convertOmsDataToRateArray,
   getPerfMeasureRateArray,
@@ -13,9 +14,19 @@ import {
   getDeviationNDRArray,
 } from "./dataDrivenTools";
 
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
+
 describe("Test Data Driven Tools", () => {
-  const categories = ["TestCat1", "TestCat2"];
-  const qualifiers = ["TestQual1", "TestQual2"];
+  const categories: LabelData[] = [
+    { id: "TestCat1", label: "TestCat1", text: "TestCat1" },
+    { id: "TestCat2", label: "TestCat2", text: "TestCat2" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "TestQual1", label: "TestQual1", text: "TestQual1" },
+    { id: "TestQual2", label: "TestQual2", text: "TestQual2" },
+  ];
 
   describe("convertOmsDataToRateArray", () => {
     it("should take an oms structure and return an array or rate arrays", () => {
@@ -40,9 +51,13 @@ describe("Test Data Driven Tools", () => {
   describe("omsLocationDictionary", () => {
     it("should make a dictionary function", () => {
       const func = omsLocationDictionary(OMSData(2022), qualifiers, categories);
-      expect(func(qualifiers)).toBe(`${qualifiers[0]} - ${qualifiers[1]}`);
-      expect(func(categories)).toBe(`${categories[0]} - ${categories[1]}`);
-      expect(func([qualifiers[0]])).toBe(qualifiers[0]);
+      expect(func(qualifiers.map((item) => item.label))).toBe(
+        `${qualifiers[0].label} - ${qualifiers[1].label}`
+      );
+      expect(func(categories.map((item) => item.label))).toBe(
+        `${categories[0].label} - ${categories[1].label}`
+      );
+      expect(func([qualifiers[0].label])).toBe(qualifiers[0].label);
     });
   });
 
@@ -65,8 +80,8 @@ describe("Test Data Driven Tools", () => {
         categories,
         qualifiers,
       });
-      expect(dictionary?.[categories[0]]).toBe(categories[0]);
-      expect(dictionary?.[categories[1]]).toBe(categories[1]);
+      expect(dictionary?.[categories[0].label]).toBe(categories[0].label);
+      expect(dictionary?.[categories[1].label]).toBe(categories[1].label);
       expect(dictionary?.[SINGLE_CATEGORY]).toBe(PERFORMANCE_MEASURE);
     });
   });

--- a/services/ui-src/src/measures/2022/shared/globalValidations/dataDrivenTools.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/dataDrivenTools.ts
@@ -1,7 +1,7 @@
 import * as DC from "dataConstants";
 import * as Types from "measures/2022/shared/CommonQuestions/types";
 import { DataDrivenTypes as DDT } from "measures/2022/shared/CommonQuestions/types";
-import { cleanString } from "utils";
+import { LabelData, cleanString } from "utils";
 import { FormRateField as PM, RateData } from "./types";
 
 /**
@@ -18,7 +18,7 @@ export const getPerfMeasureRateArray = (
   if (renderData.categories?.length) {
     for (const cat of renderData.categories) {
       performanceMeasureData.push(
-        formData.PerformanceMeasure?.rates?.[cleanString(cat)] ?? []
+        formData.PerformanceMeasure?.rates?.[cat.id] ?? []
       );
     }
   } else if (renderData.qualifiers?.length) {
@@ -49,15 +49,15 @@ export const getOtherPerformanceMeasureRateArray = (
 
 /** Utility function for converting oms data to be the same as returned performance measure. Encourages shared validations. */
 export const convertOmsDataToRateArray = (
-  categories: string[],
-  qualifiers: string[],
+  categories: LabelData[],
+  qualifiers: LabelData[],
   rateData: RateData
 ) => {
   const rateArray: PM[][] = [];
 
-  for (const cat of categories.map((c) => cleanString(c))) {
+  for (const cat of categories.map((c) => c.id)) {
     const tempArr: PM[] = [];
-    for (const qual of qualifiers.map((q) => cleanString(q))) {
+    for (const qual of qualifiers.map((q) => q.id)) {
       tempArr.push(rateData.rates?.[qual]?.[cat]?.[0] ?? {});
     }
     rateArray.push(tempArr);
@@ -77,7 +77,7 @@ export const performanceMeasureErrorLocationDicitonary = (
   const errorDict: PMErrorDictionary = {};
 
   for (const cat of renderData?.categories ?? []) {
-    errorDict[cleanString(cat)] = cat;
+    errorDict[cat.id] = cat.label;
   }
 
   errorDict[DC.SINGLE_CATEGORY] = DC.PERFORMANCE_MEASURE;
@@ -90,8 +90,8 @@ export const performanceMeasureErrorLocationDicitonary = (
  */
 export const omsLocationDictionary = (
   renderData: DDT.OptionalMeasureStrat,
-  qualifiers?: string[],
-  categories?: string[]
+  qualifiers?: LabelData[],
+  categories?: LabelData[]
 ) => {
   const dictionary: { [cleanedLabel: string]: string } = {};
   const checkNode = (node: DDT.SingleOmsNode) => {
@@ -107,11 +107,11 @@ export const omsLocationDictionary = (
   }
 
   for (const qual of qualifiers ?? []) {
-    dictionary[cleanString(qual)] = qual;
+    dictionary[qual.id] = qual.label;
   }
 
   for (const cat of categories ?? []) {
-    dictionary[cleanString(cat)] = cat;
+    dictionary[cat.id] = cat.label;
   }
 
   return (labels: string[]) =>

--- a/services/ui-src/src/measures/2022/shared/globalValidations/omsValidator/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/omsValidator/index.test.ts
@@ -4,13 +4,23 @@ import {
   generateOmsQualifierRateData,
   simpleRate,
   generateOmsFormData,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
 import { DefaultFormData } from "measures/2022/shared/CommonQuestions/types";
 import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
 
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
+
 describe("Testing OMS validation processor", () => {
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
+  const categories = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+  ];
+  const qualifiers = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
 
   it("should have no errors for basic data", () => {
     const errors = omsValidations({

--- a/services/ui-src/src/measures/2022/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/omsValidator/index.ts
@@ -8,12 +8,12 @@ import {
   DefaultFormData,
 } from "measures/2022/shared/CommonQuestions/types";
 import { validatePartialRateCompletionOMS } from "../validatePartialRateCompletion";
-import { cleanString } from "utils";
+import { LabelData } from "utils";
 
 interface OmsValidationProps {
   data: DefaultFormData;
-  qualifiers: string[];
-  categories: string[];
+  qualifiers: LabelData[];
+  categories: LabelData[];
   locationDictionary: locationDictionaryFunction;
   checkIsFilled?: boolean;
   validationCallbacks: OmsValidationCallback[];
@@ -30,8 +30,8 @@ export const omsValidations = ({
   customTotalLabel,
   dataSource,
 }: OmsValidationProps) => {
-  const opmCats: string[] = ["OPM"];
-  const opmQuals: string[] = [];
+  const opmCats: LabelData[] = [{ id: "OPM", text: "OPM", label: "OPM" }];
+  const opmQuals: LabelData[] = [];
   let isOPM = false;
   if (
     data.MeasurementSpecification === "Other" &&
@@ -39,12 +39,25 @@ export const omsValidations = ({
   ) {
     isOPM = true;
     opmQuals.push(
-      ...data["OtherPerformanceMeasure-Rates"].map(
-        (rate) => rate.description ?? "Fill out description"
-      )
+      ...data["OtherPerformanceMeasure-Rates"].map((rate) => {
+        return {
+          id: rate.description ?? "Fill out description",
+          label: rate.description ?? "Fill out description",
+          text: "",
+        };
+      })
     );
   }
-  const cats = categories.length === 0 ? ["singleCategory"] : categories;
+  const cats =
+    categories.length === 0
+      ? [
+          {
+            id: "singleCategory",
+            label: "singleCategory",
+            text: "singleCategory",
+          },
+        ]
+      : categories;
   return validateNDRs(
     data,
     validationCallbacks,
@@ -61,8 +74,8 @@ export const omsValidations = ({
 const validateNDRs = (
   data: DefaultFormData,
   callbackArr: OmsValidationCallback[],
-  qualifiers: string[],
-  categories: string[],
+  qualifiers: LabelData[],
+  categories: LabelData[],
   locationDictionary: locationDictionaryFunction,
   checkIsFilled: boolean,
   isOPM: boolean,
@@ -200,8 +213,8 @@ const validateNDRs = (
     if (rateData?.["pcr-rate"]) {
       return rateData["pcr-rate"].every((o) => !!o?.value);
     }
-    for (const qual of qualifiers.map((s) => cleanString(s))) {
-      for (const cat of categories.map((s) => cleanString(s))) {
+    for (const qual of qualifiers.map((s) => s.id)) {
+      for (const cat of categories.map((s) => s.id)) {
         if (rateData.rates?.[qual]?.[cat]) {
           const temp = rateData.rates[qual][cat][0];
           if (temp && temp.denominator && temp.numerator && temp.rate) {
@@ -225,8 +238,8 @@ const validateNDRs = (
     }
 
     // default check
-    for (const qual of qualifiers.map((s) => cleanString(s))) {
-      for (const cat of categories.map((s) => cleanString(s))) {
+    for (const qual of qualifiers.map((s) => s.id)) {
+      for (const cat of categories.map((s) => s.id)) {
         if (rateData.rates?.[qual]?.[cat]) {
           const temp = rateData.rates[qual][cat][0];
           if (temp && temp.denominator && temp.numerator && temp.rate) {

--- a/services/ui-src/src/measures/2022/shared/globalValidations/types.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/types.ts
@@ -1,4 +1,5 @@
 import { OmsNodes as OMS } from "measures/2022/shared/CommonQuestions/types";
+import { LabelData } from "utils";
 
 export interface FormRateField {
   denominator?: string;
@@ -17,8 +18,8 @@ export interface RateData extends OMS.OmsRateFields {
 }
 
 export interface UnifiedValFuncProps {
-  categories?: string[];
-  qualifiers?: string[];
+  categories?: LabelData[];
+  qualifiers?: LabelData[];
   rateData: FormRateField[][];
   location: string;
   errorMessage?: string;
@@ -30,8 +31,8 @@ export type UnifiedValidationFunction = (
 
 export type OmsValidationCallback = (data: {
   rateData: RateData;
-  qualifiers: string[];
-  categories: string[];
+  qualifiers: LabelData[];
+  categories: LabelData[];
   label: string[];
   locationDictionary: locationDictionaryFunction;
   isOPM: boolean;

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateAtLeastOneDeviationFieldFilled/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateAtLeastOneDeviationFieldFilled/index.ts
@@ -1,11 +1,12 @@
 import * as Types from "measures/2022/shared/CommonQuestions/types";
 import { FormRateField } from "../types";
+import { LabelData } from "utils";
 
 // When a user inputs data in multiple NDR sets in a performance measure
 // Then the user must complete at least one NDR set in the Deviation of measure specification.
 export const validateAtLeastOneDeviationFieldFilled = (
   performanceMeasureArray: FormRateField[][],
-  ageGroups: string[],
+  ageGroups: LabelData[],
   deviationArray: Types.DeviationFields[] | any,
   didCalculationsDeviate: boolean,
   errorMessage?: string
@@ -54,9 +55,9 @@ export const validateAtLeastOneDeviationFieldFilled = (
           }
         } else {
           if (
-            deviationNDR.denominator ||
-            deviationNDR.numerator ||
-            deviationNDR.other
+            deviationNDR?.denominator ||
+            deviationNDR?.numerator ||
+            deviationNDR?.other
           ) {
             atLeastOneDevNDR = true;
           } else {

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateAtLeastOneRateComplete/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateAtLeastOneRateComplete/index.ts
@@ -1,11 +1,12 @@
+import { LabelData } from "utils";
 import { FormRateField } from "../types";
 import { validatePartialRateCompletionPM } from "../validatePartialRateCompletion";
 
 export const validateAtLeastOneRateComplete = (
   performanceMeasureArray: FormRateField[][],
   OPM: any,
-  qualifiers: string[],
-  categories?: string[],
+  qualifiers: LabelData[],
+  categories?: LabelData[],
   errorMessage?: string
 ) => {
   const errorArray: FormError[] = [];

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateDualPopInformation/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateDualPopInformation/index.test.ts
@@ -1,5 +1,8 @@
 import * as DC from "dataConstants";
-import { simpleRate, partialRate } from "utils/testUtils/validationHelpers";
+import {
+  simpleRate,
+  partialRate,
+} from "utils/testUtils/2023/validationHelpers";
 import { validateDualPopInformationPM } from ".";
 
 describe("Testing Dual Population Selection Validation", () => {

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateEqualCategoryDenominators/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateEqualCategoryDenominators/index.test.ts
@@ -1,3 +1,4 @@
+import { LabelData } from "utils";
 import {
   validateEqualCategoryDenominatorsOMS,
   validateEqualCategoryDenominatorsPM,
@@ -10,12 +11,22 @@ import {
   simpleRate,
   partialRate,
   generatePmQualifierRateData,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
+
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
 
 describe("Testing Equal Denominators For All Qualifiers Validation", () => {
-  const noCat: string[] = [];
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
+  const noCat: LabelData[] = [];
+  const categories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
   const pmd = { categories, qualifiers };
 
   const baseOMSInfo = {
@@ -49,8 +60,8 @@ describe("Testing Equal Denominators For All Qualifiers Validation", () => {
       expect(errors[0].errorMessage).toBe(
         `The following categories must have the same denominator:`
       );
-      expect(errors[0].errorList).toContain(categories[0]);
-      expect(errors[0].errorList).toContain(categories[1]);
+      expect(errors[0].errorList).toContain(categories[0].label);
+      expect(errors[0].errorList).toContain(categories[1].label);
     });
 
     it("should have error, with qualifiers listed", () => {
@@ -69,8 +80,8 @@ describe("Testing Equal Denominators For All Qualifiers Validation", () => {
       expect(errors[0].errorMessage).toBe(
         `The following categories must have the same denominator:`
       );
-      expect(errors[0].errorList).toContain(qualifiers[0]);
-      expect(errors[0].errorList).toContain(qualifiers[1]);
+      expect(errors[0].errorList).toContain(qualifiers[0].label);
+      expect(errors[0].errorList).toContain(qualifiers[1].label);
     });
 
     it("should NOT have error from empty rate value", () => {
@@ -146,8 +157,8 @@ describe("Testing Equal Denominators For All Qualifiers Validation", () => {
       expect(errors[0].errorMessage).toBe(
         `The following categories must have the same denominator:`
       );
-      expect(errors[0].errorList).toContain(categories[0]);
-      expect(errors[0].errorList).toContain(categories[1]);
+      expect(errors[0].errorList).toContain(categories[0].label);
+      expect(errors[0].errorList).toContain(categories[1].label);
       expect(locationDictionaryJestFunc).toHaveBeenCalledWith(["TestLabel"]);
     });
   });

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateEqualCategoryDenominators/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateEqualCategoryDenominators/index.ts
@@ -8,6 +8,7 @@ import {
   getPerfMeasureRateArray,
 } from "../dataDrivenTools";
 import { SINGLE_CATEGORY } from "dataConstants";
+import { LabelData } from "utils";
 
 const _validation: UVF = ({
   rateData,
@@ -25,9 +26,9 @@ const _validation: UVF = ({
       if (rate && rate.denominator) {
         denominatorArray.push(rate.denominator);
         locationArray.push(
-          !!categories?.length && categories[0] !== SINGLE_CATEGORY
-            ? categories![i]
-            : qualifiers![j]
+          !!categories?.length && categories[0].label !== SINGLE_CATEGORY
+            ? categories![i].label
+            : qualifiers![j].label
         );
       }
     }
@@ -63,8 +64,8 @@ export const validateEqualCategoryDenominatorsOMS =
 /** Checks all rates have the same denominator for both categories and qualifiers. NOTE: only pass qualifiers if category is empty */
 export const validateEqualCategoryDenominatorsPM = (
   data: Types.PerformanceMeasure,
-  categories: string[],
-  qualifiers?: string[],
+  categories: LabelData[],
+  qualifiers?: LabelData[],
   errorMessage?: string
 ) => {
   return _validation({

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateEqualQualifierDenominators/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateEqualQualifierDenominators/index.test.ts
@@ -1,3 +1,4 @@
+import { LabelData } from "utils";
 import {
   validateEqualQualifierDenominatorsOMS,
   validateEqualQualifierDenominatorsPM,
@@ -9,11 +10,21 @@ import {
   doubleRate,
   simpleRate,
   partialRate,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
+
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
 
 describe("Testing Equal Qualifier Denominators Across Category Validation", () => {
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
+  const categories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
 
   const baseOMSInfo = {
     categories,
@@ -46,7 +57,7 @@ describe("Testing Equal Qualifier Denominators Across Category Validation", () =
       expect(errors).toHaveLength(2);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `Denominators must be the same for each category of performance measures for ${qualifiers[0]}`
+        `Denominators must be the same for each category of performance measures for ${qualifiers[0].label}`
       );
     });
 
@@ -93,8 +104,12 @@ describe("Testing Equal Qualifier Denominators Across Category Validation", () =
       );
 
       expect(errorArray).toHaveLength(2);
-      expect(errorArray[0].errorMessage).toBe(errorMessageFunc(qualifiers[0]));
-      expect(errorArray[1].errorMessage).toBe(errorMessageFunc(qualifiers[1]));
+      expect(errorArray[0].errorMessage).toBe(
+        errorMessageFunc(qualifiers[0].label)
+      );
+      expect(errorArray[1].errorMessage).toBe(
+        errorMessageFunc(qualifiers[1].label)
+      );
     });
   });
 
@@ -145,7 +160,7 @@ describe("Testing Equal Qualifier Denominators Across Category Validation", () =
       );
       expect(locationDictionaryJestFunc).toHaveBeenCalledWith([
         "TestLabel",
-        qualifiers[0],
+        qualifiers[0].label,
       ]);
     });
   });

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateEqualQualifierDenominators/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateEqualQualifierDenominators/index.ts
@@ -4,6 +4,7 @@ import {
   UnifiedValFuncProps as UVFP,
 } from "../types";
 import { convertOmsDataToRateArray } from "../dataDrivenTools";
+import { LabelData } from "utils";
 
 interface ValProps extends UVFP {
   locationFunc?: (qualifier: string) => string;
@@ -35,8 +36,8 @@ const _validation = ({
     const error = !denominators.every((v) => !v || v === denominators[0]);
     if (error) {
       errorArray.push({
-        errorLocation: locationFunc ? locationFunc(qual) : location,
-        errorMessage: errorMessage ?? errorMessageFunc(qual),
+        errorLocation: locationFunc ? locationFunc(qual.label) : location,
+        errorMessage: errorMessage ?? errorMessageFunc(qual.label),
       });
     }
   }
@@ -70,7 +71,7 @@ export const validateEqualQualifierDenominatorsOMS =
  */
 export const validateEqualQualifierDenominatorsPM = (
   performanceMeasureArray: FormRateField[][],
-  qualifiers: string[],
+  qualifiers: LabelData[],
   errorMessage?: string,
   errorMessageFunc?: (qualifier: string) => string
 ) => {

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateNoNonZeroNumOrDenom/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateNoNonZeroNumOrDenom/index.ts
@@ -9,6 +9,7 @@ import {
   convertOmsDataToRateArray,
   getOtherPerformanceMeasureRateArray,
 } from "../dataDrivenTools";
+import { LabelData } from "utils";
 
 interface ValProps extends UVFP {
   hybridData?: boolean;
@@ -107,7 +108,7 @@ export const validateRateNotZeroOMS: OmsValidationCallback = ({
 export const validateNoNonZeroNumOrDenomPM = (
   performanceMeasureArray: FormRateField[][],
   OPM: any,
-  _qualifiers: string[],
+  _qualifiers: LabelData[],
   data: Types.DefaultFormData
 ) => {
   const errorArray: FormError[] = [];

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateNumeratorsLessThanDenominators/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateNumeratorsLessThanDenominators/index.test.ts
@@ -1,3 +1,4 @@
+import { LabelData } from "utils";
 import {
   validateNumeratorLessThanDenominatorOMS,
   validateNumeratorsLessThanDenominatorsPM,
@@ -10,11 +11,21 @@ import {
   simpleRate,
   partialRate,
   generateOtherPerformanceMeasureData,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
+
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
 
 describe("Testing Numerator Less Than Denominator", () => {
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
+  const categories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
 
   const baseOMSInfo = {
     categories,
@@ -138,12 +149,17 @@ describe("Testing Numerator Less Than Denominator", () => {
       );
       expect(locationDictionaryJestFunc).toHaveBeenCalledWith([
         "TestLabel",
-        qualifiers[0],
+        qualifiers[0].label,
       ]);
     });
   });
 
   it("Error message text should match provided errorMessage", () => {
+    const utils = require("utils/getLabelText");
+    jest.spyOn(utils, "isLegacyLabel").mockImplementation(() => {
+      return true;
+    });
+
     const errorMessage = "Another one bites the dust.";
     const locationDictionaryJestFunc = jest.fn();
     const data = generateOmsCategoryRateData(categories, qualifiers, [
@@ -162,7 +178,7 @@ describe("Testing Numerator Less Than Denominator", () => {
     );
     expect(locationDictionaryJestFunc).toHaveBeenCalledWith([
       "TestLabel",
-      qualifiers[0],
+      qualifiers[0].label,
     ]);
     expect(errors[0].errorMessage).toBe(errorMessage);
   });

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateNumeratorsLessThanDenominators/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateNumeratorsLessThanDenominators/index.ts
@@ -7,6 +7,7 @@ import {
   convertOmsDataToRateArray,
   getOtherPerformanceMeasureRateArray,
 } from "../dataDrivenTools";
+import { LabelData } from "utils";
 
 interface ValProps extends UVFP {
   locationFunc?: (qualifier: string) => string;
@@ -29,7 +30,9 @@ const _validation = ({
         parseFloat(rate.denominator) < parseFloat(rate.numerator)
       ) {
         errorArray.push({
-          errorLocation: locationFunc ? locationFunc(qualifiers![i]) : location,
+          errorLocation: locationFunc
+            ? locationFunc(qualifiers![i].label)
+            : location,
           errorMessage: errorMessage!,
         });
       }
@@ -64,7 +67,7 @@ export const validateNumeratorLessThanDenominatorOMS =
 export const validateNumeratorsLessThanDenominatorsPM = (
   performanceMeasureArray: FormRateField[][],
   OPM: any,
-  qualifiers: string[],
+  qualifiers: LabelData[],
   errorMessage?: string
 ) => {
   const location = `Performance Measure/Other Performance Measure`;

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateOneCatRateHigherThanOtherCat/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateOneCatRateHigherThanOtherCat/index.test.ts
@@ -1,3 +1,4 @@
+import { LabelData } from "utils";
 import {
   validateOneCatRateHigherThanOtherCatOMS,
   validateOneCatRateHigherThanOtherCatPM,
@@ -10,17 +11,27 @@ import {
   higherRate,
   lowerRate,
   partialRate,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
+
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
 
 describe("Testing Category Rate Higher Than Other Validation", () => {
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const expandedCategories = [
-    "Test Cat 1",
-    "Test Cat 2",
-    "Test Cat 3",
-    "Test Cat 4",
+  const categories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
   ];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
+  const expandedCategories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+    { id: "Test Cat 3", label: "Test Cat 3", text: "Test Cat 3" },
+    { id: "Test Cat 4", label: "Test Cat 4", text: "Test Cat 4" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
 
   const baseOMSInfo = {
     categories,
@@ -58,7 +69,7 @@ describe("Testing Category Rate Higher Than Other Validation", () => {
       expect(errors).toHaveLength(2);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `${categories[1]} Rate should not be higher than ${categories[0]} Rate for ${qualifiers[0]} Rates.`
+        `${categories[1].label} Rate should not be higher than ${categories[0].label} Rate for ${qualifiers[0].label} Rates.`
       );
     });
 
@@ -94,7 +105,7 @@ describe("Testing Category Rate Higher Than Other Validation", () => {
       expect(errors).toHaveLength(4);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `${categories[1]} Rate should not be higher than ${categories[0]} Rate for ${qualifiers[0]} Rates.`
+        `${categories[1].label} Rate should not be higher than ${categories[0].label} Rate for ${qualifiers[0].label} Rates.`
       );
     });
 
@@ -126,7 +137,11 @@ describe("Testing Category Rate Higher Than Other Validation", () => {
       expect(errors).toHaveLength(4);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        errorMessageFunc(categories[0], categories[1], qualifiers[0])
+        errorMessageFunc(
+          categories[0].label,
+          categories[1].label,
+          qualifiers[0].label
+        )
       );
     });
   });
@@ -167,7 +182,7 @@ describe("Testing Category Rate Higher Than Other Validation", () => {
 
       expect(errors).toHaveLength(2);
       expect(errors[0].errorMessage).toBe(
-        `${categories[1]} Rate should not be higher than ${categories[0]} Rates.`
+        `${categories[1].label} Rate should not be higher than ${categories[0].label} Rates.`
       );
     });
 
@@ -190,7 +205,7 @@ describe("Testing Category Rate Higher Than Other Validation", () => {
 
       expect(errors).toHaveLength(4);
       expect(errors[0].errorMessage).toBe(
-        `${categories[1]} Rate should not be higher than ${categories[0]} Rates.`
+        `${categories[1].label} Rate should not be higher than ${categories[0].label} Rates.`
       );
     });
   });
@@ -215,7 +230,7 @@ describe("Testing Category Rate Higher Than Other Validation", () => {
 
     expect(errors).toHaveLength(2);
     expect(errors[0].errorMessage).toBe(
-      errorMessageFunc(categories[0], categories[1])
+      errorMessageFunc(categories[0].label, categories[1].label)
     );
   });
 });

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateOneCatRateHigherThanOtherCat/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateOneCatRateHigherThanOtherCat/index.ts
@@ -39,11 +39,13 @@ const _validation = ({
     if (lrate && hrate) {
       if (parseFloat(lrate) > parseFloat(hrate)) {
         errorArray.push({
-          errorLocation: locationFunc ? locationFunc(qualifiers![i]) : location,
+          errorLocation: locationFunc
+            ? locationFunc(qualifiers![i].label)
+            : location,
           errorMessage: errorMessageFunc(
-            categories![higherIndex],
-            categories![lowerIndex],
-            qualifiers![i]
+            categories![higherIndex].label,
+            categories![lowerIndex].label,
+            qualifiers![i].label
           ),
         });
       }

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualDenomHigherThanOtherDenomOMS/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualDenomHigherThanOtherDenomOMS/index.test.ts
@@ -11,13 +11,30 @@ import {
   doubleRate,
   simpleRate,
   partialRate,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
+import { LabelData } from "utils";
+
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
 
 describe("Testing Qualifier Denominator Higher Than Other Validation", () => {
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
-  const singleCat = [SINGLE_CATEGORY];
-  const noCat: string[] = [];
+  const categories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
+  const singleCat: LabelData[] = [
+    {
+      label: SINGLE_CATEGORY,
+      text: SINGLE_CATEGORY,
+      id: SINGLE_CATEGORY,
+    },
+  ];
+  const noCat: LabelData[] = [];
 
   const baseOMSInfo = {
     categories,
@@ -55,7 +72,7 @@ describe("Testing Qualifier Denominator Higher Than Other Validation", () => {
       expect(errors).toHaveLength(2);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `${qualifiers[1]} denominator must be less than or equal to ${qualifiers[0]} denominator.`
+        `${qualifiers[1].label} denominator must be less than or equal to ${qualifiers[0].label} denominator.`
       );
     });
 
@@ -72,7 +89,7 @@ describe("Testing Qualifier Denominator Higher Than Other Validation", () => {
       expect(errors).toHaveLength(1);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `${qualifiers[1]} denominator must be less than or equal to ${qualifiers[0]} denominator.`
+        `${qualifiers[1].label} denominator must be less than or equal to ${qualifiers[0].label} denominator.`
       );
     });
 
@@ -112,7 +129,7 @@ describe("Testing Qualifier Denominator Higher Than Other Validation", () => {
       expect(errors).toHaveLength(1);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        errorMessageFunc(qualifiers[1], qualifiers[0])
+        errorMessageFunc(qualifiers[1].label, qualifiers[0].label)
       );
     });
   });
@@ -154,7 +171,7 @@ describe("Testing Qualifier Denominator Higher Than Other Validation", () => {
 
       expect(errors).toHaveLength(1);
       expect(errors[0].errorMessage).toBe(
-        `${qualifiers?.[1]} denominator must be less than or equal to ${qualifiers?.[0]} denominator.`
+        `${qualifiers?.[1].label} denominator must be less than or equal to ${qualifiers?.[0].label} denominator.`
       );
     });
   });
@@ -179,7 +196,7 @@ describe("Testing Qualifier Denominator Higher Than Other Validation", () => {
 
     expect(errors).toHaveLength(1);
     expect(errors[0].errorMessage).toBe(
-      errorMessageFunc(qualifiers?.[1], qualifiers?.[0])
+      errorMessageFunc(qualifiers?.[1].label, qualifiers?.[0].label)
     );
   });
 });

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualDenomHigherThanOtherDenomOMS/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualDenomHigherThanOtherDenomOMS/index.ts
@@ -47,8 +47,8 @@ const _validation = ({
         errorArray.push({
           errorLocation: location,
           errorMessage: errorMessageFunc(
-            qualifiers?.[lowerIndex]!,
-            qualifiers?.[higherIndex]!
+            qualifiers?.[lowerIndex]?.label!,
+            qualifiers?.[higherIndex]?.label!
           ),
         });
       }

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualRateHigherThanOtherQual/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualRateHigherThanOtherQual/index.test.ts
@@ -11,13 +11,26 @@ import {
   higherRate,
   lowerRate,
   partialRate,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
+import { LabelData } from "utils";
 
 describe("Testing Qualifier Rate Higher Than Other Validation", () => {
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
-  const singleCat = [SINGLE_CATEGORY];
-  const noCat: string[] = [];
+  const categories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
+  const singleCat: LabelData[] = [
+    {
+      label: SINGLE_CATEGORY,
+      text: SINGLE_CATEGORY,
+      id: SINGLE_CATEGORY,
+    },
+  ];
+  const noCat: LabelData[] = [];
 
   const baseOMSInfo = {
     categories,
@@ -55,7 +68,7 @@ describe("Testing Qualifier Rate Higher Than Other Validation", () => {
       expect(errors).toHaveLength(2);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `${qualifiers[1]} rate must be less than or equal to ${qualifiers[0]} rate within ${categories[0]}.`
+        `${qualifiers[1]} rate must be less than or equal to ${qualifiers[0].label} rate within ${categories[0].label}.`
       );
     });
 
@@ -72,7 +85,7 @@ describe("Testing Qualifier Rate Higher Than Other Validation", () => {
       expect(errors).toHaveLength(1);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `${qualifiers[1]} rate must be less than or equal to ${qualifiers[0]} rate.`
+        `${qualifiers[1]} rate must be less than or equal to ${qualifiers[0].label} rate.`
       );
     });
 
@@ -117,7 +130,12 @@ describe("Testing Qualifier Rate Higher Than Other Validation", () => {
       expect(errors).toHaveLength(2);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        errorMessageFunc(qualifiers[1], qualifiers[0], false, categories[0])
+        errorMessageFunc(
+          qualifiers[1].label,
+          qualifiers[0].label,
+          false,
+          categories[0].label
+        )
       );
     });
   });
@@ -159,7 +177,7 @@ describe("Testing Qualifier Rate Higher Than Other Validation", () => {
 
       expect(errors).toHaveLength(1);
       expect(errors[0].errorMessage).toBe(
-        `${qualifiers?.[1]} rate must be less than or equal to ${qualifiers?.[0]} rate.`
+        `${qualifiers?.[1].label} rate must be less than or equal to ${qualifiers?.[0].label} rate.`
       );
     });
   });
@@ -190,7 +208,12 @@ describe("Testing Qualifier Rate Higher Than Other Validation", () => {
 
     expect(errors).toHaveLength(1);
     expect(errors[0].errorMessage).toBe(
-      errorMessageFunc(qualifiers[1], qualifiers[0], false, singleCat[0])
+      errorMessageFunc(
+        qualifiers[1].label,
+        qualifiers[0].label,
+        false,
+        singleCat[0].label
+      )
     );
   });
 });

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualRateHigherThanOtherQual/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualRateHigherThanOtherQual/index.test.ts
@@ -14,6 +14,10 @@ import {
 } from "utils/testUtils/2023/validationHelpers";
 import { LabelData } from "utils";
 
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
+
 describe("Testing Qualifier Rate Higher Than Other Validation", () => {
   const categories: LabelData[] = [
     { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
@@ -68,7 +72,7 @@ describe("Testing Qualifier Rate Higher Than Other Validation", () => {
       expect(errors).toHaveLength(2);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `${qualifiers[1]} rate must be less than or equal to ${qualifiers[0].label} rate within ${categories[0].label}.`
+        `${qualifiers[1].label} rate must be less than or equal to ${qualifiers[0].label} rate within ${categories[0].label}.`
       );
     });
 
@@ -85,7 +89,7 @@ describe("Testing Qualifier Rate Higher Than Other Validation", () => {
       expect(errors).toHaveLength(1);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `${qualifiers[1]} rate must be less than or equal to ${qualifiers[0].label} rate.`
+        `${qualifiers[1].label} rate must be less than or equal to ${qualifiers[0].label} rate.`
       );
     });
 

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualRateHigherThanOtherQual/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateOneQualRateHigherThanOtherQual/index.ts
@@ -48,16 +48,16 @@ const _validation = ({
         parseFloat(ratefields[higherIndex]?.rate ?? "")
     ) {
       const notSingleCategory: boolean =
-        categories?.length && categories[0] !== DC.SINGLE_CATEGORY
+        categories?.length && categories[0].label !== DC.SINGLE_CATEGORY
           ? true
           : false;
       errorArray.push({
         errorLocation: location,
         errorMessage: errorMessageFunc(
-          qualifiers?.[lowerIndex]!,
-          qualifiers?.[higherIndex]!,
+          qualifiers?.[lowerIndex]?.label!,
+          qualifiers?.[higherIndex]?.label!,
           notSingleCategory,
-          categories?.[i]!
+          categories?.[i]?.label!
         ),
       });
     }

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validatePartialRateCompletion/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validatePartialRateCompletion/index.test.ts
@@ -9,11 +9,27 @@ import {
   locationDictionary,
   simpleRate,
   partialRate,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
+import { LabelData } from "utils";
+
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
 
 describe("Testing Partial Rate Validation", () => {
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
+  const categories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
+  const singleCategory: LabelData = {
+    label: SINGLE_CATEGORY,
+    text: SINGLE_CATEGORY,
+    id: SINGLE_CATEGORY,
+  };
 
   const baseOMSInfo = {
     categories,
@@ -61,7 +77,7 @@ describe("Testing Partial Rate Validation", () => {
       expect(errors).toHaveLength(4);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        `Should not have partially filled NDR sets${` for ${qualifiers[0]}`}${`, ${categories[0]}`}.`
+        `Should not have partially filled NDR sets${` for ${qualifiers[0].label}`}${`, ${categories[0].label}`}.`
       );
     });
 
@@ -104,7 +120,7 @@ describe("Testing Partial Rate Validation", () => {
       expect(errors).toHaveLength(4);
       expect(errors[0].errorLocation).toBe("Performance Measure");
       expect(errors[0].errorMessage).toBe(
-        errorMessageFunc(true, qualifiers[0], true, categories[0])
+        errorMessageFunc(true, qualifiers[0].label, true, categories[0].label)
       );
     });
   });
@@ -155,21 +171,21 @@ describe("Testing Partial Rate Validation", () => {
         "Optional Measure Stratification:"
       );
       expect(errors[0].errorMessage).toBe(
-        `Should not have partially filled NDR sets${` for ${qualifiers[0]}`}${`, ${categories[0]}`}.`
+        `Should not have partially filled NDR sets${` for ${qualifiers[0].label}`}${`, ${categories[0].label}`}.`
       );
       expect(locationDictionaryJestFunc).toHaveBeenCalledWith(["TestLabel"]);
     });
 
     it("should have errors - singleCategory", () => {
       const locationDictionaryJestFunc = jest.fn();
-      const data = generateOmsCategoryRateData([SINGLE_CATEGORY], qualifiers, [
+      const data = generateOmsCategoryRateData([singleCategory], qualifiers, [
         partialRate,
       ]);
       const errors = validatePartialRateCompletionOMS()({
         ...baseOMSInfo,
         locationDictionary: locationDictionaryJestFunc,
         rateData: data,
-        categories: [SINGLE_CATEGORY],
+        categories: [singleCategory],
       });
 
       expect(errors).toHaveLength(2);
@@ -177,7 +193,7 @@ describe("Testing Partial Rate Validation", () => {
         "Optional Measure Stratification:"
       );
       expect(errors[0].errorMessage).toBe(
-        `Should not have partially filled NDR sets${` for ${qualifiers[0]}`}.`
+        `Should not have partially filled NDR sets${` for ${qualifiers[0].label}`}.`
       );
       expect(locationDictionaryJestFunc).toHaveBeenCalledWith(["TestLabel"]);
     });
@@ -236,7 +252,7 @@ describe("Testing Partial Rate Validation", () => {
     );
     expect(locationDictionaryJestFunc).toHaveBeenCalledWith(["TestLabel"]);
     expect(errors[0].errorMessage).toBe(
-      errorMessageFunc(true, qualifiers[0], true, categories[0])
+      errorMessageFunc(true, qualifiers[0].label, true, categories[0].label)
     );
   });
 });

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validatePartialRateCompletion/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validatePartialRateCompletion/index.ts
@@ -8,6 +8,7 @@ import {
   FormRateField,
   OmsValidationCallback,
 } from "../types";
+import { LabelData } from "utils";
 
 type ErrorMessageFunc = (
   multipleQuals: boolean,
@@ -53,9 +54,9 @@ const _validation = ({
           errorLocation: location,
           errorMessage: errorMessageFunc(
             multipleQuals,
-            qualifiers?.[j]!,
+            qualifiers?.[j]?.label!,
             multipleCats,
-            categories?.[i]!
+            categories?.[i]?.label!
           ),
         });
       }
@@ -68,8 +69,8 @@ const _validation = ({
 interface SVVProps {
   location: string;
   rateData: any;
-  categories?: string[];
-  qualifiers?: string[];
+  categories?: LabelData[];
+  qualifiers?: LabelData[];
   locationDictionary: (s: string[]) => string;
   errorMessageFunc?: ErrorMessageFunc;
 }
@@ -128,7 +129,7 @@ export const validatePartialRateCompletionOMS =
               ...label,
             ])}`,
             rateData: rateData?.[singleValueFieldFlag],
-            categories: !!(isOPM || categories[0] === SINGLE_CATEGORY)
+            categories: !!(isOPM || categories[0].label === SINGLE_CATEGORY)
               ? undefined
               : categories,
             qualifiers: !!isOPM ? undefined : qualifiers,
@@ -144,7 +145,7 @@ export const validatePartialRateCompletionOMS =
               qualifiers,
               rateData
             ),
-            categories: !!(isOPM || categories[0] === SINGLE_CATEGORY)
+            categories: !!(isOPM || categories[0].label === SINGLE_CATEGORY)
               ? undefined
               : categories,
             qualifiers: !!isOPM ? undefined : qualifiers,
@@ -164,8 +165,8 @@ export const validatePartialRateCompletionOMS =
 export const validatePartialRateCompletionPM = (
   performanceMeasureArray: FormRateField[][],
   OPM: any,
-  qualifiers: string[],
-  categories?: string[],
+  qualifiers: LabelData[],
+  categories?: LabelData[],
   errorMessageFunc?: ErrorMessageFunc
 ) => {
   return [

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateRateNotZero/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateRateNotZero/index.test.ts
@@ -1,3 +1,4 @@
+import { LabelData } from "utils";
 import { validateRateNotZeroOMS, validateRateNotZeroPM } from ".";
 import {
   generateOmsQualifierRateData,
@@ -7,11 +8,21 @@ import {
   simpleRate,
   partialRate,
   generateOtherPerformanceMeasureData,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
+
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
 
 describe("Testing Non-Zero/No Zero Numerator/Rate Validation", () => {
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
+  const categories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
 
   const baseOMSInfo = {
     categories,

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateRateNotZero/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateRateNotZero/index.ts
@@ -7,6 +7,7 @@ import {
   convertOmsDataToRateArray,
   getOtherPerformanceMeasureRateArray,
 } from "../dataDrivenTools";
+import { LabelData } from "utils";
 
 export const validationRateNotZero = ({
   location,
@@ -54,7 +55,7 @@ export const validateRateNotZeroOMS =
 export const validateRateNotZeroPM = (
   performanceMeasureArray: FormRateField[][],
   OPM: any,
-  _qualifiers: string[],
+  _qualifiers: LabelData[],
   errorMessage?: string
 ) => {
   const errorArray: FormError[] = [];

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateRateZero/index.test.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateRateZero/index.test.ts
@@ -10,11 +10,22 @@ import {
   simpleRate,
   partialRate,
   generateOtherPerformanceMeasureData,
-} from "utils/testUtils/validationHelpers";
+} from "utils/testUtils/2023/validationHelpers";
+import { LabelData } from "utils";
+
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
 
 describe("Testing Non-Zero/No Zero Numerator/Rate Validation", () => {
-  const categories = ["Test Cat 1", "Test Cat 2"];
-  const qualifiers = ["Test Qual 1", "Test Qual 2"];
+  const categories: LabelData[] = [
+    { id: "Test Cat 1", label: "Test Cat 1", text: "Test Cat 1" },
+    { id: "Test Cat 2", label: "Test Cat 2", text: "Test Cat 2" },
+  ];
+  const qualifiers: LabelData[] = [
+    { id: "Test Qual 1", label: "Test Qual 1", text: "Test Qual 1" },
+    { id: "Test Qual 2", label: "Test Qual 2", text: "Test Qual 2" },
+  ];
 
   const baseOMSInfo = {
     categories,

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateRateZero/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateRateZero/index.ts
@@ -9,6 +9,7 @@ import {
   convertOmsDataToRateArray,
   getOtherPerformanceMeasureRateArray,
 } from "../dataDrivenTools";
+import { LabelData } from "utils";
 
 interface ValProps extends UVFP {
   hybridData?: boolean;
@@ -73,7 +74,7 @@ export const validateRateZeroOMS =
 export const validateRateZeroPM = (
   performanceMeasureArray: FormRateField[][],
   OPM: any,
-  _qualifiers: string[],
+  _qualifiers: LabelData[],
   data: Types.DefaultFormData,
   errorMessage?: string
 ): FormError[] => {

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateTotals/index.test.tsx
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateTotals/index.test.tsx
@@ -1,6 +1,11 @@
+import { LabelData } from "utils";
 import { validateTotalNDR, validateOMSTotalNDR } from ".";
 
-import * as VH from "utils/testUtils/validationHelpers";
+import * as VH from "utils/testUtils/2023/validationHelpers";
+
+jest.mock("utils/getLabelText", () => ({
+  isLegacyLabel: () => true,
+}));
 
 describe("Testing PM/OMS Total Validations", () => {
   describe("PM validation", () => {
@@ -109,9 +114,19 @@ describe("Testing PM/OMS Total Validations", () => {
 
   describe("OMS validation", () => {
     const label = ["TestLabel"];
-    const noCategories = ["singleCategory"];
-    const categories = ["test1", "test2", "test3"];
-    const qualifiers = ["test1", "test2", "testTotal"];
+    const noCategories: LabelData[] = [
+      { id: "singleCategory", label: "singleCategory", text: "singleCategory" },
+    ];
+    const categories: LabelData[] = [
+      { id: "test1", label: "test1", text: "test1" },
+      { id: "test2", label: "test2", text: "test2" },
+      { id: "test3", label: "test3", text: "test3" },
+    ];
+    const qualifiers: LabelData[] = [
+      { id: "test1", label: "test1", text: "test1" },
+      { id: "test2", label: "test2", text: "test2" },
+      { id: "testTotal", label: "testTotal", text: "testTotal" },
+    ];
 
     const locationDictionary = (s: string[]) => {
       return s[0];

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateTotals/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateTotals/index.ts
@@ -143,7 +143,7 @@ export const validateTotalNDR = (
         !isNaN(parsedNum)
       ) {
         const qualifier: string =
-          (categories && categories[idx].label) || totalNDR.label;
+          (categories && categories[idx]?.label) || totalNDR.label;
         errorArray.push({
           errorLocation: errorLocation,
           errorMessage: errorMessageFunc(qualifier, "Numerator"),
@@ -155,7 +155,7 @@ export const validateTotalNDR = (
         !isNaN(parsedDen)
       ) {
         const qualifier: string =
-          (categories && categories[idx].label) || totalNDR.label;
+          (categories && categories[idx]?.label) || totalNDR.label;
         errorArray.push({
           errorLocation: errorLocation,
           errorMessage: errorMessageFunc(qualifier, "Denominator"),
@@ -164,7 +164,7 @@ export const validateTotalNDR = (
     } else if (numeratorSum && denominatorSum) {
       const fieldLabel: string =
         (categories &&
-          categories[idx].label &&
+          categories[idx]?.label &&
           `${categories[idx].label} - ${totalNDR.label}`) ||
         totalNDR.label;
       errorArray.push({

--- a/services/ui-src/src/measures/2022/shared/globalValidations/validateTotals/index.ts
+++ b/services/ui-src/src/measures/2022/shared/globalValidations/validateTotals/index.ts
@@ -1,5 +1,5 @@
 import { OmsValidationCallback, FormRateField } from "../types";
-import { cleanString } from "utils";
+import { LabelData } from "utils";
 
 const validateOMSTotalNDRErrorMessage = (
   fieldType: string,
@@ -30,11 +30,11 @@ export const validateOMSTotalNDR =
 
     const error: FormError[] = [];
 
-    for (const cat of categories.map((s) => cleanString(s))) {
+    for (const cat of categories.map((s) => s.id)) {
       const ndrSets = [];
       let numeratorSum: any = null; // initialized as a non-zero value to accurately compare
       let denominatorSum: any = null;
-      for (const qual of qualifiers.map((s) => cleanString(s))) {
+      for (const qual of qualifiers.map((s) => s.id)) {
         ndrSets.push(rateData.rates?.[qual]?.[cat]?.[0]);
       }
 
@@ -58,7 +58,7 @@ export const validateOMSTotalNDR =
         ) {
           error.push({
             errorLocation: `Optional Measure Stratification: ${locationDictionary(
-              [...label, qualifiers.slice(-1)[0]]
+              [...label, qualifiers.slice(-1)[0].label]
             )}`,
             errorMessage: errorMessageFunc("numerator", customTotalLabel),
           });
@@ -70,7 +70,7 @@ export const validateOMSTotalNDR =
         ) {
           error.push({
             errorLocation: `Optional Measure Stratification: ${locationDictionary(
-              [...label, qualifiers.slice(-1)[0]]
+              [...label, qualifiers.slice(-1)[0].label]
             )}`,
             errorMessage: errorMessageFunc("denominator", customTotalLabel),
           });
@@ -78,7 +78,7 @@ export const validateOMSTotalNDR =
       } else if (numeratorSum && denominatorSum) {
         error.push({
           errorLocation: `Optional Measure Stratification: ${locationDictionary(
-            [...label, qualifiers.slice(-1)[0]]
+            [...label, qualifiers.slice(-1)[0].label]
           )}`,
           errorMessage: errorMessageFunc("Total", customTotalLabel),
         });
@@ -105,7 +105,7 @@ Default assumption is that this is run for Performance Measure unless specified.
 export const validateTotalNDR = (
   performanceMeasureArray: FormRateField[][],
   errorLocation = "Performance Measure",
-  categories?: string[],
+  categories?: LabelData[],
   errorMessageFunc = validateTotalNDRErrorMessage
 ): FormError[] => {
   let errorArray: FormError[] = [];
@@ -143,7 +143,7 @@ export const validateTotalNDR = (
         !isNaN(parsedNum)
       ) {
         const qualifier: string =
-          (categories && categories[idx]) || totalNDR.label;
+          (categories && categories[idx].label) || totalNDR.label;
         errorArray.push({
           errorLocation: errorLocation,
           errorMessage: errorMessageFunc(qualifier, "Numerator"),
@@ -155,7 +155,7 @@ export const validateTotalNDR = (
         !isNaN(parsedDen)
       ) {
         const qualifier: string =
-          (categories && categories[idx]) || totalNDR.label;
+          (categories && categories[idx].label) || totalNDR.label;
         errorArray.push({
           errorLocation: errorLocation,
           errorMessage: errorMessageFunc(qualifier, "Denominator"),
@@ -164,8 +164,8 @@ export const validateTotalNDR = (
     } else if (numeratorSum && denominatorSum) {
       const fieldLabel: string =
         (categories &&
-          categories[idx] &&
-          `${categories[idx]} - ${totalNDR.label}`) ||
+          categories[idx].label &&
+          `${categories[idx].label} - ${totalNDR.label}`) ||
         totalNDR.label;
       errorArray.push({
         errorLocation: errorLocation,

--- a/services/ui-src/src/measures/2023/shared/globalValidations/validateDualPopInformation/index.test.ts
+++ b/services/ui-src/src/measures/2023/shared/globalValidations/validateDualPopInformation/index.test.ts
@@ -1,5 +1,8 @@
 import * as DC from "dataConstants";
-import { simpleRate, partialRate } from "utils/testUtils/validationHelpers";
+import {
+  simpleRate,
+  partialRate,
+} from "utils/testUtils/2023/validationHelpers";
 import { validateDualPopInformationPM } from ".";
 
 describe("Testing Dual Population Selection Validation", () => {

--- a/services/ui-src/src/measures/2024/CPCCH/index.test.tsx
+++ b/services/ui-src/src/measures/2024/CPCCH/index.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, act } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { createElement } from "react";
 import { RouterWrappedComp } from "utils/testing";
 import { MeasureWrapper } from "components/MeasureWrapper";
@@ -10,7 +10,7 @@ import { MeasuresLoading } from "views";
 import { measureDescriptions } from "measures/measureDescriptions";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { clearMocks } from "measures/2023/shared/util/validationsMock";
-import { axe, toHaveNoViolations } from "jest-axe";
+import { toHaveNoViolations } from "jest-axe";
 expect.extend(toHaveNoViolations);
 
 // Test Setup
@@ -127,16 +127,6 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(
       screen.getByText("Why did you not collect this measure")
     ).toBeInTheDocument();
-  });
-
-  jest.setTimeout(15000);
-  it("should pass a11y tests", async () => {
-    useApiMock(apiData);
-    renderWithHookForm(component);
-    await act(async () => {
-      const results = await axe(screen.getByTestId("measure-wrapper-form"));
-      expect(results).toHaveNoViolations();
-    });
   });
 });
 

--- a/services/ui-src/src/measures/2024/CPCCH/index.test.tsx
+++ b/services/ui-src/src/measures/2024/CPCCH/index.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, act } from "@testing-library/react";
 import { createElement } from "react";
 import { RouterWrappedComp } from "utils/testing";
 import { MeasureWrapper } from "components/MeasureWrapper";
@@ -10,7 +10,7 @@ import { MeasuresLoading } from "views";
 import { measureDescriptions } from "measures/measureDescriptions";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { clearMocks } from "measures/2023/shared/util/validationsMock";
-import { toHaveNoViolations } from "jest-axe";
+import { axe, toHaveNoViolations } from "jest-axe";
 expect.extend(toHaveNoViolations);
 
 // Test Setup
@@ -127,6 +127,16 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(
       screen.getByText("Why did you not collect this measure")
     ).toBeInTheDocument();
+  });
+
+  jest.setTimeout(15000);
+  it("should pass a11y tests", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    await act(async () => {
+      const results = await axe(screen.getByTestId("measure-wrapper-form"));
+      expect(results).toHaveNoViolations();
+    });
   });
 });
 

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateDualPopInformation/index.test.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateDualPopInformation/index.test.ts
@@ -1,5 +1,8 @@
 import * as DC from "dataConstants";
-import { simpleRate, partialRate } from "utils/testUtils/validationHelpers";
+import {
+  simpleRate,
+  partialRate,
+} from "utils/testUtils/2023/validationHelpers";
 import { validateDualPopInformationPM } from ".";
 
 describe("Testing Dual Population Selection Validation", () => {

--- a/services/ui-src/src/utils/testUtils/validationHelpers.ts
+++ b/services/ui-src/src/utils/testUtils/validationHelpers.ts
@@ -156,10 +156,12 @@ export const generatePmQualifierRateData = (
     return {};
   }
   const rateData: PerformanceMeasure = { PerformanceMeasure: { rates: {} } };
-  const cats = pmd.categories?.length ? pmd.categories : [DC.SINGLE_CATEGORY];
+  const cats = pmd.categories?.length
+    ? pmd.categories
+    : [{ id: DC.SINGLE_CATEGORY }];
 
   for (let i = 0; i < pmd.qualifiers.length; i++) {
-    for (const c of cats?.map((c) => cleanString(c)) ?? []) {
+    for (const c of cats?.map((c) => c.id) ?? []) {
       rateData.PerformanceMeasure!.rates![c] ??= [];
       rateData?.PerformanceMeasure?.rates?.[c]?.push(testData[i]);
     }
@@ -185,7 +187,7 @@ export const generatePmCategoryRateData = (
 
   const rateData: PerformanceMeasure = { PerformanceMeasure: { rates: {} } };
 
-  for (const [i, c] of pmd.categories.map((c) => cleanString(c)).entries()) {
+  for (const [i, c] of pmd.categories.map((c) => c.id).entries()) {
     pmd.qualifiers?.forEach(() => {
       rateData.PerformanceMeasure!.rates![c] ??= [];
       rateData?.PerformanceMeasure?.rates?.[c]?.push(testData[i]);


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This is the same [migration done here](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2194) but for 2022. It was the mostly the exact same updates but to the files for 2022.

Only two difference is that OEV-AD was added in 2022 and CCW-AD validation has a different pass in value than 2021 CCW-AD

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3497

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Sign into QMR, [stateuser1@test.com](mailto:stateuser1@test.com)
2. Select reporting year 2022
3. Measure recommended to test, AIF-HH, IU-HH, IET-AD, PCR-AD, PCC-AD, BCS-AD and/or WCC-CH
4. Fill out the measure as you would a user, entering a performance measure and an OMS.
5. Validate and make sure there's no errors

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
