### PR TITLE
CMDCT-3822: removing particular measures for combined rates page and updating helper text to reflext the removed measures

### DIFF
--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -9,6 +9,7 @@ import { MeasureTableItem } from "components/Table/types";
 import { useFlags } from "launchdarkly-react-client-sdk";
 
 const measuresWithoutPerformanceData = [
+  "CSQ",
   "CPC-CH",
   "LBW-CH",
   "LRCD-CH",
@@ -55,10 +56,7 @@ const GetMeasuresByCoreSet = (coreSet: string, state: string, year: string) => {
     ?.filter(
       // filter out the coreset qualifiers (CSQ) and also filter out
       // the measures that are not asked to report performance measure data
-      (item) =>
-        item.measure &&
-        item.measure !== "CSQ" &&
-        !measuresWithoutPerformanceData.includes(item.measure)
+      (item) => !measuresWithoutPerformanceData.includes(item.measure)
     )
     .sort((a, b) => a?.measure?.localeCompare(b?.measure));
 

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -45,8 +45,15 @@ const GetMeasuresByCoreSet = (coreSet: string, state: string, year: string) => {
   const measures = data?.Items as MeasureData[];
   const formatted = measures
     ?.filter(
-      // filter out the coreset qualifiers
-      (item) => item.measure && item.measure !== "CSQ"
+      // filter out the coreset qualifiers and measures where states aren't asked to report measure data
+      (item) =>
+        item.measure &&
+        item.measure !== "CSQ" &&
+        item.measure !== "CPC-CH" &&
+        item.measure !== "LBW-CH" &&
+        item.measure !== "LRCD-CH" &&
+        item.measure !== "CPA-AD" &&
+        item.measure !== "NCIIDD-AD"
     )
     .sort((a, b) => a?.measure?.localeCompare(b?.measure));
 
@@ -113,8 +120,15 @@ export const CombinedRatesPage = () => {
           Core Set Measures Combined Rates
         </CUI.Heading>
         <CUI.Text>
-          Instructions for the user - includes how to interpret the page and
-          what they need to do to see rates (i.e. complete all measures)
+          Click into a measure below to preview the preliminary combined
+          Medicaid and CHIP rate. Please complete the measure in both the
+          Medicaid and CHIP reports to ensure the combined rate is complete.
+          <br />
+          <br />
+          The following measures are excluded from the combined rates page
+          because states are not asked to report performance measure data for
+          these measures for FFY 2024 Core Set reporting in the online reporting
+          system: CPC-CH, LBW-CH, LRCD-CH, CPA-AD, NCIIDD-AD
         </CUI.Text>
         <CUI.Tabs
           width="100%"

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -8,14 +8,7 @@ import { Link, useParams, useSearchParams } from "react-router-dom";
 import { MeasureTableItem } from "components/Table/types";
 import { useFlags } from "launchdarkly-react-client-sdk";
 
-const measuresWithoutPerformanceData = [
-  "CSQ",
-  "CPC-CH",
-  "LBW-CH",
-  "LRCD-CH",
-  "CPA-AD",
-  "NCIIDD-AD",
-];
+const measuresWithoutPerformanceData = ["CSQ", "CPC-CH", "CPA-AD"];
 
 const GetColumns = () => {
   return [
@@ -54,9 +47,12 @@ const GetMeasuresByCoreSet = (coreSet: string, state: string, year: string) => {
   const measures = data?.Items as MeasureData[];
   const formatted = measures
     ?.filter(
-      // filter out the coreset qualifiers (CSQ) and also filter out
-      // the measures that are not asked to report performance measure data
-      (item) => !measuresWithoutPerformanceData.includes(item.measure)
+      // filter out all the measures that do not have combined rates:
+      // the coreset qualifiers (CSQ), measures that are autocompleted,
+      // and the measures that are not asked to report performance measure data
+      (item) =>
+        !item.autoCompleted &&
+        !measuresWithoutPerformanceData.includes(item.measure)
     )
     .sort((a, b) => a?.measure?.localeCompare(b?.measure));
 

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -8,6 +8,14 @@ import { Link, useParams, useSearchParams } from "react-router-dom";
 import { MeasureTableItem } from "components/Table/types";
 import { useFlags } from "launchdarkly-react-client-sdk";
 
+const measuresWithoutPerformanceData = [
+  "CPC-CH",
+  "LBW-CH",
+  "LRCD-CH",
+  "CPA-AD",
+  "NCIIDD-AD",
+];
+
 const GetColumns = () => {
   return [
     {
@@ -45,15 +53,12 @@ const GetMeasuresByCoreSet = (coreSet: string, state: string, year: string) => {
   const measures = data?.Items as MeasureData[];
   const formatted = measures
     ?.filter(
-      // filter out the coreset qualifiers and measures where states aren't asked to report measure data
+      // filter out the coreset qualifiers (CSQ) and also filter out
+      // the measures that are not asked to report performance measure data
       (item) =>
         item.measure &&
         item.measure !== "CSQ" &&
-        item.measure !== "CPC-CH" &&
-        item.measure !== "LBW-CH" &&
-        item.measure !== "LRCD-CH" &&
-        item.measure !== "CPA-AD" &&
-        item.measure !== "NCIIDD-AD"
+        !measuresWithoutPerformanceData.includes(item.measure)
     )
     .sort((a, b) => a?.measure?.localeCompare(b?.measure));
 
@@ -123,8 +128,8 @@ export const CombinedRatesPage = () => {
           Click into a measure below to preview the preliminary combined
           Medicaid and CHIP rate. Please complete the measure in both the
           Medicaid and CHIP reports to ensure the combined rate is complete.
-          <br />
-          <br />
+        </CUI.Text>
+        <CUI.Text>
           The following measures are excluded from the combined rates page
           because states are not asked to report performance measure data for
           these measures for FFY 2024 Core Set reporting in the online reporting


### PR DESCRIPTION
### Description
Simple PR to filter out measures that should not be displayed on combined rates page and then updated helper text to reflect removed measures

---
### How to test
1. On coreset page, select View Combined Rates
2. Confirm that the text under Core Set Measures Combined Rates is updated to what is in the [ticket](https://jiraent.cms.gov/browse/CMDCT-3822)
3. For Child Core Set tab, make sure that CPC-CH, LBW-CH and LRCD-CH measures are no longer displayed in the list
4. For Adult Core Set tab, make sure that CPA-AD, and NCIIDD-AD measures are no longer displayed in the list