### PR TITLE
Mandatory Measure Instructions - Home Health

### DIFF
--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -313,6 +313,8 @@ export const CoreSet = () => {
     (measure) => measure.id
   );
 
+  const coreSetPrefix = coreSet[0].slice(0, 2);
+
   return (
     <QMR.StateLayout
       breadcrumbItems={[
@@ -323,17 +325,18 @@ export const CoreSet = () => {
         },
       ]}
     >
-      {Number(year) >= 2024 && coreSet[0].slice(0, 2) === "CC" && (
-        <CUI.Box mb="8">
-          <Alert heading="Mandatory Measure Instructions">
-            <CUI.Text>
-              {
-                "Beginning with FFY 2024 reporting, states are required to report all of the measures on the Child Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Child and Adult Core Sets."
-              }
-            </CUI.Text>
-          </Alert>
-        </CUI.Box>
-      )}
+      {Number(year) >= 2024 &&
+        (coreSetPrefix === "CC" || coreSetPrefix === "HH") && (
+          <CUI.Box mb="8">
+            <Alert heading="Mandatory Measure Instructions">
+              <CUI.Text>
+                {coreSetPrefix === "CC"
+                  ? "Beginning with FFY 2024 reporting, states are required to report all of the measures on the Child Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Child and Adult Core Sets."
+                  : "States with approved Health Home Programs in operation by June 30, 2023 are required to report all of the measures on the Health Home Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Health Home Core Sets."}
+              </CUI.Text>
+            </Alert>
+          </CUI.Box>
+        )}
       <QMR.UpdateInfoModal
         closeModal={closeModal}
         handleModalResponse={handleModalResponse}

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -313,6 +313,11 @@ export const CoreSet = () => {
     (measure) => measure.id
   );
 
+  const coreSetInstructions: { [key: string]: string } = {
+    CC: "Beginning with FFY 2024 reporting, states are required to report all of the measures on the Child Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Child and Adult Core Sets.",
+    HH: "States with approved Health Home Programs in operation by June 30, 2023 are required to report all of the measures on the Health Home Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Health Home Core Sets.",
+  };
+
   const coreSetPrefix = coreSet[0].slice(0, 2);
 
   return (
@@ -325,18 +330,13 @@ export const CoreSet = () => {
         },
       ]}
     >
-      {Number(year) >= 2024 &&
-        (coreSetPrefix === "CC" || coreSetPrefix === "HH") && (
-          <CUI.Box mb="8">
-            <Alert heading="Mandatory Measure Instructions">
-              <CUI.Text>
-                {coreSetPrefix === "CC"
-                  ? "Beginning with FFY 2024 reporting, states are required to report all of the measures on the Child Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Child and Adult Core Sets."
-                  : "States with approved Health Home Programs in operation by June 30, 2023 are required to report all of the measures on the Health Home Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Health Home Core Sets."}
-              </CUI.Text>
-            </Alert>
-          </CUI.Box>
-        )}
+      {Number(year) >= 2024 && coreSetInstructions[coreSetPrefix] && (
+        <CUI.Box mb="8">
+          <Alert heading="Mandatory Measure Instructions">
+            <CUI.Text>{coreSetInstructions[coreSetPrefix]}</CUI.Text>
+          </Alert>
+        </CUI.Box>
+      )}
       <QMR.UpdateInfoModal
         closeModal={closeModal}
         handleModalResponse={handleModalResponse}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3775

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Add a HH core set page for FFY 2024 and confirm that the banner exists. Banner should match [Figma design](https://www.figma.com/design/CaKupDWdVLgmnFZyhBSdGm/MDCT_QMR?node-id=313-2339&t=nqgSCIgA14HNsDl1-0). Info text should be: **"States with approved Health Home Programs in operation by June 30, 2023 are required to report all of the measures on the Health Home Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Health Home Core Sets."**
2. Confirm that the banner does not exist prior to 2024

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
