### PR TITLE
Combined Rates Page - Rates showing in wrong order

### DIFF
--- a/services/ui-src/src/labels/RateTextLabels.tsx
+++ b/services/ui-src/src/labels/RateTextLabels.tsx
@@ -1,0 +1,4 @@
+export * as RateLabel2021 from "measures/2021/rateLabelText";
+export * as RateLabel2022 from "measures/2022/rateLabelText";
+export * as RateLabel2023 from "measures/2023/rateLabelText";
+export * as RateLabel2024 from "measures/2024/rateLabelText";

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -4,7 +4,6 @@ import {
   RateCategoryMap,
   RateDataShape,
 } from "./CombinedRateTypes";
-import { useEffect, useState } from "react";
 import { LabelData } from "utils";
 import * as Labels from "labels/RateTextLabels";
 
@@ -86,23 +85,18 @@ export const sortRateNDR = (
 };
 
 export const CombinedRateNDR = ({ json }: Props) => {
-  const [tables, setTables] = useState<TableDataShape[]>();
-  const measure = json?.measure!;
-  const year = json?.year!;
+  const measure = json.measure;
+  const year = json.year;
   const data = collectRatesForDisplay(json);
   const headers: ProgramType[] = ["Medicaid", "Separate CHIP", "Combined Rate"];
   const rows: Measures[] = ["numerator", "denominator", "rate"];
 
   //dynamically pull the rateLabelText by combined rates year so that we can get the cat and qual info of the measure
   const rateTextLabel = Labels[`RateLabel${year}` as keyof typeof Labels];
-  useEffect(() => {
-    if (rateTextLabel) {
-      const { categories, qualifiers } = rateTextLabel!.getCatQualLabels(
-        measure! as keyof typeof rateTextLabel.data
-      );
-      setTables(sortRateNDR(data, categories, qualifiers));
-    }
-  }, [rateTextLabel]);
+  const { categories, qualifiers } = rateTextLabel!.getCatQualLabels(
+    measure! as keyof typeof rateTextLabel.data
+  );
+  const tables = sortRateNDR(data, categories, qualifiers);
 
   //centralize formatting of the display data so that all the renders value are consistent
   tables?.forEach((table) => {
@@ -154,11 +148,8 @@ type TableDataShape = {
 };
 
 const collectRatesForDisplay = (
-  json: CombinedRatePayload | undefined
+  json: CombinedRatePayload
 ): TableDataShape[] => {
-  if (!json) {
-    return [];
-  }
   const tables: TableDataShape[] = [];
   const data = json.data;
 

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -14,13 +14,13 @@ type ProgramType = typeof programTypes[number];
 const verticalTable = (table: any) => {
   return (
     <CUI.VStack align="flex-start" mt="4">
-      {programTypes.slice(0, -1).map((programType) => (
-        <CUI.List padding="0 0 1rem 2rem" textTransform="capitalize">
+      {programTypes.slice(0, -1).map((programType, ptIndex) => (
+        <CUI.List key={ptIndex} padding="0 0 1rem 2rem" textTransform="capitalize">
           <CUI.Text fontWeight="bold" mb="2">
             {programType}
           </CUI.Text>
-          {rateComponents.map((rateComponent) => (
-            <CUI.ListItem pl="7">
+          {rateComponents.map((rateComponent, rIndex) => (
+            <CUI.ListItem key={rIndex} pl="7">
               {rateComponent}: {table[programType]?.[rateComponent.toLowerCase()]}
             </CUI.ListItem>
           ))}
@@ -42,19 +42,19 @@ const horizontalTable = (table: TableDataShape) => {
       <CUI.Thead>
         <CUI.Tr>
           <CUI.Td></CUI.Td>
-          {programTypes.map((programTypes) => (
-            <CUI.Th sx={sx.header}>{programTypes}</CUI.Th>
+          {programTypes.map((programTypes, index) => (
+            <CUI.Th key={index} sx={sx.header}>{programTypes}</CUI.Th>
           ))}
         </CUI.Tr>
       </CUI.Thead>
       <CUI.Tbody>
-        {rateComponents.map((rateComponent) => (
-          <CUI.Tr sx={sx.row}>
+        {rateComponents.map((rateComponent, rIndex) => (
+          <CUI.Tr key={rIndex} sx={sx.row}>
             <CUI.Th sx={sx.verticalHeader} scope="row">
               {rateComponent}
             </CUI.Th>
-            {programTypes.map((programType) => (
-              <CUI.Td isNumeric sx={sx.content}>
+            {programTypes.map((programType, ptIndex) => (
+              <CUI.Td key={ptIndex} isNumeric sx={sx.content}>
                 {table[programType]?.[rateComponent]}
               </CUI.Td>
             ))}
@@ -104,9 +104,9 @@ export const CombinedRateNDR = ({ json }: Props) => {
 
   return (
     <CUI.Box sx={sx.tableContainer} mb="3rem">
-      {tables?.map((table) => {
+      {tables?.map((table, index) => {
         return (
-          <CUI.Box as={"section"}>
+          <CUI.Box key={index} as={"section"}>
             {table.category ? (
               <CUI.Heading fontSize="xl" mt="12" mb="2">
                 {table.category} - {table.label}

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -14,11 +14,12 @@ type TableKeys = {
   uid: string;
   label: string;
   category?: string;
-}
+};
 /** An intermediate shape, not guaranteed to have an entry for every program type */
-type PartialTableDataShape = TableKeys & Partial<Record<ProgramType, RateDataShape>>
+type PartialTableDataShape = TableKeys &
+  Partial<Record<ProgramType, RateDataShape>>;
 /** Corresponds directly to the tables as we display them */
-type TableDataShape = TableKeys & Record<ProgramType, RateDataShape>
+type TableDataShape = TableKeys & Record<ProgramType, RateDataShape>;
 type Props = {
   json: CombinedRatePayload;
 };
@@ -27,7 +28,11 @@ const verticalTable = (table: TableDataShape) => {
   return (
     <CUI.VStack align="flex-start" mt="4">
       {programTypes.slice(0, -1).map((programType, ptIndex) => (
-        <CUI.List key={ptIndex} padding="0 0 1rem 2rem" textTransform="capitalize">
+        <CUI.List
+          key={ptIndex}
+          padding="0 0 1rem 2rem"
+          textTransform="capitalize"
+        >
           <CUI.Text fontWeight="bold" mb="2">
             {programType}
           </CUI.Text>
@@ -55,7 +60,9 @@ const horizontalTable = (table: TableDataShape) => {
         <CUI.Tr>
           <CUI.Td></CUI.Td>
           {programTypes.map((programTypes, index) => (
-            <CUI.Th key={index} sx={sx.header}>{programTypes}</CUI.Th>
+            <CUI.Th key={index} sx={sx.header}>
+              {programTypes}
+            </CUI.Th>
           ))}
         </CUI.Tr>
       </CUI.Thead>
@@ -96,12 +103,8 @@ export const CombinedRateNDR = ({ json }: Props) => {
                 {table.label}
               </CUI.Heading>
             )}
-            <CUI.Hide below="md">
-              {horizontalTable(table)}
-            </CUI.Hide>
-            <CUI.Show below="md">
-              {verticalTable(table)}
-            </CUI.Show>
+            <CUI.Hide below="md">{horizontalTable(table)}</CUI.Hide>
+            <CUI.Show below="md">{verticalTable(table)}</CUI.Show>
           </CUI.Box>
         );
       })}
@@ -156,7 +159,9 @@ const collectRatesForDisplay = (
 // so it is less confusing to use a standard function declaration here.
 // Usage note: Normally assertion functions throw errors when an object isn't of the asserted type,
 // but it is also valid to coerce it into that type instead, as we do here.
-function provideDefaultValues (tables: PartialTableDataShape[]): asserts tables is TableDataShape[] {
+function provideDefaultValues(
+  tables: PartialTableDataShape[]
+): asserts tables is TableDataShape[] {
   for (let table of tables) {
     for (let programType of programTypes) {
       const notAnswered = programType === "Combined Rate" ? "" : "Not reported";
@@ -165,10 +170,15 @@ function provideDefaultValues (tables: PartialTableDataShape[]): asserts tables 
       const denominator = table[programType]?.denominator ?? notAnswered;
       const rate = table[programType]?.rate ?? "-";
       // Add value back to table object
-      table[programType] = { ...table[programType]!, numerator, denominator, rate };
+      table[programType] = {
+        ...table[programType]!,
+        numerator,
+        denominator,
+        rate,
+      };
     }
   }
-};
+}
 
 /**
  * Sort the rates in-place, to match how they are displayed on individual measure pages.
@@ -180,8 +190,9 @@ const sortRates = (tables: TableDataShape[], year: string, measure: string) => {
     measure as keyof typeof rateTextLabel.data
   );
   // Build an array of uids in the order they are displayed in the pm section
-  const uidOrder = categories
-    .flatMap((cat) => qualifiers.map((qual) => `${cat.id}.${qual.id}`));
+  const uidOrder = categories.flatMap((cat) =>
+    qualifiers.map((qual) => `${cat.id}.${qual.id}`)
+  );
   tables.sort((a, b) => uidOrder.indexOf(a.uid) - uidOrder.indexOf(b.uid));
 };
 

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -7,31 +7,28 @@ import {
 import { LabelData } from "utils";
 import * as Labels from "labels/RateTextLabels";
 
-type ProgramType = "Medicaid" | "Separate CHIP" | "Combined Rate";
-type Measures = "numerator" | "denominator" | "rate";
+const programTypes = ["Medicaid", "Separate CHIP", "Combined Rate"] as const;
+const rateComponents = ["numerator", "denominator", "rate"] as const;
+type ProgramType = typeof programTypes[number];
 
-const verticalTable = (
-  headers: ProgramType[],
-  rows: Measures[],
-  table: any
-) => {
+const verticalTable = (table: any) => {
   return (
     <CUI.VStack align="flex-start" mt="4">
-      {headers.slice(0, -1).map((header) => (
+      {programTypes.slice(0, -1).map((programType) => (
         <CUI.List padding="0 0 1rem 2rem" textTransform="capitalize">
           <CUI.Text fontWeight="bold" mb="2">
-            {header}
+            {programType}
           </CUI.Text>
-          {rows.map((row) => (
+          {rateComponents.map((rateComponent) => (
             <CUI.ListItem pl="7">
-              {row}: {table[header]?.[row.toLowerCase()]}
+              {rateComponent}: {table[programType]?.[rateComponent.toLowerCase()]}
             </CUI.ListItem>
           ))}
         </CUI.List>
       ))}
       <CUI.List padding="0 0 1rem 2rem">
         <CUI.Text fontWeight="bold" mb="2">
-          {headers[2]}: {table["Combined Rate"]?.rate}
+          {programTypes[2]}: {table["Combined Rate"]?.rate}
         </CUI.Text>
       </CUI.List>
       <CUI.Divider borderColor="gray.300" />
@@ -39,30 +36,26 @@ const verticalTable = (
   );
 };
 
-const horizontalTable = (
-  headers: ProgramType[],
-  rows: Measures[],
-  table: TableDataShape
-) => {
+const horizontalTable = (table: TableDataShape) => {
   return (
     <CUI.Table variant="unstyled" mt="4" size="md" verticalAlign="top">
       <CUI.Thead>
         <CUI.Tr>
           <CUI.Td></CUI.Td>
-          {headers.map((header) => (
-            <CUI.Th sx={sx.header}>{header}</CUI.Th>
+          {programTypes.map((programTypes) => (
+            <CUI.Th sx={sx.header}>{programTypes}</CUI.Th>
           ))}
         </CUI.Tr>
       </CUI.Thead>
       <CUI.Tbody>
-        {rows.map((row) => (
+        {rateComponents.map((rateComponent) => (
           <CUI.Tr sx={sx.row}>
             <CUI.Th sx={sx.verticalHeader} scope="row">
-              {row}
+              {rateComponent}
             </CUI.Th>
-            {headers.map((header) => (
+            {programTypes.map((programType) => (
               <CUI.Td isNumeric sx={sx.content}>
-                {table[header]?.[row]}
+                {table[programType]?.[rateComponent]}
               </CUI.Td>
             ))}
           </CUI.Tr>
@@ -88,8 +81,6 @@ export const CombinedRateNDR = ({ json }: Props) => {
   const measure = json.measure;
   const year = json.year;
   const data = collectRatesForDisplay(json);
-  const headers: ProgramType[] = ["Medicaid", "Separate CHIP", "Combined Rate"];
-  const rows: Measures[] = ["numerator", "denominator", "rate"];
 
   //dynamically pull the rateLabelText by combined rates year so that we can get the cat and qual info of the measure
   const rateTextLabel = Labels[`RateLabel${year}` as keyof typeof Labels];
@@ -100,7 +91,7 @@ export const CombinedRateNDR = ({ json }: Props) => {
 
   //centralize formatting of the display data so that all the renders value are consistent
   tables?.forEach((table) => {
-    headers.forEach((header) => {
+    programTypes.forEach((header) => {
       const notAnswered = header === "Combined Rate" ? "" : "Not reported";
       //setting values to not answered if key doesn't exist
       const numerator = table[header]?.numerator ?? notAnswered;
@@ -126,10 +117,10 @@ export const CombinedRateNDR = ({ json }: Props) => {
               </CUI.Heading>
             )}
             <CUI.Hide below="md">
-              {horizontalTable(headers, rows, table)}
+              {horizontalTable(table)}
             </CUI.Hide>
             <CUI.Show below="md">
-              {verticalTable(headers, rows, table)}
+              {verticalTable(table)}
             </CUI.Show>
           </CUI.Box>
         );

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -23,7 +23,7 @@ type Props = {
   json: CombinedRatePayload;
 };
 
-const verticalTable = (table: any) => {
+const verticalTable = (table: TableDataShape) => {
   return (
     <CUI.VStack align="flex-start" mt="4">
       {programTypes.slice(0, -1).map((programType, ptIndex) => (
@@ -33,7 +33,7 @@ const verticalTable = (table: any) => {
           </CUI.Text>
           {rateComponents.map((rateComponent, rIndex) => (
             <CUI.ListItem key={rIndex} pl="7">
-              {rateComponent}: {table[programType]?.[rateComponent.toLowerCase()]}
+              {rateComponent}: {table[programType][rateComponent]}
             </CUI.ListItem>
           ))}
         </CUI.List>

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -5,6 +5,7 @@ import {
   RateDataShape,
 } from "./CombinedRateTypes";
 import { useEffect, useState } from "react";
+import { LabelData } from "utils";
 
 type ProgramType = "Medicaid" | "CHIP" | "Combined Rate";
 type Measures = "numerator" | "denominator" | "rate";
@@ -73,13 +74,12 @@ const horizontalTable = (
 
 export const sortRateNDR = (
   data: TableDataShape[],
-  categories: any,
-  qualifiers: any
+  categories: LabelData[],
+  qualifiers: LabelData[]
 ) => {
+  //build an array of uids in the order they are displayed in the pm section
   const sortList = categories
-    .map((cat: { id: any }) => [
-      ...qualifiers.map((qual: { id: any }) => `${cat.id}.${qual.id}`),
-    ])
+    .map((cat) => [...qualifiers.map((qual) => `${cat.id}.${qual.id}`)])
     .flat();
   return data.sort((a, b) => sortList.indexOf(a.uid) - sortList.indexOf(b.uid));
 };
@@ -94,6 +94,7 @@ export const CombinedRateNDR = ({ json }: Props) => {
 
   useEffect(() => {
     const sort = async () => {
+      //dynamicallu pull the rateLabelText by combined rates year so that we can get the cat and qual info of the measure
       const module = await import(`../../../measures/${year}/rateLabelText`);
       const { categories, qualifiers } = module?.getCatQualLabels(
         measure! as keyof typeof module.data

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -6,6 +6,7 @@ import {
 } from "./CombinedRateTypes";
 import { useEffect, useState } from "react";
 import { LabelData } from "utils";
+import * as Labels from "labels/RateTextLabels";
 
 type ProgramType = "Medicaid" | "CHIP" | "Combined Rate";
 type Measures = "numerator" | "denominator" | "rate";
@@ -92,17 +93,16 @@ export const CombinedRateNDR = ({ json }: Props) => {
   const headers: ProgramType[] = ["Medicaid", "CHIP", "Combined Rate"];
   const rows: Measures[] = ["numerator", "denominator", "rate"];
 
+  //dynamically pull the rateLabelText by combined rates year so that we can get the cat and qual info of the measure
+  const rateTextLabel = Labels[`RateLabel${year}` as keyof typeof Labels];
   useEffect(() => {
-    const sort = async () => {
-      //dynamicallu pull the rateLabelText by combined rates year so that we can get the cat and qual info of the measure
-      const module = await import(`../../../measures/${year}/rateLabelText`);
-      const { categories, qualifiers } = module?.getCatQualLabels(
-        measure! as keyof typeof module.data
+    if (rateTextLabel) {
+      const { categories, qualifiers } = rateTextLabel!.getCatQualLabels(
+        measure! as keyof typeof rateTextLabel.data
       );
       setTables(sortRateNDR(data, categories, qualifiers));
-    };
-    sort();
-  }, [measure]);
+    }
+  }, [rateTextLabel]);
 
   //centralize formatting of the display data so that all the renders value are consistent
   tables?.forEach((table) => {

--- a/services/ui-src/src/utils/testUtils/useApiMock.tsx
+++ b/services/ui-src/src/utils/testUtils/useApiMock.tsx
@@ -136,21 +136,67 @@ export const defaultMockValues = {
     error: undefined,
     isError: undefined,
     data: {
-      Items: [
-        {
-          autoCompleted: false,
-          compoundKey: "AL2021ACSIET-AD",
-          coreSet: "ACS",
-          createdAt: 1642167976771,
-          description:
-            "Initiation and Engagement of Alcohol and Other Drug Abuse or Dependence Treatment",
-          lastAltered: 1642167976771,
-          measure: "IET-AD",
-          state: "AL",
-          status: "incomplete",
-          year: 2021,
-        },
-      ],
+      Item: {
+        compoundKey: "MA2024CCSAAB-CH",
+        measure: "AAB-CH",
+        state: "MA",
+        data: [
+          {
+            column: "CHIP",
+            dataSourceSelections: {
+              AdministrativeData0: {
+                selected: ["MedicaidManagementInformationSystemMMIS"],
+              },
+            },
+            dataSource: ["AdministrativeData"],
+            rates: {
+              ZCy3XP: [
+                {
+                  uid: "ZCy3XP.xS5HMm",
+                  label: "Ages 3 months to 17 years",
+                  rate: "0.0",
+                  numerator: "1",
+                  denominator: "1",
+                },
+              ],
+            },
+          },
+          {
+            column: "Medicaid",
+            dataSourceSelections: {
+              AdministrativeData0: {
+                selected: ["MedicaidManagementInformationSystemMMIS"],
+              },
+            },
+            dataSource: ["AdministrativeData"],
+            rates: {
+              ZCy3XP: [
+                {
+                  uid: "ZCy3XP.xS5HMm",
+                  label: "Ages 3 months to 17 years",
+                  rate: "0.0",
+                  numerator: "2",
+                  denominator: "2",
+                },
+              ],
+            },
+          },
+          {
+            column: "Combined Rate",
+            rates: [
+              {
+                uid: "ZCy3XP.xS5HMm",
+                label: "Ages 3 months to 17 years",
+                category: "",
+                rate: "0.0",
+                numerator: "3",
+                denominator: "3",
+              },
+            ],
+          },
+        ],
+        year: "2024",
+      },
     },
   },
 };

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.test.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.test.tsx
@@ -18,11 +18,9 @@ jest.mock("react-router-dom", () => ({
 
 const queryClient = new QueryClient();
 
-beforeEach(() => {
-  useApiMock({});
-});
 describe("Test CombinedRatesMeasure", () => {
-  it("renders", () => {
+  it("renders", async () => {
+    useApiMock({});
     render(
       <QueryClientProvider client={queryClient}>
         <RouterWrappedComp>
@@ -44,6 +42,7 @@ describe("Test CombinedRatesMeasure", () => {
 
 describe("Test accessibility", () => {
   it("passes a11y tests", async () => {
+    useApiMock({});
     const { container } = render(
       <QueryClientProvider client={queryClient}>
         <RouterWrappedComp>

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import { DataSourceInformationBanner } from "shared/commonQuestions/DataSouceInformationBanner/DataSourceInformationBanner";
 import { useGetRate } from "hooks/api";
 import { CombinedRateNDR } from "shared/commonQuestions/CombinedRateNDR/CombinedRateNDR";
+import { LoadingWrapper } from "components";
 
 interface Props {
   year: string;
@@ -31,7 +32,6 @@ export const CombinedRatesMeasure = ({
     coreSet: combinedCoreSetAbbr,
     year,
   });
-  const item = data?.Item;
   return (
     <QMR.StateLayout
       breadcrumbItems={[
@@ -71,8 +71,12 @@ export const CombinedRatesMeasure = ({
           </CUI.Link>
         </CUI.ListItem>
       </CUI.UnorderedList>
-      <DataSourceInformationBanner data={item?.data!} />
-      <CombinedRateNDR json={item!} />
+      <LoadingWrapper isLoaded={!!data}>
+        {data?.Item?.data && (
+          <DataSourceInformationBanner data={data.Item.data} />
+        )}
+        {data?.Item && <CombinedRateNDR json={data.Item} />}
+      </LoadingWrapper>
     </QMR.StateLayout>
   );
 };

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -2,7 +2,7 @@ import * as QMR from "components";
 import * as CUI from "@chakra-ui/react";
 import { useParams } from "react-router-dom";
 import { DataSourceInformationBanner } from "shared/commonQuestions/DataSouceInformationBanner/DataSourceInformationBanner";
-import { useGetRate } from "hooks/api/useGetRate";
+import { useGetRate } from "hooks/api";
 import { CombinedRateNDR } from "shared/commonQuestions/CombinedRateNDR/CombinedRateNDR";
 
 interface Props {
@@ -72,7 +72,7 @@ export const CombinedRatesMeasure = ({
         </CUI.ListItem>
       </CUI.UnorderedList>
       <DataSourceInformationBanner data={item?.data!} />
-      <CombinedRateNDR json={data?.Item} />
+      <CombinedRateNDR json={item!} />
     </QMR.StateLayout>
   );
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The BO's want the table in Combined Rates to display the labels of the N/D/R set the same way it is listed in the Performance Measure section. This PR will address that.

How this works is we grab the categories and qualifies from the rateLabelText of whatever year the user is looking at by doing a semi-dynamic import:
![Screenshot 2024-07-10 at 4 14 34 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/d95dd179-0dd2-49cb-9209-5d1e9e734e16)

Then we build an ordered array containing the uid and do a sort to reorganize the table to match the N/D/R order in the PM section.
![Screenshot 2024-07-10 at 2 50 03 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/26dfe58a-b162-4d5d-ae7b-3b9077554536)

How the data looks in the Measure (example AMM-AD):
![Screenshot 2024-07-10 at 2 56 39 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/44f6b6cf-3c79-45e7-a3c9-47c1a8d0a4f8)

Currently what it's doing:
![Screenshot 2024-07-10 at 2 56 19 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/d129024b-2cf4-471f-9cbe-2983ae0bc100)

What it should look like:
![Screenshot 2024-07-10 at 2 56 59 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/127151429/0847e68a-b526-4d97-8e2f-816f85313a78)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3782

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d1bhfisusdxz9x.cloudfront.net/

1) Sign into QMR, any user with combined rates. i.e. [stateuser@test.com](mailto:stateuser@test.com)
2) Fill in N/D/R information for any of these measures: AMM-AD, FUM-AD, IET-AD, APM-CH, TFL-CH
3) Save your data
4) Go to the Combined Rates page and check that the combine rates - N/D/R table is the same order wise as the measure's page.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
