### PR TITLE
[QMR] Combined Rates - Hybrid Nuance

### DIFF
--- a/services/app-api/handlers/rate/calculations/hybridCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/hybridCalculation.ts
@@ -58,7 +58,7 @@ export class HybridCalculation extends RateCalculation {
           rate["weighted rate"] =
             isNaN(weight) || !rate.rate
               ? ""
-              : fixRounding(formula(rate.rate, weight), 1).toFixed(1);
+              : fixRounding(formula(Number(rate.rate), weight), 1).toFixed(1);
           return rate;
         });
       }

--- a/services/app-api/handlers/rate/calculations/hybridCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/hybridCalculation.ts
@@ -39,8 +39,8 @@ export class HybridCalculation extends RateCalculation {
   }
 
   getFormula(measure: string): Function {
-    return (numerator: number, denominator: number, weight: number) =>
-      fixRounding(weight, 5) * fixRounding((numerator / denominator) * 100, 1);
+    return (rate: number, weight: number) =>
+      fixRounding(weight, 5) * fixRounding(rate, 1);
   }
 
   expandRates(arr: FormattedMeasureData[]) {
@@ -58,10 +58,7 @@ export class HybridCalculation extends RateCalculation {
           rate["weighted rate"] =
             isNaN(weight) || !rate.rate
               ? ""
-              : fixRounding(
-                  formula(rate.numerator, rate.denominator, weight),
-                  1
-                ).toFixed(1);
+              : fixRounding(formula(rate.rate, weight), 1).toFixed(1);
           return rate;
         });
       }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
TLDR: For all measures where a hybrid data source is selected, users have an option to manually override the auto-calculated rate. Originally, the combined rates table was not using the manually overrode rate, it was re-calculating the rate using the numerator and denominator, which caused discrepancy between what was actually entered in the individual measure page and the combined rates table. This PR fixes that so that the combined rates table does use a manually entered rate, otherwise defaults to the auto-calculated rate. Here's an example:
<img width="637" alt="Screenshot 2024-08-09 at 12 18 31 PM" src="https://github.com/user-attachments/assets/6daa418a-7755-4c03-a47b-e6c2b8bef32b">
For the CHIP column, the auto-calculated rate was 3.3 and 4.4 was manually entered by a user. For a manually entered rate of 4.4, the weighted rate for the column should be 1.1, not 0.8.

<img width="582" alt="Screenshot 2024-08-09 at 12 18 54 PM" src="https://github.com/user-attachments/assets/cb582ca1-caf9-4bae-9e3c-78e790ea5409">

For the Medicaid column, the auto-calculated rate was 0 and 8.0 was manually entered by a user. For a manually entered rate of 8.0, the weighted rate for the CHIP column should be 6.0, not 0.0.



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3904

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Go to an individual measure and click the hybrid data source (you can click any combination of data sources as long as hybrid is checked). Use the numbers in the attached pictures to fill out an individual measure's N/D/R and Measure-Eligible population. Make sure to override the auto-calculated rate with the manually entered rates as shown.
2. Go to the combined rates table and make sure that the correct weighted rates are showing up. If you're using the example provided above, the correct weighted rates should be 6.0 for the Medicaid column and 1.1 for the Chip column.
3. Repeat for CPU-AD -- it follows the same behavior but for this measure the data source you need to check is Case Management Record Review. Follow steps 1-2 accordingly. 

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
