### PR TITLE
CMDCT-3784, CMDCT-3786, CMDCT-3789: updating labels for combined rates and other things

### DIFF
--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -18,7 +18,7 @@ export const measureDescriptions: MeasureList = {
     "CPA-AD":
       "Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H, Adult Version (Medicaid)",
     "FUA-AD":
-      "Follow-up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence",
+      "Follow-Up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence",
     "FUH-AD":
       "Follow-Up After Hospitalization for Mental Illness: Age 18 and Older",
     "FUM-AD": "Follow-Up After Emergency Department Visit for Mental Illness",
@@ -114,7 +114,7 @@ export const measureDescriptions: MeasureList = {
     "CPA-AD":
       "Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H, Adult Version (Medicaid)",
     "FUA-AD":
-      "Follow-up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence: Age 18 and Older",
+      "Follow-Up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence: Age 18 and Older",
     "FUH-AD":
       "Follow-Up After Hospitalization for Mental Illness: Age 18 and Older",
     "FUM-AD":
@@ -217,7 +217,7 @@ export const measureDescriptions: MeasureList = {
     "CPU-AD":
       "Long-Term Services and Supports Comprehensive Care Plan and Update",
     "FUA-AD":
-      "Follow-up After Emergency Department Visit for Substance Use: Age 18 and Older",
+      "Follow-Up After Emergency Department Visit for Substance Use: Age 18 and Older",
     "FUH-AD":
       "Follow-Up After Hospitalization for Mental Illness: Age 18 and Older",
     "FUM-AD":
@@ -319,7 +319,7 @@ export const measureDescriptions: MeasureList = {
     "CPU-AD":
       "Long-Term Services and Supports Comprehensive Care Plan and Update",
     "FUA-AD":
-      "Follow-up After Emergency Department Visit for Substance Use: Age 18 and Older",
+      "Follow-Up After Emergency Department Visit for Substance Use: Age 18 and Older",
     "FUH-AD":
       "Follow-Up After Hospitalization for Mental Illness: Age 18 and Older",
     "FUM-AD":

--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -18,7 +18,7 @@ export const measureDescriptions: MeasureList = {
     "CPA-AD":
       "Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H, Adult Version (Medicaid)",
     "FUA-AD":
-      "Follow-Up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence",
+      "Follow-up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence",
     "FUH-AD":
       "Follow-Up After Hospitalization for Mental Illness: Age 18 and Older",
     "FUM-AD": "Follow-Up After Emergency Department Visit for Mental Illness",
@@ -114,7 +114,7 @@ export const measureDescriptions: MeasureList = {
     "CPA-AD":
       "Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H, Adult Version (Medicaid)",
     "FUA-AD":
-      "Follow-Up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence: Age 18 and Older",
+      "Follow-up After Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence: Age 18 and Older",
     "FUH-AD":
       "Follow-Up After Hospitalization for Mental Illness: Age 18 and Older",
     "FUM-AD":
@@ -217,7 +217,7 @@ export const measureDescriptions: MeasureList = {
     "CPU-AD":
       "Long-Term Services and Supports Comprehensive Care Plan and Update",
     "FUA-AD":
-      "Follow-Up After Emergency Department Visit for Substance Use: Age 18 and Older",
+      "Follow-up After Emergency Department Visit for Substance Use: Age 18 and Older",
     "FUH-AD":
       "Follow-Up After Hospitalization for Mental Illness: Age 18 and Older",
     "FUM-AD":

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -5,7 +5,7 @@ import {
   RateDataShape,
 } from "./CombinedRateTypes";
 
-type ProgramType = "Medicaid" | "CHIP" | "Combined Rate";
+type ProgramType = "Medicaid" | "Separate CHIP" | "Combined Rate";
 type Measures = "numerator" | "denominator" | "rate";
 
 const VerticalTable = (
@@ -72,13 +72,13 @@ const HorizontalTable = (
 
 export const CombinedRateNDR = ({ json }: Props) => {
   const tables = collectRatesForDisplay(json);
-  const headers: ProgramType[] = ["Medicaid", "CHIP", "Combined Rate"];
+  const headers: ProgramType[] = ["Medicaid", "Separate CHIP", "Combined Rate"];
   const rows: Measures[] = ["numerator", "denominator", "rate"];
 
   //centralize formatting of the display data so that all the renders value are consistent
   tables.forEach((table) => {
     headers.forEach((header) => {
-      const notAnswered = header === "Combined Rate" ? "" : "Not answered";
+      const notAnswered = header === "Combined Rate" ? "" : "Not reported";
       //setting values to not answered if key doesn't exist
       const numerator = table[header]?.numerator ?? notAnswered;
       const denominator = table[header]?.denominator ?? notAnswered;
@@ -119,7 +119,7 @@ type TableDataShape = {
   uid: string;
   label: string;
   category?: string;
-  CHIP?: RateDataShape;
+  "Separate CHIP"?: RateDataShape;
   Medicaid?: RateDataShape;
   "Combined Rate"?: RateDataShape;
 };
@@ -159,7 +159,7 @@ const collectRatesForDisplay = (
     rememberRate(medicaidRate, "Medicaid");
   }
   for (let chipRate of Object.values(chipData).flat()) {
-    rememberRate(chipRate, "CHIP");
+    rememberRate(chipRate, "Separate CHIP");
   }
   for (let combinedRate of combinedRatesData) {
     rememberRate(combinedRate, "Combined Rate");

--- a/services/ui-src/src/shared/commonQuestions/DataSouceInformationBanner/DataSourceInformationBanner.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DataSouceInformationBanner/DataSourceInformationBanner.tsx
@@ -4,7 +4,7 @@ import { AnyObject } from "types";
 interface Props {
   data: AnyObject[];
 }
-const columns = ["Medicaid", "CHIP"];
+const columns = ["Medicaid", "Separate CHIP"];
 
 const DataSourceRecord: Record<string, string> = {
   AdministrativeData: "Administrative Data",
@@ -62,7 +62,7 @@ export const DataSourceInformationBanner = ({ data }: Props) => {
           })
         ) : (
           <CUI.Text tabIndex={0} pt="1.25rem">
-            Not answered
+            Not reported
           </CUI.Text>
         )}
       </CUI.Box>

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -57,7 +57,7 @@ export const CombinedRatesMeasure = ({
             target="_blank"
             color="blue.600"
           >
-            CHIP - {measure} - {measureName}
+            Separate CHIP - {measure} - {measureName}
           </CUI.Link>
         </CUI.ListItem>
         <CUI.ListItem>


### PR DESCRIPTION
### Description
This super simple PR contains label changes for 3 tickets:
1. CMDCT-3784: Changed "CHIP" to "Separate CHIP"
2. CMDCT-3786: Changed "Not answered" to "Not reported"
3. CMDCT-3789: Changed 2024 FUA-AD measure to capitalize the up in "Follow-Up"

---
### How to test
## Testing CMDCT-3784 and CMDCT-3786
1. Navigate to combined rates page and click into any measure for child or adult
2. Observe that any reference to CHIP now says Separate CHIP
3. Observe that anything that doesn't have a value says "Not reported" instead of "Not answered"

## Testing CMDCT-3789:
1. Navigate to core sets and click on Adult Medicaid
2. Scroll down to the FUA-AD measure and make sure the title has "up" capitalized in "Follow-Up"
3. Click into the measure and make sure that the title and the first question all have "Follow-Up" capitalized correctly