### PR TITLE
[QMR] Combined Rates - Track CoreSet Tab Selection

### DIFF
--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -16,6 +16,20 @@ const CoreSetSuffixRecord: Record<string, string> = {
   CH: "CCS",
 };
 
+const getPathToCombinedRatesTab = (
+  state: string,
+  year: string,
+  coreSetAbbr: string
+) => {
+  if (coreSetAbbr === "ACS") {
+    return `/${state}/${year}/combined-rates?tab=adult`;
+  } else if (coreSetAbbr === "CCS") {
+    return `/${state}/${year}/combined-rates?tab=child`;
+  } else {
+    return `/${state}/${year}/combined-rates`;
+  }
+};
+
 export const CombinedRatesMeasure = ({
   year,
   measureName,
@@ -35,7 +49,10 @@ export const CombinedRatesMeasure = ({
   return (
     <QMR.StateLayout
       breadcrumbItems={[
-        { path: `/${state}/${year}/combined-rates`, name: `FFY ${year}` },
+        {
+          path: getPathToCombinedRatesTab(state!, year, combinedCoreSetAbbr),
+          name: `FFY ${year}`,
+        },
         {
           path: `/${state}/${year}`,
           name: `${measure} Combined Rates`,

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -4,7 +4,7 @@ import * as QMR from "components";
 import { useGetMeasures } from "hooks/api";
 import { AnyObject, CoreSetAbbr, MeasureData, coreSetType } from "types";
 import { measureDescriptions } from "measures/measureDescriptions";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import { MeasureTableItem } from "components/Table/types";
 import { useFlags } from "launchdarkly-react-client-sdk";
 
@@ -83,6 +83,7 @@ export const CombinedRatesPage = () => {
   );
   const coreSetTabs = GetCoreSetTabs(coreSetsAbbr);
   const { state, year } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   let coreSetData = coreSetTabs.map((coreSet) =>
     GetMeasuresByCoreSet(coreSet.abbr, state!, year!)
   );
@@ -115,7 +116,14 @@ export const CombinedRatesPage = () => {
           Instructions for the user - includes how to interpret the page and
           what they need to do to see rates (i.e. complete all measures)
         </CUI.Text>
-        <CUI.Tabs width="100%" variant="unstyled">
+        <CUI.Tabs
+          width="100%"
+          variant="unstyled"
+          onChange={(index) =>
+            setSearchParams({ tab: index == 0 ? "child" : "adult" })
+          }
+          defaultIndex={searchParams.get("tab") === "adult" ? 1 : 0}
+        >
           <CUI.TabList>
             {coreSetTabs.map((coreSet) => (
               <CUI.Tab


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3768

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Click the View Combined Rates button (top right), and confirm that the page defaults to the "Child Core Set" tab view.
2. Switch between the two tabs and confirm that the parameter in the URL changes appropriately 
3. Click a measure. When you click the back button, you should return to the child tab if you are looking at a child measure, and you should return to the adult tab if you are looking at an adult measure. There's two ways to return to this page - a) with the browser back button and b) the back arrow button in the header. Confirm that the two ways of going back result in the same experience and take you back to the appropriate tab. 
4. Confirm that there are no console errors or warnings

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
