### PR TITLE
QMR - Additional Validation Content Change for IET-AD

### DIFF
--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateNDRTotalsMatchSum/index.test.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateNDRTotalsMatchSum/index.test.ts
@@ -20,7 +20,7 @@ describe("Testing PM Total vs Sum validations", () => {
     const result = valNumerator[0];
     expect(result.errorLocation).toBe("Performance Measure");
     expect(result.errorMessage).toBe(
-      "Numerators must be the sum for each category of performance measures"
+      "The numerators for each diagnosis cohort should sum to the total SUD numerator."
     );
   });
 
@@ -31,7 +31,7 @@ describe("Testing PM Total vs Sum validations", () => {
     const result = valNumerator[0];
     expect(result.errorLocation).toBe("Performance Measure");
     expect(result.errorMessage).toBe(
-      "Numerators must be the sum for each category of performance measures"
+      "The numerators for each diagnosis cohort should sum to the total SUD numerator."
     );
   });
 
@@ -44,7 +44,7 @@ describe("Testing PM Total vs Sum validations", () => {
     const result = valDenominators[0];
     expect(result.errorLocation).toBe("Performance Measure");
     expect(result.errorMessage).toBe(
-      "Denominators must be the sum for each category of performance measures"
+      "The denominators for each diagnosis cohort should sum to the total SUD denominator."
     );
   });
 
@@ -57,7 +57,7 @@ describe("Testing PM Total vs Sum validations", () => {
     const result = valDenominators[0];
     expect(result.errorLocation).toBe("Performance Measure");
     expect(result.errorMessage).toBe(
-      "Denominators must be the sum for each category of performance measures"
+      "The denominators for each diagnosis cohort should sum to the total SUD denominator."
     );
   });
 });

--- a/services/ui-src/src/measures/2024/shared/globalValidations/validateNDRTotalsMatchSum/index.ts
+++ b/services/ui-src/src/measures/2024/shared/globalValidations/validateNDRTotalsMatchSum/index.ts
@@ -46,7 +46,7 @@ export function validateNDRTotalsMatchSum(
       errorArray.push({
         errorLocation: "Performance Measure",
         errorMessage:
-          "Numerators must be the sum for each category of performance measures",
+          "The numerators for each diagnosis cohort should sum to the total SUD numerator.",
       });
     }
 
@@ -57,7 +57,7 @@ export function validateNDRTotalsMatchSum(
       errorArray.push({
         errorLocation: "Performance Measure",
         errorMessage:
-          "Denominators must be the sum for each category of performance measures",
+          "The denominators for each diagnosis cohort should sum to the total SUD denominator.",
       });
     }
   }


### PR DESCRIPTION
### Description
When the numerators don't sum properly, update the validation language to:
 -  "The numerators for each diagnosis cohort should sum to the total SUD numerator." 
 
When the denominators don't sum properly, update the validation language to: 
 - "The denominators for each diagnosis cohort should sum to the total SUD denominator."


### Related ticket(s)
CMDCT-3931

---
### How to test

### 1) Click on IET-AD measure
<img width="346" alt="IET-AD_Measure" src="https://github.com/user-attachments/assets/2897eaea-595a-4785-8053-fdbd9c16b874">

### 2) Fill out numerators and denominators (denominators must match for the same cohort) for both initiation and engagment treatments.
<img width="866" alt="Opioid_Use_Numbers" src="https://github.com/user-attachments/assets/90995e43-49d7-4f52-ae2a-3504d546aad3">

### 3) Change denominators and numerators for totals to see validation errors.
<img width="805" alt="SUD_Total_Numbers-changed" src="https://github.com/user-attachments/assets/dacc506f-7609-451e-a39f-ff3916aa00a1">

### 4) Expect the following error messages - one for each changed value
<img width="615" alt="Validation-error-messages" src="https://github.com/user-attachments/assets/00575639-7365-470c-924b-a08c96a05975">

### Notes
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary