### PR TITLE
CMDCT-3853: updating performance measure warning when checkbox is checked but data isnt filled out

### DIFF
--- a/services/ui-src/src/measures/2024/shared/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
@@ -52,7 +52,7 @@ export const ComplexValidateDualPopInformation = (
   if (dualEligible && filledInData.length === 0) {
     errorArray.push({
       errorLocation: "Performance Measure",
-      errorMessage: `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for ${errorReplacementText}`,
+      errorMessage: `Individuals Dually Eligible for Medicare and Medicaid" is selected in the "Definition of Denominator" question but you are missing performance measure data for ${errorReplacementText}`,
       errorType: "Warning",
     });
   }

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateDualPopInformation/index.test.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateDualPopInformation/index.test.ts
@@ -83,7 +83,7 @@ describe("Testing Dual Population Selection Validation", () => {
     expect(errors.length).toBe(1);
     expect(errors[0].errorLocation).toBe("Performance Measure");
     expect(errors[0].errorMessage).toBe(
-      `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for Age 65 and Older`
+      `Individuals Dually Eligible for Medicare and Medicaid" is selected in the "Definition of Denominator" question but you are missing performance measure data for Age 65 and Older`
     );
   });
 
@@ -99,7 +99,7 @@ describe("Testing Dual Population Selection Validation", () => {
     expect(errors.length).toBe(1);
     expect(errors[0].errorLocation).toBe("Performance Measure");
     expect(errors[0].errorMessage).toBe(
-      `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for TestLabel`
+      `Individuals Dually Eligible for Medicare and Medicaid" is selected in the "Definition of Denominator" question but you are missing performance measure data for TestLabel`
     );
   });
 

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateDualPopInformation/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateDualPopInformation/index.ts
@@ -8,7 +8,7 @@ const validateDualPopInformationPMErrorMessage = (
   if (!dualEligible) {
     return `Information has been included in the ${errorReplacementText} Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing`;
   } else {
-    return `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for ${errorReplacementText}`;
+    return `Individuals Dually Eligible for Medicare and Medicaid" is selected in the "Definition of Denominator" question but you are missing performance measure data for ${errorReplacementText}`;
   }
 };
 


### PR DESCRIPTION
### Description
updating performance measure warning when checkbox is checked but num/denom/rate data for 65 and older isn't filled out

---
### How to test
1. Navigate to any 2024 measure and fill out the form. When at Definition of Population Included in the Measure section, make sure to select the `Individuals Dually Eligible for Medicare and Medicaid`
2. When filling out the numerator/denominator/rate section, DO NOT fill out the Age 65 and Older section
3. Finish filling out the form and hit the Validate button
4. You should now see the following error with the exact wording on the screenshot: 
![Screenshot 2024-07-23 at 3 44 44 PM](https://github.com/user-attachments/assets/ba6607e0-2194-4d58-9df2-f6b8d3d6e890)
