### PR TITLE
CMDCT-3929: making definition of denom text changes for not separated coresets

### DIFF
--- a/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
@@ -170,6 +170,10 @@ const coreSetSpecificOptions: CoreSetSpecificOptions = {
         value: DC.DENOMINATOR_INC_MEDICAID_POP,
       },
       {
+        displayValue: "Medicaid-Expansion CHIP (Title XXI)",
+        value: DC.DENOMINATOR_INC_MEDICAID_EXPANSION,
+      },
+      {
         displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
         value: DC.DENOMINATOR_INC_MEDICAID_DUAL_ELIGIBLE,
       },
@@ -178,11 +182,13 @@ const coreSetSpecificOptions: CoreSetSpecificOptions = {
       <>
         <CUI.Text mt="3">
           Please select all populations that are included in the denominator.
-          For example, if your data include both Medicaid (Title XIX) enrollees
-          and individuals dually eligible for Medicare and Medicaid, select:
+          For example, if your data include Medicaid (Title XIX) beneficiaries,
+          Medicaid-Expansion CHIP (Title XXI) beneficiaries, and individuals
+          dually eligible for Medicare and Medicaid, select:
         </CUI.Text>
         <CUI.UnorderedList m="5" ml="10">
           <CUI.ListItem>Medicaid (Title XIX)</CUI.ListItem>
+          <CUI.ListItem>Medicaid-Expansion CHIP (Title XXI)</CUI.ListItem>
           <CUI.ListItem>
             Individuals Dually Eligible for Medicare and Medicaid
           </CUI.ListItem>
@@ -197,22 +203,20 @@ const coreSetSpecificOptions: CoreSetSpecificOptions = {
         value: DC.DENOMINATOR_INC_MEDICAID_POP,
       },
       {
-        displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
-        value: DC.DENOMINATOR_INC_MEDICAID_DUAL_ELIGIBLE,
+        displayValue: "Medicaid-Expansion CHIP (Title XXI)",
+        value: DC.DENOMINATOR_INC_MEDICAID_EXPANSION,
       },
     ],
     helpText: (
       <>
         <CUI.Text mb="2">
           Please select all populations that are included in the denominator.
-          For example, if your data include both Medicaid (Title XIX) enrollees
-          and individuals dually eligible for Medicare and Medicaid, select:
+          For example, if your data include both Medicaid (Title XIX) and
+          Medicaid-Expansion CHIP (Title XXI) beneficiaries, select both:
         </CUI.Text>
         <CUI.UnorderedList m="5" ml="10">
           <CUI.ListItem>Medicaid (Title XIX)</CUI.ListItem>
-          <CUI.ListItem>
-            Individuals Dually Eligible for Medicare and Medicaid
-          </CUI.ListItem>
+          <CUI.ListItem>Medicaid-Expansion CHIP (Title XXI)</CUI.ListItem>
         </CUI.UnorderedList>
       </>
     ),


### PR DESCRIPTION
### Description
Super simple PR to update options for coresets that don't have separate medicaid and chip measures

### Related ticket(s)
CMDCT-3929

---
### How to test
1. Log in as a user with state that doesn't have separate coresets for medicaid and chip (such as stateuserDC)
2. Navigate to adult coreset and click on any measure and scroll to Definition of denominator section and make sure it matches the updates noted in the [ticket](https://jiraent.cms.gov/browse/CMDCT-3929)
3. repeat step 2 with the child coreset
