### PR TITLE
CMDCT-3472: adding some nightmarish manual brute force styles to pdfs

### DIFF
--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -123,25 +123,39 @@ export const applyPrinceSpecificCss = (): HTMLStyleElement => {
     .prince-top-link, .prince-supp-text, h1 { margin: auto !important; text-align: center !important; width: fitcontent !important; margin: 10px 0 !important; }
     .prince-upload-wrapper, .prince-file-item { border: 3px !important; border-style: dotted; background-color: var(--chakra-colors-blue-100); border-radius: var(--chakra-radii-md) }
     .replaced-text-area {border-radius: var(--chakra-radii-md); border-width: 1px; border-style: solid; border-color: inherit; padding: 15px; box-sizing: border-box; white-space: pre-wrap;}
+    
+    
     ${
-      /* Prince doesn't support color and background colors or css grid out of the box. we have to brute force those styles here */ ""
+      /* ******* Prince doesn't support certain css elements like background colors or css grid out of the box. we have to brute force those styles here.
+      All of these css class names can be found by inspecting the elements on the pdf page in the browser. ********* */ ""
     }
-    .chakra-button { background: var(--chakra-colors-gray-100) !important; margin: 16px }
+
+    .chakra-button { background: var(--chakra-colors-gray-100) !important; margin: 16px 8px }
     .chakra-link { color: var(--chakra-colors-blue-600) !important; }
     .chakra-link * { color: blue !important; }
-    .css-gzpnyx[data-checked], .css-1oi6yiz[data-checked] { background: var(--chakra-colors-blue-500) !important; border-color: var(--chakra-colors-blue-500) !important; }
-    .chakra-checkbox__control * { color: var(--chakra-colors-white) !important; display: flex !important }
-    .css-gzpnyx[data-checked]::before { content: ""; width: 50%; height: 50%; border-radius: 50%; background: var(--chakra-colors-white) !important; }
     ${
-      /* On line 61 of this file, we are replacing text-align: right with center. 
-      There are few places where we don't want to do this so we are overriding those styles below for some inputs */ ""
+      /* Chakra radio buttons and checkboxes that are checked don't display colors correctly due to Prince pdf limitation with background colors. 
+      These styles below manually add the background colors back to the checked radio buttons and checkboxes */ ""
     }
+    .css-gzpnyx[data-checked], .css-1oi6yiz[data-checked] { background: var(--chakra-colors-blue-500) !important; border-color: var(--chakra-colors-blue-500) !important; }
+    .css-gzpnyx[data-checked]::before { content: ""; width: 50%; height: 50%; border-radius: 50%; background: var(--chakra-colors-white) !important; }
+    .chakra-checkbox__control * { color: var(--chakra-colors-white) !important; display: flex !important }
+    ${
+      /* On line 61 of this file, we are replacing text-align: right with text-align: center. 
+      There are few places where we don't want to do this so we are overriding those styles below for some inputs.
+      The classes below are targeting the core set qualifiers Delivery System percentage inputs and elements inside the inputs */ ""
+    }
+    .css-xumdn4 { padding-right: 16px !important }
     .css-1pkmg65, .css-18akmna { text-align: right !important; padding-right: 40px !important; }
     ${
-      /* The below css classes are targeting icons in inputs need to have display: flex (that display is getting removed on line 61). 
-      these class names can be found by looking at the elements on the pdf in the browser. */ ""
+      /* The below css classes are targeting icons in inputs need to have display: flex (that display is getting removed on line 61) */ ""
     }
     .css-11pdqhs, .css-1nqqbdv { display: flex !important }
+    ${
+      /* These css classes are targeting the numerator, denominator, rate inputs. These need to have display: flex and other css styles to look correct */ ""
+    }
+    .css-1qqj5ri { display: flex !important; flex-direction: row !important; width: 100% !important }
+    .css-1kxonj9 {margin-left: 0px !important; margin-top: 0px !important; padding: 8px !important;}
   `
     )
   );

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -159,8 +159,8 @@ export const applyPrinceSpecificCss = (): HTMLStyleElement => {
     ${
       /* These ds-c css classes are targeting the warning box for other data source */ ""
     }
-    .ds-c-alert--warn { display: inline-flex !important ; background-color: #fef9e9 !important }
-    .ds-c-alert-icon { height: 24px !important; width: 24px !important; }
+    .ds-c-alert--warn { display: inline-flex !important; background-color: #fef9e9 !important }
+    .ds-c-alert__icon { font-size: 16px !important; height: 24px !important; width: 24px !important }
   `
     )
   );

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -155,7 +155,12 @@ export const applyPrinceSpecificCss = (): HTMLStyleElement => {
       /* These css classes are targeting the numerator, denominator, rate inputs. These need to have display: flex and other css styles to look correct */ ""
     }
     .css-1qqj5ri { display: flex !important; flex-direction: row !important; width: 100% !important }
-    .css-1kxonj9 {margin-left: 0px !important; margin-top: 0px !important; padding: 8px !important;}
+    .css-1kxonj9 { margin-left: 0px !important; margin-top: 0px !important; padding: 8px !important; }
+    ${
+      /* These ds-c css classes are targeting the warning box for other data source */ ""
+    }
+    .ds-c-alert--warn { display: inline-flex !important ; background-color: #fef9e9 !important }
+    .ds-c-alert-icon { height: 24px !important; width: 24px !important; }
   `
     )
   );

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -123,6 +123,25 @@ export const applyPrinceSpecificCss = (): HTMLStyleElement => {
     .prince-top-link, .prince-supp-text, h1 { margin: auto !important; text-align: center !important; width: fitcontent !important; margin: 10px 0 !important; }
     .prince-upload-wrapper, .prince-file-item { border: 3px !important; border-style: dotted; background-color: var(--chakra-colors-blue-100); border-radius: var(--chakra-radii-md) }
     .replaced-text-area {border-radius: var(--chakra-radii-md); border-width: 1px; border-style: solid; border-color: inherit; padding: 15px; box-sizing: border-box; white-space: pre-wrap;}
+    ${
+      /* Prince doesn't support color and background colors or css grid out of the box. we have to brute force those styles here */ ""
+    }
+    .chakra-button { background: var(--chakra-colors-gray-100) !important; margin: 16px }
+    .chakra-link { color: var(--chakra-colors-blue-600) !important; }
+    .chakra-link * { color: blue !important; }
+    .css-gzpnyx[data-checked], .css-1oi6yiz[data-checked] { background: var(--chakra-colors-blue-500) !important; border-color: var(--chakra-colors-blue-500) !important; }
+    .chakra-checkbox__control * { color: var(--chakra-colors-white) !important; display: flex !important }
+    .css-gzpnyx[data-checked]::before { content: ""; width: 50%; height: 50%; border-radius: 50%; background: var(--chakra-colors-white) !important; }
+    ${
+      /* On line 61 of this file, we are replacing text-align: right with center. 
+      There are few places where we don't want to do this so we are overriding those styles below for some inputs */ ""
+    }
+    .css-1pkmg65, .css-18akmna { text-align: right !important; padding-right: 40px !important; }
+    ${
+      /* The below css classes are targeting icons in inputs need to have display: flex (that display is getting removed on line 61). 
+      these class names can be found by looking at the elements on the pdf in the browser. */ ""
+    }
+    .css-11pdqhs, .css-1nqqbdv { display: flex !important }
   `
     )
   );


### PR DESCRIPTION
### Description
This actually ended up being a pretty contained PR so I am not going to say sorry for it even though it is truly an abomination. 

### **Summary of Prince issues in our PDFs**

Prince PDFs have a long and well known limitation that it does not recognize certain css properties like `background-color` (see [this](https://stackoverflow.com/questions/20653871/background-color-is-not-showing-in-prince-xml) stack overflow post describing the issue and solution). I understand this stack overflow post is 10 years old, but our PDFs were having the EXACT issues described in that post with certain chakra elements like radio buttons and checkboxes. Someone mentioned that you can override these styles using !important, so that's what this PR is. Any styles that aren't properly coming through are recreated in the custom prince styling that we are already doing. 

Also Prince PDFs do not support css grid, so I did a little manual overriding there too.

Also also, for some god forsaken reason, we were already going through every bit of css and changing any instance of `display: flex `to `block` and then `text-align: right` to `center` (see [here](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/blob/master/services/ui-src/src/views/ExportAll/util.tsx#L62) for the chunk of code that does this). That works for MOST elements but it was messing up some elements too. I found it easiest to find the specific ones that were broken after doing that and manually override them to have the correct css again. Not ideal at all but it does sort of work!

### **Summary of the things I fixed**

1. Chakra buttons did not have a grey background and they also were not displaying with proper spacing because they are in a css grid which prince pdfs doesn't support. I just manually added the background and recreated the grid spacing with margins. See before and after: 
<img width="1494" alt="Screenshot 2024-07-09 at 9 57 04 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/16945230/4aa3cfba-d102-4cb7-9f56-60eb6ea4f70e">

2. Chakra radio buttons and checkboxes only had an outline (background color was not taking affect) so I fixed that. See below: 
<img width="1377" alt="Screenshot 2024-07-08 at 4 00 39 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/16945230/9a384526-d91a-40ff-8f3a-017bb5e7fdac">

3. In the questionnaire section, there were some percentages that were all messed up because of the thing i referenced about us replacing `display: flex` with `display: block`. These percentages need `display: flex` to look normal so I just manually overrode (overWrote?) that css to make it look gud:
<img width="1479" alt="Screenshot 2024-07-09 at 10 37 33 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/16945230/4898cc5f-e230-4112-ba3c-446924b5d6a3">

4. In the sections where there are Numerator, Denominator, and Rate inputs, `display: flex` was not getting applied correctly and it was being displayed as a column instead of row. so I added flex back in so that the display is a row: 
<img width="1546" alt="Screenshot 2024-07-09 at 11 22 53 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/16945230/d53ce239-278c-4f0a-88c0-5981a7eb711f">


### Related ticket(s)
https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2142

---
### How to test
1. Go to QMR core set view and click on the three dot menu of any core set (ideally core sets where you've completed some measures) and click "Export"
2. This will take you to the pdf print out page. Click the "Print PDF" button and wait for the PDF to export
3. Once the PDF opens in a new tab, give it a good look-see. Make sure it sort of looks as good as possible and use my screenshots as a reference to make sure that all my claimed changes are actually showing up
