### PR TITLE
CMDCT-3790: fixing AIF-HH and IU-HH measures for NC

### DIFF
--- a/services/ui-src/src/measures/2024/shared/globalValidations/ComplexValidations/ComplexNoNonZeroNumOrDenom/index.tsx
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/ComplexValidations/ComplexNoNonZeroNumOrDenom/index.tsx
@@ -16,7 +16,7 @@ export const ComplexNoNonZeroNumOrDenomOMS = (
       errorArray.push(
         ...ComplexNoNonZeroNumOrDenom(
           [],
-          [{ description: key, rate: [...rateData[key]["OPM"]] }],
+          [{ description: key, rate: rateData[key] }],
           ndrFormulas,
           `${errorLocation} - ${key}`
         )
@@ -74,7 +74,7 @@ export const ComplexNoNonZeroNumOrDenom = (
     }
   }
   OPM &&
-    OPM.forEach((performanceMeasure: any) => {
+    Object.keys(OPM).forEach((performanceMeasure: any) => {
       performanceMeasure.rate?.forEach((rate: any) => {
         if (parseFloat(rate.numerator) === 0 && parseFloat(rate.rate) !== 0) {
           nonZeroRateError = true;


### PR DESCRIPTION
### Description
There was an issue with certain Health Home measures for all years such as AIF-HH and IU-HH where if you selected "Other" for Measurement Specification, filled out the form and filled out some of the Optional Measure Stratification rates, the measure would validate successfully but it would fail to complete with an error in the console:
<img width="299" alt="Screenshot 2024-07-11 at 2 28 21 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/16945230/2683d547-aac2-4a2e-b444-985b7b668591">

The cause of this bug is that during the validation process, we were attempting to iterate an object and the object we were trying to iterate over never existed in the first place.

My updates here are simple, I changed to pass in the correct object, and then iterate over the object with Object.keys. This fixed the console error and now the measure can be completed successfully. 

---
### How to test
1. Sign into a state that has Health Home coreset (stateuserNC@test.com or stateuserDC@test.com are two that I know of)
2. Click on the Health Home coreset and navigate to either the AIF-HH or the IU-HH measure
3. Fill out the form with "Other" selected for Measurement Specification
4. When you get to the Optional Measure Stratification, fill out at least one of the fields for Race, Ethnicity, etc.
5. Validate the measure and make sure there is no console error like the one in the description
6. Complete the measure and make sure that the measure truly completes without the console error in the description
8. do some additional testing to make sure that validation for the rates still works as expected
9. repeat steps 1-8 for each year (i'm pretty sure only DC has HH for each year so you'll have to use DC user)
