### PR TITLE
CMDCT-3903: if one admin and one hybrid data source, make sure admin mep uses denominator to calculate weighed rate

### DIFF
--- a/services/app-api/handlers/rate/calculations/hybridCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/hybridCalculation.ts
@@ -48,13 +48,23 @@ export class HybridCalculation extends RateCalculation {
 
     return arr.map((data) => {
       if (data.dataSource.length <= 0) return data;
-
-      const weight =
-        Number(data["measure-eligible population"]) /
-        this.totalMeasureEligiblePopulation;
+      const isHybridDataSource =
+        data.dataSource.includes(DataSource.Hybrid) ||
+        data.dataSource.includes(DataSource.CaseMagementRecordReview);
 
       for (const [key, value] of Object.entries(data.rates)) {
         data.rates[key] = (value as RateNDRShape[]).map((rate) => {
+          let weight = 0;
+          if (!isHybridDataSource && !data["measure-eligible population"]) {
+            weight =
+              Number(rate.denominator) /
+              (this.totalMeasureEligiblePopulation + Number(rate.denominator));
+          } else {
+            weight =
+              Number(data["measure-eligible population"]) /
+              this.totalMeasureEligiblePopulation;
+          }
+
           rate["weighted rate"] =
             isNaN(weight) || !rate.rate
               ? ""

--- a/services/app-api/handlers/rate/calculations/hybridCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/hybridCalculation.ts
@@ -55,7 +55,11 @@ export class HybridCalculation extends RateCalculation {
       for (const [key, value] of Object.entries(data.rates)) {
         data.rates[key] = (value as RateNDRShape[]).map((rate) => {
           let weight;
-          if (!isHybridDataSource && !data["measure-eligible population"]) {
+          if (
+            this.totalMeasureEligiblePopulation !== 0 &&
+            !isHybridDataSource &&
+            !data["measure-eligible population"]
+          ) {
             weight =
               Number(rate.denominator) /
               (this.totalMeasureEligiblePopulation + Number(rate.denominator));

--- a/services/app-api/handlers/rate/calculations/hybridCalculation.ts
+++ b/services/app-api/handlers/rate/calculations/hybridCalculation.ts
@@ -54,7 +54,7 @@ export class HybridCalculation extends RateCalculation {
 
       for (const [key, value] of Object.entries(data.rates)) {
         data.rates[key] = (value as RateNDRShape[]).map((rate) => {
-          let weight = 0;
+          let weight;
           if (!isHybridDataSource && !data["measure-eligible population"]) {
             weight =
               Number(rate.denominator) /

--- a/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateTypes.ts
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRateNDR/CombinedRateTypes.ts
@@ -2,6 +2,7 @@ export type Program = "CHIP" | "Medicaid";
 export type DataSource =
   | "AdministrativeData"
   | "ElectronicHealthRecords"
+  | "Casemanagementrecordreview"
   | "HybridAdministrativeandMedicalRecordsData";
 export type CategoryId = string;
 export type QualifierId = string;


### PR DESCRIPTION
### Description
If one source uses hybrid data, and another source uses admin data, the current state of the app is that there will be an MEP for hybrid and no MEP for admin. This will in turn not have a weighted rate calculation in combined rates. This needed to be updated so that if admin source does not have MEP, we instead use the denominator to calculate weighted rate.

Before:
<img width="1056" alt="Screenshot 2024-08-09 at 5 00 23 PM" src="https://github.com/user-attachments/assets/ac5a088c-6d67-4f18-b4ab-019ae11567b8">

After:
![Screenshot 2024-08-09 at 4 58 30 PM](https://github.com/user-attachments/assets/5f561270-3df0-49cc-9bd0-681097681ebc)


Questions to ask David:
1.  do we allow users to enter MEP for admin data source and should we calculate weighted rate with that user entered MEP
2. do we want to support a 0 MEP value

### Related ticket(s)
CMDCT-3903

---
### How to test
1. Find a medicaid measure with total measure eligible population (an adult one is CBP-AD and a child one is IMA-CH) and fill it out using a Data Source type of Hybrid. make sure to fill in the total measure eligible population with any number other than 0
2. Find the corresponding chip measure and fill that out using a Data Source type of Administrative. make sure to leave the total measure eligible population field blank
3. Go to the combined rates page and select the measure you just filled out in the first two steps
4. Observe that the hybrid measure uses the measure eligible population number you entered and has a weighted rate calculation. Also observe that admin measure has a measure eligible population number that matches its denominator and also has a weighted rate calculation. lastly make sure there is a combined weighted rate calculation.
