### PR TITLE
Banner - Adult Core Set

### DIFF
--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -19,6 +19,7 @@ import { useQueryClient } from "react-query";
 import { useUser } from "hooks/authHooks";
 import { coreSetTitles } from "shared/coreSetByYear";
 import { Alert } from "@cmsgov/design-system";
+import { parseLabelToHTML } from "utils";
 
 interface HandleDeleteMeasureData {
   coreSet: CoreSetAbbr;
@@ -314,6 +315,7 @@ export const CoreSet = () => {
   );
 
   const coreSetInstructions: { [key: string]: string } = {
+    AC: "Beginning with FFY 2024 reporting, states are required to report the behavioral health measures on the Adult Core Set. The behavioral health measures are denoted as mandatory in the measure list below. More information on mandatory reporting requirements is included in the <a href='https://www.medicaid.gov/sites/default/files/2023-12/sho23005_1.pdf'>Initial Core Set Mandatory Reporting Guidance for the Child and Adult Core Sets</a>.",
     CC: "Beginning with FFY 2024 reporting, states are required to report all of the measures on the Child Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Child and Adult Core Sets.",
     HH: "States with approved Health Home Programs in operation by June 30, 2023 are required to report all of the measures on the Health Home Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Health Home Core Sets.",
   };
@@ -333,7 +335,9 @@ export const CoreSet = () => {
       {Number(year) >= 2024 && coreSetInstructions[coreSetPrefix] && (
         <CUI.Box mb="8">
           <Alert heading="Mandatory Measure Instructions">
-            <CUI.Text>{coreSetInstructions[coreSetPrefix]}</CUI.Text>
+            <CUI.Text>
+              {parseLabelToHTML(coreSetInstructions[coreSetPrefix])}
+            </CUI.Text>
           </Alert>
         </CUI.Box>
       )}

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -315,7 +315,7 @@ export const CoreSet = () => {
   );
 
   const coreSetInstructions: { [key: string]: string } = {
-    AC: "Beginning with FFY 2024 reporting, states are required to report the behavioral health measures on the Adult Core Set. The behavioral health measures are denoted as mandatory in the measure list below. More information on mandatory reporting requirements is included in the <a href='https://www.medicaid.gov/sites/default/files/2023-12/sho23005_1.pdf'>Initial Core Set Mandatory Reporting Guidance for the Child and Adult Core Sets</a>.",
+    AC: "Beginning with FFY 2024 reporting, states are required to report the behavioral health measures on the Adult Core Set. The behavioral health measures are denoted as mandatory in the measure list below. More information on mandatory reporting requirements is included in the <a href='https://www.medicaid.gov/sites/default/files/2023-12/sho23005_1.pdf' target='_blank'>Initial Core Set Mandatory Reporting Guidance for the Child and Adult Core Sets</a>.",
     CC: "Beginning with FFY 2024 reporting, states are required to report all of the measures on the Child Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Child and Adult Core Sets.",
     HH: "States with approved Health Home Programs in operation by June 30, 2023 are required to report all of the measures on the Health Home Core Set. More information on mandatory reporting requirements is included in the Initial Core Set Mandatory Reporting Guidance for the Health Home Core Sets.",
   };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
New mandatory banner added to the top of adult coreset. @ajaitasaini did such a great job setting up the functionality for the banner that adding the language for the adult was very straightforward.

![Screenshot 2024-07-26 at 9 59 15 AM](https://github.com/user-attachments/assets/f40fe8ec-749b-4391-b786-f2e439bdb3d5)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3855

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d10zdtpxg23u5l.cloudfront.net/

1) Sign into QMR, any user
2) Click into the Adult CoreSet
3) Check that the mandatory banner exist, the language matches the jira ticket and the link works

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
