### PR TITLE
CMDCT-3821: removing combined rates page for states that do not have combined rates

### DIFF
--- a/services/ui-src/src/utils/constants.ts
+++ b/services/ui-src/src/utils/constants.ts
@@ -60,5 +60,24 @@ export const stateAbbreviations = [
   "WY",
 ];
 
+// Certain states do not have separate chip and medicaid so they do not have combined rates
+export const statesWithoutCombinedRates = [
+  "AK",
+  "AS",
+  "DC",
+  "GU",
+  "HI",
+  "NH",
+  "NM",
+  "NC",
+  "ND",
+  "OH",
+  "PR",
+  "SC",
+  "VI",
+  "VT",
+  "WY",
+];
+
 // BANNERS
 export const bannerId = "admin-banner-id";

--- a/services/ui-src/src/views/CombinedRatesPage/index.test.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.test.tsx
@@ -1,15 +1,16 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import { useApiMock } from "utils/testUtils/useApiMock";
-import { RouterWrappedComp } from "utils/testing";
+import { BrowserRouter as Router } from "react-router-dom";
 import { CombinedRatesPage } from "views";
+import { measureDescriptions } from "measures/measureDescriptions";
 expect.extend(toHaveNoViolations);
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
-  useParams: () => ({
+  useParams: jest.fn().mockReturnValue({
     year: "2024",
-    state: "OH",
+    state: "AL",
   }),
 }));
 
@@ -26,8 +27,7 @@ const useGetMeasuresValues = {
         lastAltered: 1642167976771,
         compoundKey: "AL2024ACSIET-AD",
         measure: "IET-AD",
-        description:
-          "Initiation and Engagement of Alcohol and Other Drug Abuse or Dependence Treatment",
+        description: measureDescriptions[2024]["IET-AD"],
         state: "AL",
         status: "incomplete",
         year: 2024,
@@ -39,8 +39,7 @@ const useGetMeasuresValues = {
         lastAltered: 1642167976771,
         compoundKey: "AL2024ACSAAB-AD",
         measure: "AAB-AD",
-        description:
-          "Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis: Ages 3 Months to 17 Years",
+        description: measureDescriptions[2024]["AAB-AD"],
         state: "AL",
         status: "incomplete",
         year: 2024,
@@ -54,9 +53,9 @@ describe("Test Combined Rates Page", () => {
     const apiData = { useGetMeasuresValues: useGetMeasuresValues };
     useApiMock(apiData);
     render(
-      <RouterWrappedComp>
+      <Router>
         <CombinedRatesPage />
-      </RouterWrappedComp>
+      </Router>
     );
   });
   it("renders", () => {
@@ -90,9 +89,9 @@ describe("Test accessibility", () => {
     const apiData = {};
     useApiMock(apiData);
     const { container } = render(
-      <RouterWrappedComp>
+      <Router>
         <CombinedRatesPage />
-      </RouterWrappedComp>
+      </Router>
     );
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -7,6 +7,7 @@ import { measureDescriptions } from "measures/measureDescriptions";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { MeasureTableItem } from "components/Table/types";
 import { useFlags } from "launchdarkly-react-client-sdk";
+import { statesWithoutCombinedRates } from "views/StateHome";
 
 const GetColumns = () => {
   return [
@@ -90,6 +91,18 @@ export const CombinedRatesPage = () => {
 
   if (isLoading || !data.Items) {
     return <QMR.LoadingWave />;
+  }
+
+  // block display from states that do not have combined rates
+  if (state && statesWithoutCombinedRates.includes(state)) {
+    return (
+      <CUI.Box data-testid="unauthorized-container">
+        <QMR.Notification
+          alertStatus="error"
+          alertTitle="You are not authorized to view this page"
+        />
+      </CUI.Box>
+    );
   }
 
   return (

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -7,7 +7,7 @@ import { measureDescriptions } from "measures/measureDescriptions";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { MeasureTableItem } from "components/Table/types";
 import { useFlags } from "launchdarkly-react-client-sdk";
-import { statesWithoutCombinedRates } from "views/StateHome";
+import { statesWithoutCombinedRates } from "utils";
 
 const GetColumns = () => {
   return [
@@ -99,7 +99,7 @@ export const CombinedRatesPage = () => {
       <CUI.Box data-testid="unauthorized-container">
         <QMR.Notification
           alertStatus="error"
-          alertTitle="You are not authorized to view this page"
+          alertTitle={`Combined rates for ${state} are not supported`}
         />
       </CUI.Box>
     );

--- a/services/ui-src/src/views/StateHome/__tests__/index.test.tsx
+++ b/services/ui-src/src/views/StateHome/__tests__/index.test.tsx
@@ -122,7 +122,7 @@ describe("Test StateHome 2024", () => {
     mockUseUser.mockImplementation(() => useUser);
     mockUseParams.mockReturnValue({
       year: "2024",
-      state: "OH",
+      state: "IN",
     });
     useApiMock({});
     render(testComponent);

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -20,6 +20,7 @@ import { coreSets, CoreSetField } from "shared/coreSetByYear";
 
 import { useFlags } from "launchdarkly-react-client-sdk";
 import { Link } from "react-router-dom";
+import { statesWithoutCombinedRates } from "utils";
 
 interface HandleDeleteData {
   state: string;
@@ -39,25 +40,6 @@ interface IRepYear {
   value: string;
 }
 
-export const statesWithoutCombinedRates = [
-  "AK",
-  "AS",
-  "DC",
-  "GU",
-  "HI",
-  "NH",
-  "NM",
-  "NC",
-  "ND",
-  "CNMI",
-  "OH",
-  "PR",
-  "SC",
-  "VI",
-  "VT",
-  "WY",
-];
-
 const ReportingYear = () => {
   const navigate = useNavigate();
   const { state, year } = useParams();
@@ -67,8 +49,6 @@ const ReportingYear = () => {
   // display the Combined Rates button for those states
   const showCombinedRatesButton =
     state && !statesWithoutCombinedRates.includes(state);
-
-  console.log(state);
 
   let reportingyearOptions: IRepYear[] =
     reportingYears && reportingYears.length

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -39,11 +39,36 @@ interface IRepYear {
   value: string;
 }
 
+export const statesWithoutCombinedRates = [
+  "AK",
+  "AS",
+  "DC",
+  "GU",
+  "HI",
+  "NH",
+  "NM",
+  "NC",
+  "ND",
+  "CNMI",
+  "OH",
+  "PR",
+  "SC",
+  "VI",
+  "VT",
+  "WY",
+];
+
 const ReportingYear = () => {
   const navigate = useNavigate();
   const { state, year } = useParams();
   const { data: reportingYears } = useGetReportingYears();
   const releasedTwentyTwentyFour = useFlags()?.["release2024"];
+  // Certain states do not have separate chip and medicaid so we will not
+  // display the Combined Rates button for those states
+  const showCombinedRatesButton =
+    state && !statesWithoutCombinedRates.includes(state);
+
+  console.log(state);
 
   let reportingyearOptions: IRepYear[] =
     reportingYears && reportingYears.length
@@ -86,7 +111,7 @@ const ReportingYear = () => {
           </option>
         ))}
       </CUI.Select>
-      {year === "2024" && (
+      {year === "2024" && showCombinedRatesButton && (
         <CUI.Box mt="22px">
           <Link
             to={`/${state}/${year}/combined-rates`}


### PR DESCRIPTION
### Description
Certain states do not have separate medicaid and chip measures so they do not need access to combined rates page. This PR removes the "View Combined Rates" button from those state coreset pages.

It also gives users from said states an unauthorized error if they happen to navigate manually to the /combined-rates page:
![Screenshot 2024-07-23 at 10 32 26 AM](https://github.com/user-attachments/assets/2028ce9c-db7b-4b1d-a9a9-c47b045b351d)

---
### How to test
1. Log in as adminuser@test.com
2. Select any of the following states: AK, AS, DC, GU, HI, NH, NM, NC, ND, OH, PR, SC, VI, VT or WY
3. Confirm that when you get to the state coreset homepage, there is no "View Combined Rates" button
4. Navigate manually to `http://<url>/<STATE>/2024/combined-rates` and make sure that you see the unauthorized error in the screenshot above
