### PR TITLE
CMDCT-3644, CMDCT-3879: updating qualifier content for separate chip and medicaid

### DIFF
--- a/services/ui-src/src/measures/2024/shared/Qualifiers/data.ts
+++ b/services/ui-src/src/measures/2024/shared/Qualifiers/data.ts
@@ -13,7 +13,7 @@ const AdultData: DataDriven = {
   title: "Adult Core Set Qualifiers",
   questionTitle: "Adult Core Set Questions",
   qualifierHeader: (year) =>
-    `As of September 30, ${year} what percentage of your Medicaid/CHIP enrollees (above age 21) were enrolled in each delivery system?`,
+    `As of September 30, ${year}, what percentage of your Medicaid/CHIP enrollees (above age 21) were enrolled in each delivery system?`,
   textTable: [["Ages 21 to 64"], ["Age 65 and older"]],
   fieldValues: ["TwentyOneToSixtyFour", "GreaterThanSixtyFour"],
   formData: {
@@ -47,7 +47,7 @@ const AdultChipData: DataDriven = {
   title: "Adult Core Set Qualifiers: CHIP",
   questionTitle: "Adult Core Set Questions: CHIP",
   qualifierHeader: (year) =>
-    `As of September 30, ${year} what percentage of your Medicaid/CHIP enrollees (above age 21) were enrolled in each delivery system?`,
+    `As of September 30, ${year}, what percentage of your Separate CHIP enrollees (age 21 and older) were enrolled in each delivery system?`,
   textTable: [["Ages 21 to 64"], ["Age 65 and older"]],
   fieldValues: ["TwentyOneToSixtyFour", "GreaterThanSixtyFour"],
   formData: {
@@ -81,7 +81,7 @@ const AdultMedicaidData: DataDriven = {
   title: "Adult Core Set Qualifiers: Medicaid",
   questionTitle: "Adult Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of September 30, ${year} what percentage of your Medicaid/CHIP enrollees (above age 21) were enrolled in each delivery system?`,
+    `As of September 30, ${year}, what percentage of your Medicaid (title XIX & XXI) enrollees (age 21 and older) were enrolled in each delivery system?`,
   textTable: [["Ages 21 to 64"], ["Age 65 and older"]],
   fieldValues: ["TwentyOneToSixtyFour", "GreaterThanSixtyFour"],
   formData: {
@@ -115,7 +115,7 @@ const ChildData: DataDriven = {
   title: "Child Core Set Qualifiers: Medicaid & CHIP",
   questionTitle: "Child Core Set Questions: Medicaid & CHIP",
   qualifierHeader: (year) =>
-    `As of September 30, ${year} what percentage of your Medicaid/CHIP enrollees (under age 21) were enrolled in each delivery system?`,
+    `As of September 30, ${year}, what percentage of your Medicaid/CHIP enrollees (under age 21) were enrolled in each delivery system?`,
   textTable: [
     ["Medicaid", "Under Age 21"],
     ["CHIP", "Under Age 21"],
@@ -152,7 +152,7 @@ const ChildChipData: DataDriven = {
   title: "Child Core Set Qualifiers: CHIP",
   questionTitle: "Child Core Set Questions: CHIP",
   qualifierHeader: (year) =>
-    `As of September 30, ${year} what percentage of your CHIP enrollees (under age 21) were enrolled in each delivery system?`,
+    `As of September 30, ${year}, what percentage of your Separate CHIP enrollees (under age 21) were enrolled in each delivery system?`,
   textTable: [["CHIP", "Under Age 21"]],
   fieldValues: ["UnderTwentyOne"],
   formData: {
@@ -182,7 +182,7 @@ const ChildMedicaidData: DataDriven = {
   title: "Child Core Set Qualifiers: Medicaid",
   questionTitle: "Child Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of September 30, ${year} what percentage of your Medicaid enrollees (under age 21) were enrolled in each delivery system (optional)?`,
+    `As of September 30, ${year}, what percentage of your Medicaid (title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system (optional)?`,
   textTable: [["Medicaid", "Under Age 21"]],
   fieldValues: ["UnderTwentyOne"],
   formData: {
@@ -212,7 +212,7 @@ const HomeData: DataDriven = {
   title: "Health Home Core Set Qualifiers",
   questionTitle: `Health Home Core Set Questions: SPA ID:`,
   qualifierHeader: (year) =>
-    `As of September 30, ${year} what percentage of your Medicaid Health Home enrollees were enrolled in each delivery system?`,
+    `As of September 30, ${year}, what percentage of your Medicaid Health Home enrollees were enrolled in each delivery system?`,
   textTable: [["Ages 0 to 17"], ["Ages 18 to 64"], ["Age 65 and older"]],
   fieldValues: [
     "ZeroToSeventeen",


### PR DESCRIPTION
### Description
the simplest PR to update wording in qualifier under delivery system question. basically just using specific medicaid or separate chip language if they're separate

CMDCT-3644 and CMDCT-3879

---
### How to test
1. For 2024, go to to adult medicaid core set qualifiers. Make sure the description under Delivery System starts with 
`As of September 30, 2023, what percentage of your Medicaid (title XIX & XXI) enrollees (age 21 and older)`
2. Go to adult chip core set qualifiers. Make sure the description under Delivery System starts with
`As of September 30, 2023, what percentage of your separate CHIP enrollees (age 21 and older)`
3. Go to child medicaid core set qualifiers. Make sure the description under Delivery System starts with
`As of September 30, 2023, what percentage of your Medicaid (title XIX & XXI) enrollees (under age 21)`
4. Go to child chip core set qualifiers. Make sure the description under Delivery System starts with 
`As of September 30, 2023, what percentage of your separate CHIP enrollees (under age 21)`
