### PR TITLE
CMDCT-3854: Adding mandatory column to 2024 measures table

### DIFF
--- a/services/app-api/handlers/dynamoUtils/measureList.ts
+++ b/services/app-api/handlers/dynamoUtils/measureList.ts
@@ -1195,188 +1195,233 @@ export const measures: Measure = {
     {
       type: "C",
       measure: "AAB-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "ADD-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "AMB-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "AMR-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "APM-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "APP-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "CCP-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "CCW-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "CDF-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "CHL-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "CIS-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "CPC-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "DEV-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "FUA-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "FUH-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "FUM-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "IMA-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "LSC-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "LBW-CH",
+      mandatory: true,
       autocompleteOnCreation: true,
     },
     {
       type: "C",
       measure: "LRCD-CH",
+      mandatory: true,
       autocompleteOnCreation: true,
     },
     {
       type: "C",
       measure: "OEV-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "PPC2-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "SFM-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "TFL-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "W30-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "WCC-CH",
+      mandatory: true,
     },
     {
       type: "C",
       measure: "WCV-CH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "AIF-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "AMB-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "CBP-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "CDF-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "COL-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "FUA-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "FUH-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "FUM-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "IET-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "IU-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "OUD-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "PCR-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "PQI92-HH",
+      mandatory: true,
     },
     {
       type: "H",
       measure: "SS-1-HH",
+      mandatory: true,
       placeholder: true,
     },
     {
       type: "H",
       measure: "SS-2-HH",
+      mandatory: true,
       placeholder: true,
     },
     {
       type: "H",
       measure: "SS-3-HH",
+      mandatory: true,
       placeholder: true,
     },
     {
       type: "H",
       measure: "SS-4-HH",
+      mandatory: true,
       placeholder: true,
     },
     {
       type: "H",
       measure: "SS-5-HH",
+      mandatory: true,
       placeholder: true,
     },
   ],

--- a/services/app-api/handlers/dynamoUtils/measureList.ts
+++ b/services/app-api/handlers/dynamoUtils/measureList.ts
@@ -60,6 +60,7 @@ export interface MeasureMetaData {
   measure: string;
   autocompleteOnCreation?: boolean;
   placeholder?: boolean;
+  mandatory?: boolean;
 }
 
 export const measures: Measure = {
@@ -1054,6 +1055,7 @@ export const measures: Measure = {
     {
       type: "A",
       measure: "AMM-AD",
+      mandatory: true,
     },
     {
       type: "A",
@@ -1082,6 +1084,7 @@ export const measures: Measure = {
     {
       type: "A",
       measure: "CDF-AD",
+      mandatory: true,
     },
     {
       type: "A",
@@ -1106,14 +1109,17 @@ export const measures: Measure = {
     {
       type: "A",
       measure: "FUA-AD",
+      mandatory: true,
     },
     {
       type: "A",
       measure: "FUH-AD",
+      mandatory: true,
     },
     {
       type: "A",
       measure: "FUM-AD",
+      mandatory: true,
     },
     {
       type: "A",
@@ -1122,6 +1128,7 @@ export const measures: Measure = {
     {
       type: "A",
       measure: "HPCMI-AD",
+      mandatory: true,
     },
     {
       type: "A",
@@ -1130,10 +1137,12 @@ export const measures: Measure = {
     {
       type: "A",
       measure: "IET-AD",
+      mandatory: true,
     },
     {
       type: "A",
       measure: "MSC-AD",
+      mandatory: true,
     },
     {
       type: "A",
@@ -1147,6 +1156,7 @@ export const measures: Measure = {
     {
       type: "A",
       measure: "OUD-AD",
+      mandatory: true,
     },
     {
       type: "A",
@@ -1175,10 +1185,12 @@ export const measures: Measure = {
     {
       type: "A",
       measure: "SAA-AD",
+      mandatory: true,
     },
     {
       type: "A",
       measure: "SSD-AD",
+      mandatory: true,
     },
     {
       type: "C",

--- a/services/app-api/handlers/measures/get.ts
+++ b/services/app-api/handlers/measures/get.ts
@@ -42,6 +42,7 @@ export const listMeasures = handler(async (event, context) => {
     )[0];
 
     v.autoCompleted = !!measure?.autocompleteOnCreation;
+    v.mandatory = !!measure?.mandatory;
   }
 
   return {

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -39,10 +39,12 @@ export interface Measure {
   year: number;
   placeholder?: boolean;
   /**
-   * The `autoCompleted` property is not present on measures in the database;
-   * it is set on fetch, according to the metadata in measureList.ts.
+   * The `autoCompleted` and `mandatory` properties are not present on
+   * measures in the database; they are set on fetch, according to the
+   * metadata in measureList.ts.
    */
   autoCompleted?: boolean;
+  mandatory?: boolean;
   data?: {
     DataSource?: DataSource[];
     DataSourceSelections?: unknown;

--- a/services/ui-src/src/components/Table/columns/measures.tsx
+++ b/services/ui-src/src/components/Table/columns/measures.tsx
@@ -83,6 +83,25 @@ export const measuresColumns = (
         );
       },
     },
+    // {
+    //   header: "Mandatory",
+    //   id: "mandatory_column_header",
+    //   styleProps: { textAlign: "center" },
+    //   cell: (data: MeasureTableItem.Data) => {
+    //     console.log(data);
+    //     return (
+    //       <CUI.Badge
+    //         fontSize="xs"
+    //         colorScheme="blue"
+    //         textTransform="capitalize"
+    //         borderRadius="lg"
+    //         px="2"
+    //       >
+    //         <CUI.Text fontWeight="normal">Mandatory</CUI.Text>
+    //       </CUI.Badge>
+    //     );
+    //   },
+    // },
     {
       header: "Reporting FFY " + year,
       id: "reporting_column_header",

--- a/services/ui-src/src/components/Table/columns/measures.tsx
+++ b/services/ui-src/src/components/Table/columns/measures.tsx
@@ -55,6 +55,7 @@ const MeasureStatusText = ({
 export const measuresColumns = (
   year: string
 ): TableColumn<MeasureTableItem.Data>[] => {
+  const displayMandatoryColumn = year === "2024";
   return [
     {
       header: "Abbreviation",
@@ -83,25 +84,30 @@ export const measuresColumns = (
         );
       },
     },
-    // {
-    //   header: "Mandatory",
-    //   id: "mandatory_column_header",
-    //   styleProps: { textAlign: "center" },
-    //   cell: (data: MeasureTableItem.Data) => {
-    //     console.log(data);
-    //     return (
-    //       <CUI.Badge
-    //         fontSize="xs"
-    //         colorScheme="blue"
-    //         textTransform="capitalize"
-    //         borderRadius="lg"
-    //         px="2"
-    //       >
-    //         <CUI.Text fontWeight="normal">Mandatory</CUI.Text>
-    //       </CUI.Badge>
-    //     );
-    //   },
-    // },
+    ...(displayMandatoryColumn
+      ? [
+          {
+            header: "Mandatory",
+            id: "mandatory_column_header",
+            styleProps: { textAlign: "center" },
+            cell: (data: MeasureTableItem.Data) => {
+              return (
+                <CUI.Badge
+                  fontSize="xs"
+                  backgroundColor="blue.50"
+                  textTransform="capitalize"
+                  borderRadius="lg"
+                  px="2"
+                >
+                  {data?.mandatory && (
+                    <CUI.Text fontWeight="normal">Mandatory</CUI.Text>
+                  )}
+                </CUI.Badge>
+              );
+            },
+          },
+        ]
+      : []),
     {
       header: "Reporting FFY " + year,
       id: "reporting_column_header",

--- a/services/ui-src/src/components/Table/types.ts
+++ b/services/ui-src/src/components/Table/types.ts
@@ -51,6 +51,7 @@ export namespace MeasureTableItem {
     actions: IKebabMenuItem[];
     reporting: string | undefined | null;
     autoCompleted?: boolean;
+    mandatory?: boolean;
   };
 
   export interface StatusTextProps {

--- a/services/ui-src/src/types.ts
+++ b/services/ui-src/src/types.ts
@@ -45,6 +45,7 @@ export interface MeasureData<DataType = any> {
   detailedDescription?: string;
   lastAltered: number;
   autoCompleted?: boolean;
+  mandatory?: boolean;
   measure: string;
   state: string;
   status: "incomplete" | "complete" | undefined;

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -198,6 +198,7 @@ const useMeasureTableDataBuilder = () => {
             lastDateModified: item.lastAltered,
             createdAt: item.createdAt,
             autoCompleted: item.autoCompleted,
+            mandatory: item.mandatory,
             id: item.measure,
             userCreated: item.userCreated,
             actions: actions,


### PR DESCRIPTION
### Description
Adding mandatory column with mandatory chip to 2024 measures
![Screenshot 2024-07-29 at 1 05 17 PM](https://github.com/user-attachments/assets/129b0721-e349-450f-9b1b-c092a2d7a626)

CMDCT-3854

---
### How to test
1. Navigate to 2024 coreset and select any adult measure
2. Make sure that the Mandatory column is present and that there are Mandatory chips for the following measures:
```
AMM-AD
CDF-AD
FUA-AD
FUH-AD
FUM-AD
HPCMI-AD
IET-AD
MSC-AD
OUD-AD
SAA-AD
SSD-AD
```

3. Navigate back to 2024 coreset and select child measures. Make sure that every child measure has the mandatory chip
4. Do step 3 for HH measures
5. Make sure that the mandatory column is not present for years 21, 22 and 23
