### PR TITLE
Combine Rates - Hybrid Data Source Only 

### DIFF
--- a/services/app-api/handlers/rate/calculations/adminstrativeCalculation.test.ts
+++ b/services/app-api/handlers/rate/calculations/adminstrativeCalculation.test.ts
@@ -5,53 +5,41 @@ import { DataSource } from "./types";
 
 describe("Test administrative calculation class", () => {
   it("Test default rate calculation", () => {
-    const adminCalc = new AdminstrativeCalculation();
-    const combinedRates = adminCalc.calculate(
-      "BCS-AD",
-      formatMeasureData(testData).map((data: any) => data.rates)
-    );
+    const adminCalc = new AdminstrativeCalculation("BCS-AD");
+    const combinedRates = adminCalc.calculate(formatMeasureData(testData));
     expect(combinedRates.rates[0].numerator).toBe("6");
     expect(combinedRates.rates[0].denominator).toBe("8");
     expect(combinedRates.rates[0].rate).toBe("75.0");
   });
   it("Test rate calculation if measure is AMB", () => {
-    const adminCalc = new AdminstrativeCalculation();
-    const combinedRates = adminCalc.calculate(
-      "AMB-AD",
-      formatMeasureData(testData).map((data: any) => data.rates)
-    );
+    const adminCalc = new AdminstrativeCalculation("AMB-AD");
+    const combinedRates = adminCalc.calculate(formatMeasureData(testData));
     expect(combinedRates.rates[0].numerator).toBe("6");
     expect(combinedRates.rates[0].denominator).toBe("8");
     expect(combinedRates.rates[0].rate).toBe("750.0");
   });
   it("Test rate calculation if measure is PQI", () => {
-    const adminCalc = new AdminstrativeCalculation();
-    const combinedRates = adminCalc.calculate(
-      "PQI01-AD",
-      formatMeasureData(testData).map((data: any) => data.rates)
-    );
+    const adminCalc = new AdminstrativeCalculation("PQI01-AD");
+    const combinedRates = adminCalc.calculate(formatMeasureData(testData));
     expect(combinedRates.rates[0].numerator).toBe("6");
     expect(combinedRates.rates[0].denominator).toBe("8");
     expect(combinedRates.rates[0].rate).toBe("75000.0");
   });
   it("Test rate calculation if measure is AAB", () => {
-    const adminCalc = new AdminstrativeCalculation();
-    const combinedRates = adminCalc.calculate(
-      "AAB-AD",
-      formatMeasureData(testData).map((data: any) => data.rates)
-    );
+    const adminCalc = new AdminstrativeCalculation("AAB-AD");
+    const combinedRates = adminCalc.calculate(formatMeasureData(testData));
     expect(combinedRates.rates[0].numerator).toBe("6");
     expect(combinedRates.rates[0].denominator).toBe("8");
     expect(combinedRates.rates[0].rate).toBe("25.0");
   });
   it("Return true if data source is administrative/EHR & not hybrid", () => {
-    const adminCalc = new AdminstrativeCalculation();
+    const adminCalc = new AdminstrativeCalculation("AAB-AD");
     const check = adminCalc.check(formatMeasureData(testData));
     expect(check).toBe(true);
   });
   it("Return false if data source has a hybrid", () => {
-    const adminCalc = new AdminstrativeCalculation();
-    testData[0].data.DataSource.push(DataSource.Hybrid);
+    const adminCalc = new AdminstrativeCalculation("AAB-AD");
+    testData[0].data?.DataSource!.push(DataSource.Hybrid);
     const check = adminCalc.check(formatMeasureData(testData));
     expect(check).toBe(false);
   });

--- a/services/app-api/handlers/rate/calculations/adminstrativeCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/adminstrativeCalculation.ts
@@ -31,11 +31,6 @@ export class AdminstrativeCalculation extends RateCalculation {
     const medicaidSources =
       arr.find((data) => data.column === "Medicaid")?.dataSource ?? [];
 
-    // If neither measure has any data source, we will not use this calculation
-    if (chipSources.length === 0 && medicaidSources.length === 0) {
-      return false;
-    }
-
     // If the user had selected hybrid as a data source, we will not use this calculation
     const isHybrid = [chipSources, medicaidSources].some((srcs) => {
       return (srcs as string[])?.includes(DataSource.Hybrid);
@@ -45,17 +40,7 @@ export class AdminstrativeCalculation extends RateCalculation {
       return false;
     }
 
-    return this.dataSrcMap.some((dataSrc) => {
-      // If a measure has no data sources, .every() returns true
-      // This is good because we still want to calculate even if only one measure is complete.
-      const chipSourcesMatch = chipSources.every((chipSrc) =>
-        dataSrc.CHIP.includes(chipSrc)
-      );
-      const medicaidSourcesMatch = medicaidSources.every((medSrc) =>
-        dataSrc.Medicaid.includes(medSrc)
-      );
-      return chipSourcesMatch && medicaidSourcesMatch;
-    });
+    return super.check(arr);
   }
 
   getFormula(measure: string): Function {

--- a/services/app-api/handlers/rate/calculations/hybridCalculation.test.ts
+++ b/services/app-api/handlers/rate/calculations/hybridCalculation.test.ts
@@ -1,0 +1,121 @@
+import { testData } from "../../../test-util/testData";
+import { formatMeasureData } from "../shared/calculateAndPutRate";
+import { HybridCalculation } from "./hybridCalculation";
+import { DataSource } from "./types";
+
+const hybridData = [
+  {
+    DataSource: [DataSource.Hybrid],
+    DataSourceSelections: [],
+    PerformanceMeasure: {
+      rates: {
+        DFukSh: [
+          {
+            uid: "DFukSh.g91VU9",
+            label: "Ages 18 to 64",
+            category: "Effective Acute Phase Treatment",
+            rate: "60.1",
+            numerator: "247",
+            denominator: "411",
+          },
+        ],
+      },
+    },
+    HybridMeasurePopulationIncluded: "10000",
+  },
+  {
+    DataSource: [DataSource.Hybrid],
+    DataSourceSelections: [],
+    PerformanceMeasure: {
+      rates: {
+        DFukSh: [
+          {
+            uid: "DFukSh.g91VU9",
+            label: "Ages 18 to 64",
+            category: "Effective Acute Phase Treatment",
+            rate: "80.0",
+            numerator: "329",
+            denominator: "411",
+          },
+        ],
+      },
+    },
+    HybridMeasurePopulationIncluded: "25000",
+  },
+];
+
+describe("Test hybrid calculation class", () => {
+  it("With no hybrid data source & no MEP", () => {
+    const hybridCalc = new HybridCalculation("IMA-CH");
+    const combinedRates = hybridCalc.calculate(formatMeasureData(testData));
+    expect(combinedRates.rates[0]).not.toHaveProperty("rate");
+    expect(combinedRates.rates[0]).not.toHaveProperty("numerator");
+    expect(combinedRates.rates[0]).not.toHaveProperty("denominator");
+    expect(combinedRates.rates[0]["weighted rate"]).toBe("");
+  });
+
+  //order matters when running these test
+  describe("With hybrid data source", () => {
+    it("With both hybrid data source and MEP filled", () => {
+      testData.map((item, idx) => {
+        item.data = hybridData[idx];
+      });
+      const hybridCalc = new HybridCalculation("IMA-CH");
+      const combinedRates = hybridCalc.calculate(formatMeasureData(testData));
+      expect(combinedRates.rates[0]).not.toHaveProperty("rate");
+      expect(combinedRates.rates[0]).not.toHaveProperty("numerator");
+      expect(combinedRates.rates[0]).not.toHaveProperty("denominator");
+      expect(combinedRates.rates[0]["weighted rate"]).toBe("74.3");
+    });
+
+    it("With both hybrid data source and one MEP filled", () => {
+      hybridData[1].HybridMeasurePopulationIncluded = "";
+      const hybridCalc = new HybridCalculation("IMA-CH");
+      const combinedRates = hybridCalc.calculate(formatMeasureData(testData));
+      expect(combinedRates.rates[0]).not.toHaveProperty("rate");
+      expect(combinedRates.rates[0]).not.toHaveProperty("numerator");
+      expect(combinedRates.rates[0]).not.toHaveProperty("denominator");
+      expect(combinedRates.rates[0]["weighted rate"]).toBe("");
+    });
+
+    it("With one hybrid data source and one MEP filled", () => {
+      //remove the second array so that there is only 1 measure to be checked
+      testData.pop();
+
+      //set the test data to a hybrid measure
+      testData[0].data = hybridData[0];
+      const hybridCalc = new HybridCalculation("IMA-CH");
+      const combinedRates = hybridCalc.calculate(formatMeasureData(testData));
+      expect(combinedRates.rates[0].numerator).toBe(
+        hybridData[0].PerformanceMeasure.rates.DFukSh[0].numerator
+      );
+      expect(combinedRates.rates[0].denominator).toBe(
+        hybridData[0].PerformanceMeasure.rates.DFukSh[0].denominator
+      );
+      expect(combinedRates.rates[0].rate).toBe(
+        hybridData[0].PerformanceMeasure.rates.DFukSh[0].rate
+      );
+      expect(combinedRates.rates[0]["weighted rate"]).toBe("60.1");
+    });
+
+    it("With one hybrid data source and no MEP filled", () => {
+      //clear out the mep data
+      hybridData[0].HybridMeasurePopulationIncluded = "";
+      //set the test data to a hybrid measure
+      testData[0].data = hybridData[0];
+
+      const hybridCalc = new HybridCalculation("IMA-CH");
+      const combinedRates = hybridCalc.calculate(formatMeasureData(testData));
+      expect(combinedRates.rates[0].numerator).toBe(
+        hybridData[0].PerformanceMeasure.rates.DFukSh[0].numerator
+      );
+      expect(combinedRates.rates[0].denominator).toBe(
+        hybridData[0].PerformanceMeasure.rates.DFukSh[0].denominator
+      );
+      expect(combinedRates.rates[0].rate).toBe(
+        hybridData[0].PerformanceMeasure.rates.DFukSh[0].rate
+      );
+      expect(combinedRates.rates[0]["weighted rate"]).toBe("");
+    });
+  });
+});

--- a/services/app-api/handlers/rate/calculations/hybridCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/hybridCalculation.ts
@@ -22,8 +22,9 @@ export class HybridCalculation extends RateCalculation {
       return rates?.reduce((prev, curr) => {
         const calculable = !(!prev["weighted rate"] || !curr["weighted rate"]);
         const weightedRate = calculable
-          ? (
-              Number(prev["weighted rate"]) + Number(curr["weighted rate"])
+          ? fixRounding(
+              Number(prev["weighted rate"]) + Number(curr["weighted rate"]),
+              1
             ).toFixed(1)
           : "";
 
@@ -39,7 +40,7 @@ export class HybridCalculation extends RateCalculation {
 
   getFormula(measure: string): Function {
     return (numerator: number, denominator: number, weight: number) =>
-      fixRounding(weight, 5) * ((numerator / denominator) * 100);
+      fixRounding(weight, 5) * fixRounding((numerator / denominator) * 100, 1);
   }
 
   expandRates(arr: FormattedMeasureData[]) {
@@ -57,7 +58,10 @@ export class HybridCalculation extends RateCalculation {
           rate["weighted rate"] =
             isNaN(weight) || !rate.rate
               ? ""
-              : formula(rate.numerator, rate.denominator, weight).toFixed(1);
+              : fixRounding(
+                  formula(rate.numerator, rate.denominator, weight),
+                  1
+                ).toFixed(1);
           return rate;
         });
       }

--- a/services/app-api/handlers/rate/calculations/hybridCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/hybridCalculation.ts
@@ -1,0 +1,54 @@
+import { StandardRateShape } from "../../../types";
+import { fixRounding } from "../../../utils/constants/math";
+import { RateCalculation } from "./rateCalculation";
+import { DataSource, FormattedMeasureData } from "./types";
+
+export class HybridCalculation extends RateCalculation {
+  dataSrcMap = [
+    {
+      Medicaid: [DataSource.Hybrid],
+      CHIP: [DataSource.Hybrid],
+    },
+    {
+      Medicaid: [DataSource.CaseMagementRecordReview],
+      CHIP: [DataSource.CaseMagementRecordReview],
+    },
+  ];
+
+  sum(arr: StandardRateShape[][], rateFormula: Function) {
+    const measurePopulationTotal = arr.map((rates) => rates);
+
+    return arr?.map((rates) =>
+      rates?.reduce((prev, curr) => {
+        const numerator =
+          Number(prev.numerator ?? 0) + Number(curr.numerator ?? 0);
+        const denominator =
+          Number(prev.denominator ?? 0) + Number(curr.denominator ?? 0);
+        const rate =
+          denominator > 0
+            ? fixRounding(rateFormula(numerator, denominator), 1).toFixed(1) //added for generating trailing zeros
+            : "";
+
+        return {
+          category: prev.category ?? "",
+          label: prev.label ?? "",
+          numerator: numerator.toString(),
+          denominator: denominator.toString(),
+          rate: rate,
+          uid: prev?.uid,
+        };
+      })
+    );
+  }
+
+  getFormula(measure: string): Function {
+    return (
+      numerator: number,
+      denominator: number,
+      measurePopulation: number,
+      totalMeasurePopulation: number
+    ) =>
+      fixRounding(measurePopulation / totalMeasurePopulation, 5) *
+      ((numerator / denominator) * 100);
+  }
+}

--- a/services/app-api/handlers/rate/calculations/hybridCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/hybridCalculation.ts
@@ -15,19 +15,17 @@ export class HybridCalculation extends RateCalculation {
     },
   ];
 
-  sum(arr: StandardRateShape[][], rateFormula: Function) {
-    const measurePopulationTotal = arr.map((rates) => rates);
-
+  sum(arr: StandardRateShape[][]) {
     return arr?.map((rates) =>
       rates?.reduce((prev, curr) => {
         const numerator =
           Number(prev.numerator ?? 0) + Number(curr.numerator ?? 0);
         const denominator =
           Number(prev.denominator ?? 0) + Number(curr.denominator ?? 0);
-        const rate =
-          denominator > 0
-            ? fixRounding(rateFormula(numerator, denominator), 1).toFixed(1) //added for generating trailing zeros
-            : "";
+        const rate = fixRounding(
+          Number(prev.rate) + Number(curr.rate),
+          1
+        ).toFixed(1);
 
         return {
           category: prev.category ?? "",
@@ -50,5 +48,55 @@ export class HybridCalculation extends RateCalculation {
     ) =>
       fixRounding(measurePopulation / totalMeasurePopulation, 5) *
       ((numerator / denominator) * 100);
+  }
+
+  public setFormulaRates(
+    values: {
+      measurePopulation: FormattedMeasureData["measurePopulation"];
+      rates: FormattedMeasureData["rates"];
+    }[],
+    calcFormula: Function
+  ) {
+    const totalMeasurePopulation = values
+      .map((value) => value.measurePopulation)
+      .reduce((prev, curr) => prev + curr!);
+
+    const weightedRates = values
+      .map((value) => {
+        const flattenRates = Object.values(value.rates).flat(2);
+        return flattenRates.map((rate) => {
+          const weightedRates = calcFormula(
+            rate.numerator,
+            rate.denominator,
+            value.measurePopulation,
+            totalMeasurePopulation
+          );
+          return { ...rate, rate: weightedRates };
+        });
+      })
+      .flat(2);
+    return weightedRates;
+  }
+
+  public calculate(
+    measure: string,
+    values: {
+      measurePopulation: FormattedMeasureData["measurePopulation"];
+      rates: FormattedMeasureData["rates"];
+    }[]
+  ) {
+    const formula: Function = this.getFormula(measure);
+    const formulaRates = this.setFormulaRates(values, formula);
+    const uid = formulaRates
+      .filter(
+        (value, index, array) =>
+          array.findIndex((item) => item.uid === value.uid) === index
+      )
+      .map((item) => item.uid);
+    const sumRates = uid.map((id) =>
+      formulaRates.filter((rate) => rate.uid === id)
+    );
+    const total = this.sum(sumRates);
+    return { column: "Combined Rate", rates: total };
   }
 }

--- a/services/app-api/handlers/rate/calculations/index.ts
+++ b/services/app-api/handlers/rate/calculations/index.ts
@@ -1,1 +1,2 @@
 export * from "./adminstrativeCalculation";
+export * from "./hybridCalculation";

--- a/services/app-api/handlers/rate/calculations/rateCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/rateCalculation.ts
@@ -55,11 +55,18 @@ export abstract class RateCalculation {
       })
     );
   }
-  public calculate(measure: string, rates: FormattedMeasureData["rates"][]) {
+
+  public calculate(
+    measure: string,
+    values: {
+      measurePopulation: FormattedMeasureData["measurePopulation"];
+      rates: FormattedMeasureData["rates"];
+    }[]
+  ) {
     const formula: Function = this.getFormula(measure);
-
-    const flattenRates = rates.map((rate) => Object.values(rate)).flat(2);
-
+    const flattenRates = values
+      .map((value) => Object.values(value.rates))
+      .flat(2);
     const uid = flattenRates
       .filter(
         (value, index, array) =>

--- a/services/app-api/handlers/rate/calculations/rateCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/rateCalculation.ts
@@ -4,11 +4,14 @@ import { DataSource, FormattedMeasureData } from "./types";
 
 export abstract class RateCalculation {
   abstract dataSrcMap: { [key in Program]: DataSource[] }[];
+  public measure: string;
 
-  constructor() {}
+  constructor(measure: string) {
+    this.measure = measure;
+  }
   abstract getFormula(measure: string): Function;
 
-  public adjustForDisplay(arr: FormattedMeasureData[]) {
+  public expandRates(arr: FormattedMeasureData[]) {
     return arr;
   }
 
@@ -74,8 +77,8 @@ export abstract class RateCalculation {
     return uid.map((id) => rates.filter((rate) => rate.uid === id));
   }
 
-  public calculate(measure: string, data: FormattedMeasureData[]) {
-    const formula: Function = this.getFormula(measure);
+  public calculate(data: FormattedMeasureData[]) {
+    const formula: Function = this.getFormula(this.measure);
     const rates = data?.map((item) => item.rates);
     const flattenRates = rates.map((rate) => Object.values(rate)).flat(2);
 

--- a/services/app-api/handlers/rate/calculations/types.ts
+++ b/services/app-api/handlers/rate/calculations/types.ts
@@ -19,7 +19,7 @@ export interface FormattedMeasureData {
   dataSourceSelections: NonNullable<
     NonNullable<Measure["data"]>["DataSourceSelections"]
   >;
-  measurePopulation?: number;
+  "measure-eligible population"?: string;
   rates: {
     [key: string]: StandardRateShape[];
   };

--- a/services/app-api/handlers/rate/calculations/types.ts
+++ b/services/app-api/handlers/rate/calculations/types.ts
@@ -19,7 +19,7 @@ export interface FormattedMeasureData {
   dataSourceSelections: NonNullable<
     NonNullable<Measure["data"]>["DataSourceSelections"]
   >;
-  measurePopulation?: string;
+  measurePopulation: number;
   rates: {
     [key: string]: StandardRateShape[];
   };

--- a/services/app-api/handlers/rate/calculations/types.ts
+++ b/services/app-api/handlers/rate/calculations/types.ts
@@ -19,7 +19,7 @@ export interface FormattedMeasureData {
   dataSourceSelections: NonNullable<
     NonNullable<Measure["data"]>["DataSourceSelections"]
   >;
-  measurePopulation: number;
+  measurePopulation?: number;
   rates: {
     [key: string]: StandardRateShape[];
   };

--- a/services/app-api/handlers/rate/calculations/types.ts
+++ b/services/app-api/handlers/rate/calculations/types.ts
@@ -4,6 +4,7 @@ export enum DataSource {
   Administrative = "AdministrativeData",
   EHR = "ElectronicHealthRecords",
   Hybrid = "HybridAdministrativeandMedicalRecordsData",
+  CaseMagementRecordReview = "Casemanagementrecordreview",
 }
 
 export enum UniqMeasureAbbr {
@@ -18,6 +19,7 @@ export interface FormattedMeasureData {
   dataSourceSelections: NonNullable<
     NonNullable<Measure["data"]>["DataSourceSelections"]
   >;
+  measurePopulation?: string;
   rates: {
     [key: string]: StandardRateShape[];
   };

--- a/services/app-api/handlers/rate/shared/calculateAndPutRate.ts
+++ b/services/app-api/handlers/rate/shared/calculateAndPutRate.ts
@@ -16,15 +16,17 @@ export const formatMeasureData = (data: (Types.Measure | undefined)[]) => {
     const column = Types.Program[item?.coreSet.at(-1) as "M" | "C"];
     const dataSource = item?.data?.DataSource ?? [];
     const dataSourceSelections = item?.data?.DataSourceSelections ?? [];
-    const measurePopulation =
-      parseInt(item?.data?.HybridMeasurePopulationIncluded!) ?? 0;
     const rates = item?.data?.PerformanceMeasure?.rates ?? {};
 
     return {
       column,
       dataSource,
       dataSourceSelections,
-      measurePopulation,
+      ...(item?.data?.HybridMeasurePopulationIncluded && {
+        measurePopulation: parseInt(
+          item?.data?.HybridMeasurePopulationIncluded
+        ),
+      }),
       rates,
     };
   });

--- a/services/app-api/handlers/rate/shared/calculateAndPutRate.ts
+++ b/services/app-api/handlers/rate/shared/calculateAndPutRate.ts
@@ -1,21 +1,31 @@
 import * as Types from "../../../types";
 import { putToTable, getMeasureByCoreSet } from "../../../storage/table";
 import { RateCalculation } from "../calculations/rateCalculation";
-import { AdminstrativeCalculation } from "../calculations";
+import { AdminstrativeCalculation, HybridCalculation } from "../calculations";
 import { MeasureParameters } from "../../../types";
 import { FormattedMeasureData } from "../calculations/types";
 
 //add new calculations to this array
-const dataSrcCalculations: RateCalculation[] = [new AdminstrativeCalculation()];
+const dataSrcCalculations: RateCalculation[] = [
+  new AdminstrativeCalculation(),
+  new HybridCalculation(),
+];
 
 export const formatMeasureData = (data: (Types.Measure | undefined)[]) => {
   return data.map((item) => {
     const column = Types.Program[item?.coreSet.at(-1) as "M" | "C"];
     const dataSource = item?.data?.DataSource ?? [];
     const dataSourceSelections = item?.data?.DataSourceSelections ?? [];
+    const measurePopulation = item?.data?.HybridMeasurePopulationIncluded;
     const rates = item?.data?.PerformanceMeasure?.rates ?? {};
 
-    return { column, dataSource, dataSourceSelections, rates };
+    return {
+      column,
+      dataSource,
+      dataSourceSelections,
+      measurePopulation,
+      rates,
+    };
   });
 };
 

--- a/services/app-api/handlers/rate/shared/calculateAndPutRate.ts
+++ b/services/app-api/handlers/rate/shared/calculateAndPutRate.ts
@@ -17,16 +17,23 @@ export const formatMeasureData = (data: (Types.Measure | undefined)[]) => {
     const dataSource = item?.data?.DataSource ?? [];
     const dataSourceSelections = item?.data?.DataSourceSelections ?? [];
     const rates = item?.data?.PerformanceMeasure?.rates ?? {};
+    const measurePopulation = item?.data?.HybridMeasurePopulationIncluded;
+
+    for (const [key, value] of Object.entries(rates)) {
+      rates[key] = value.map((rate) => {
+        return {
+          ...rate,
+          ...(measurePopulation && {
+            "measure-eligible population": measurePopulation,
+          }),
+        };
+      });
+    }
 
     return {
       column,
       dataSource,
       dataSourceSelections,
-      ...(item?.data?.HybridMeasurePopulationIncluded && {
-        measurePopulation: parseInt(
-          item?.data?.HybridMeasurePopulationIncluded
-        ),
-      }),
       rates,
     };
   });
@@ -68,12 +75,7 @@ export const calculateAndPutRate = async (
       calculation
         ? calculation.calculate(
             measure!,
-            validatedData?.map((data) => {
-              return {
-                measurePopulation: data.measurePopulation!,
-                rates: data.rates,
-              };
-            })
+            validatedData?.map((data) => data.rates)
           )
         : {},
     ];

--- a/services/app-api/handlers/rate/shared/calculateAndPutRate.ts
+++ b/services/app-api/handlers/rate/shared/calculateAndPutRate.ts
@@ -16,7 +16,8 @@ export const formatMeasureData = (data: (Types.Measure | undefined)[]) => {
     const column = Types.Program[item?.coreSet.at(-1) as "M" | "C"];
     const dataSource = item?.data?.DataSource ?? [];
     const dataSourceSelections = item?.data?.DataSourceSelections ?? [];
-    const measurePopulation = item?.data?.HybridMeasurePopulationIncluded;
+    const measurePopulation =
+      parseInt(item?.data?.HybridMeasurePopulationIncluded!) ?? 0;
     const rates = item?.data?.PerformanceMeasure?.rates ?? {};
 
     return {
@@ -65,7 +66,12 @@ export const calculateAndPutRate = async (
       calculation
         ? calculation.calculate(
             measure!,
-            validatedData?.map((data) => data.rates)
+            validatedData?.map((data) => {
+              return {
+                measurePopulation: data.measurePopulation!,
+                rates: data.rates,
+              };
+            })
           )
         : {},
     ];

--- a/services/app-api/test-util/testData.ts
+++ b/services/app-api/test-util/testData.ts
@@ -1,5 +1,5 @@
 import { DataSource } from "../handlers/rate/calculations/types";
-import { CoreSetAbbr, MeasureStatus } from "../types";
+import { CoreSetAbbr, Measure, MeasureStatus } from "../types";
 
 export const testData = [
   {
@@ -7,6 +7,7 @@ export const testData = [
     compoundKey: "MA2024ACSCAMM-AD",
     measure: "AMM-AD",
     data: {
+      DataSource: [DataSource.Administrative],
       DataSourceSelections: [],
       PerformanceMeasure: {
         rates: {
@@ -22,15 +23,12 @@ export const testData = [
           ],
         },
       },
-      MeasurementSpecification: "NCQA/HEDIS",
-      DataSource: [DataSource.Administrative],
     },
     year: 2024,
     lastAltered: 1718052665862,
     coreSet: CoreSetAbbr.ACSC,
     state: "MA",
     lastAlteredBy: "Sammy States",
-    reporting: null,
     status: MeasureStatus.INCOMPLETE,
   },
   {
@@ -38,6 +36,7 @@ export const testData = [
     compoundKey: "MA2024ACSMAMM-AD",
     measure: "AMM-AD",
     data: {
+      DataSource: [DataSource.Administrative, DataSource.EHR],
       DataSourceSelections: [],
       PerformanceMeasure: {
         rates: {
@@ -53,15 +52,12 @@ export const testData = [
           ],
         },
       },
-      MeasurementSpecification: "NCQA/HEDIS",
-      DataSource: [DataSource.Administrative, DataSource.EHR],
     },
     year: 2024,
     lastAltered: 1718052680450,
     coreSet: CoreSetAbbr.ACSM,
     state: "MA",
     lastAlteredBy: "Sammy States",
-    reporting: null,
     status: MeasureStatus.INCOMPLETE,
   },
 ];

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -51,6 +51,7 @@ export interface Measure {
         [key: string]: StandardRateShape[];
       };
     };
+    HybridMeasurePopulationIncluded: string;
   };
 }
 

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -22,6 +22,8 @@ export interface StandardRateShape {
   numerator?: string;
   denominator?: string;
   rate?: string;
+  ["measure-eligible population"]?: string;
+  ["weighted rate"]?: string;
 }
 
 export interface Measure {

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -52,7 +52,7 @@ export interface Measure {
         [key: string]: StandardRateShape[];
       };
     };
-    HybridMeasurePopulationIncluded: string;
+    HybridMeasurePopulationIncluded?: string;
   };
 }
 

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -22,7 +22,6 @@ export interface StandardRateShape {
   numerator?: string;
   denominator?: string;
   rate?: string;
-  ["measure-eligible population"]?: string;
   ["weighted rate"]?: string;
 }
 

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -124,10 +124,13 @@ const modifyDisplayByDateSource = (json: CombinedRatePayload) => {
     .flat();
 
   if (dataSources?.includes("HybridAdministrativeandMedicalRecordsData")) {
-    Object.assign(rateComponents, [
-      ...rateComponents,
-      ...hybridRateComponnents,
-    ]);
+    //prevent duplicates during a rerender
+    if (rateComponents.length <= 3) {
+      Object.assign(rateComponents, [
+        ...rateComponents,
+        ...hybridRateComponnents,
+      ]);
+    }
   }
 };
 

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -32,9 +32,10 @@ type Props = {
 
 const verticalTable = (
   table: TableDataShape,
-  rateComponents:
-    | typeof defaultRateComponents
-    | (typeof defaultRateComponents & typeof hybridRateComponents)
+  rateComponents: (
+    | typeof defaultRateComponents[number]
+    | typeof hybridRateComponents[number]
+  )[]
 ) => {
   return (
     <CUI.VStack align="flex-start" mt="4">
@@ -66,9 +67,10 @@ const verticalTable = (
 
 const horizontalTable = (
   table: TableDataShape,
-  rateComponents:
-    | typeof defaultRateComponents
-    | (typeof defaultRateComponents & typeof hybridRateComponents)
+  rateComponents: (
+    | typeof defaultRateComponents[number]
+    | typeof hybridRateComponents[number]
+  )[]
 ) => {
   return (
     <CUI.Table variant="unstyled" mt="4" size="md" verticalAlign="top">
@@ -109,9 +111,7 @@ const getRateComponent = (json: CombinedRatePayload) => {
     "HybridAdministrativeandMedicalRecordsData"
   );
 
-  if (isHybrid) return [...defaultRateComponents, ...hybridRateComponents];
-
-  return defaultRateComponents;
+  return [...defaultRateComponents, ...(isHybrid ? hybridRateComponents : [])];
 };
 
 export const CombinedRateNDR = ({ json }: Props) => {

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateNDR.tsx
@@ -57,7 +57,10 @@ const verticalTable = (
       ))}
       <CUI.List padding="0 0 1rem 2rem">
         <CUI.Text fontWeight="bold" mb="2">
-          {programTypes[2]}: {table["Combined Rate"]?.rate}
+          {programTypes[2]}:{" "}
+          {table["Combined Rate"]?.["weighted rate"] != "-"
+            ? table["Combined Rate"]?.["weighted rate"]
+            : table["Combined Rate"]?.rate}
         </CUI.Text>
       </CUI.List>
       <CUI.Divider borderColor="gray.300" />

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateTypes.ts
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateTypes.ts
@@ -13,6 +13,8 @@ export type RateDataShape = {
   numerator?: string;
   denominator?: string;
   rate?: string;
+  "measure-eligible population": string;
+  "weighted rate"?: string;
 };
 
 export type RateCategoryMap = {
@@ -22,6 +24,7 @@ export type RateCategoryMap = {
 export type SeparatedData = {
   column: Program;
   dataSource: DataSource[];
+  "measure-eligible population": string;
   rates: RateCategoryMap;
 };
 

--- a/services/ui-src/src/shared/commonQuestions/DataSouceInformationBanner/DataSourceInformationBanner.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DataSouceInformationBanner/DataSourceInformationBanner.tsx
@@ -18,7 +18,7 @@ const DataSourceRecord: Record<string, string> = {
 
 export const DataSourceInformationBanner = ({ data }: Props) => {
   const filteredData = columns.map(
-    (column) => data?.find((item) => item?.column === column) ?? {}
+    (column) => data?.find((item) => column.includes(item?.column)) ?? {}
   );
 
   const dataSourceSubsection = (dataSource: string) => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR contains the hybrid measure calculation used in the Combined Rates section. Despite the careful planning withe administrative calculation, we still needed to do a couple of rewrites to accommodate `HybridMeasurePopulationIncluded` field we are pulling from the measures.. Its located in the **Definition of Population Included in the Measure** section.
 
![Screenshot 2024-07-25 at 12 02 40 PM](https://github.com/user-attachments/assets/489a0647-d250-4d94-b063-97bec1b80bea)

**New Feature**
- The Combined Rates N/D/R table will add extra rows based on whether the data source has a hybrid selected.


**Side Issue Fix**: There was an issue with CHIP data source displaying in the data source information banner. It was caused by the naming update from CHIP to Separate CHIP

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3652

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, [stateuser1@test.com](mailto:stateuser1@test.com)
2) Select a Hybrid Measure to fill out, i.e. IMA-CH

Here are the possible state of the table based on what values were entered in.

State 1: No data source selected, no Measure-Eligible Population filled,  Rates filled
![Screenshot 2024-07-25 at 12 06 15 PM](https://github.com/user-attachments/assets/ba39875b-cc02-4006-ad06-6e83843cbe5d)

State 2: Medicaid data source selected, no Measure-Eligible Population filled, Rates filled 
![Screenshot 2024-07-25 at 12 08 08 PM](https://github.com/user-attachments/assets/0e3754d4-5765-4182-ad8f-6be3cbcb4e98)

State 3: Medicaid data source selected, Medicaid Measure-Eligible Population filled, Rates filled 
![Screenshot 2024-07-25 at 12 08 56 PM](https://github.com/user-attachments/assets/5bd2765a-ec8e-44de-9a39-bb4fb861226b)

State 4: Both data source selected, Medicaid Measure-Eligible Population filled, Rates filled
![Screenshot 2024-07-25 at 12 09 20 PM](https://github.com/user-attachments/assets/25ee1c92-4914-4c84-82dd-62ee28983c31)

State 5: Both data source selected, both Measure-Eligible Population filled, Rates filled
![Screenshot 2024-07-25 at 12 09 44 PM](https://github.com/user-attachments/assets/a16f8a50-0ff5-45c0-ab47-fa4679c0982d)


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
