### PR TITLE
CMDCT-3928: switching CPA-AD measure to use its own custom DefinitionOfPopulation

### DIFF
--- a/services/ui-src/src/measures/2024/CPAAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/index.tsx
@@ -33,7 +33,7 @@ export const CPAAD = ({
         <>
           <Q.HowDidYouReport />
           <Q.DataSource type="adult" />
-          <CMQ.DefinitionOfPopulation />
+          <Q.DefinitionOfPopulation coreSetId={coreSetId as string} />
           <Q.PerformanceMeasure />
         </>
       )}

--- a/services/ui-src/src/measures/2024/CPAAD/questions/DefinitionOfPopulation.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/questions/DefinitionOfPopulation.tsx
@@ -3,55 +3,50 @@ import * as CUI from "@chakra-ui/react";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { FormData } from "../types";
 
-export const DefinitionOfPopulation = ({ coresetId }: any) => {
+interface DefOfDenomOption {
+  displayValue: string;
+  value: string;
+}
+interface CoreSetSpecificOptions {
+  [coreSetId: string]: {
+    options: DefOfDenomOption[];
+    helpText: string;
+  };
+}
+
+export const DefinitionOfPopulation = ({ coreSetId }: any) => {
   const register = useCustomRegister<FormData>();
 
-  // default options
-  const ACSMOptions = [
-    {
-      displayValue: "Medicaid (Title XIX)",
-      value: "Medicaid (Title XIX)",
-    },
-    {
-      displayValue: "Medicaid-Expansion CHIP (Title XXI)",
-      value: "SurveySampleIncCHIP",
-    },
-    {
-      displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
-      value: "SurveySampleIncMedicareMedicaidDualEligible",
-    },
-    {
-      displayValue: "Other",
-      value: "Other",
-      children: [
-        <QMR.TextArea
-          label="Define the Other survey population:"
-          name="define-the-other-survey-population"
-        />,
+  const coreSetSpecificOptions: CoreSetSpecificOptions = {
+    ACSM: {
+      options: [
+        {
+          displayValue: "Medicaid (Title XIX)",
+          value: "Medicaid (Title XIX)",
+        },
+        {
+          displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
+          value: "SurveySampleIncMedicareMedicaidDualEligible",
+        },
       ],
+      helpText:
+        "Please select all populations that are included in the survey sample. For example, if your survey sample includes both non-dual Medicaid (Title XIX) beneficiaries and Individuals Dually Eligible for Medicare and Medicaid, select both Medicaid population (Title XIX) and Individuals Dually Eligible for Medicare and Medicaid.",
     },
-  ];
-
-  const ACSCOptions = [
-    {
-      displayValue: "Separate CHIP (Title XXI)",
-      value: "Separate CHIP (Title XXI)",
-    },
-    {
-      displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
-      value: "Individuals Dually Eligible for Medicare and Medicaid",
-    },
-    {
-      displayValue: "Other",
-      value: "Other",
-      children: [
-        <QMR.TextArea
-          label="Define the Other survey population:"
-          name="define-the-other-survey-population"
-        />,
+    ACSC: {
+      options: [
+        {
+          displayValue: "Separate CHIP (Title XXI)",
+          value: "Separate CHIP (Title XXI)",
+        },
+        {
+          displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
+          value: "Individuals Dually Eligible for Medicare and Medicaid",
+        },
       ],
+      helpText:
+        "Please select all populations that are included in the survey sample. For example, if your survey sample includes both Separate CHIP (Title XXI) beneficiaries and Individuals Dually Eligible for Medicare and Medicaid, select both Separate CHIP (Title XXI) and Individuals Dually Eligible for Medicare and Medicaid.",
     },
-  ];
+  };
 
   return (
     <QMR.CoreQuestionWrapper
@@ -59,25 +54,29 @@ export const DefinitionOfPopulation = ({ coresetId }: any) => {
       label="Definition of Population Included in the Measure"
     >
       <CUI.Heading size="sm" as="h3">
-        Definition of population included in the survey sample
+        Definition of denominator
       </CUI.Heading>
       <CUI.Text mt="3" mb="3">
-        Please select all populations that are included. For example, if your
-        survey sample includes both non-dual Medicaid (Title XIX) beneficiaries
-        and Individuals Dually Eligible for Medicare and Medicaid, select both
-        Medicaid (Title XIX) and Individuals Dually Eligible for Medicare and
-        Medicaid. 
+        {coreSetSpecificOptions[coreSetId].helpText}
       </CUI.Text>
 
       <QMR.Checkbox
         {...register("DefinitionOfSurveySample")}
-        options={
-          coresetId === "ACSC" || coresetId === "CCSC"
-            ? ACSCOptions
-            : ACSMOptions
-        }
+        options={[
+          ...coreSetSpecificOptions[coreSetId].options,
+          {
+            displayValue: "Other",
+            value: "Other",
+            children: [
+              <QMR.TextArea
+                label="Define the Other survey population:"
+                name="define-the-other-survey-population"
+              />,
+            ],
+          },
+        ]}
       />
-      {coresetId === "ACSM" && (
+      {coreSetId === "ACSM" && (
         <QMR.TextArea
           label="If this measure has been reported by the state previously and there has been a change in the included population, please provide any available context below:"
           formControlProps={{ paddingTop: "15px" }}


### PR DESCRIPTION
### Description
This is a tragic PR. Because of the changes requested in CMDCT-3928, we need to go back to using a custom DefinitionOfPopulation specifically for CPA-AD measure. Previously, Aileen had successfully switched all the measures over to using the common DefinitionOfPopulation component so this sets us back a bit on that front. 

@BearHanded idk what you think about this. we could TECHNICALLY add the CPA-AD specific definitions to the common file, but that would make an already bloated component even more bloated and lead to some potentially painful conditional rendering.

### Related ticket(s)
CMDCT-3928

---
### How to test
1. Log in a user with separate medicaid and chip measures
2. Go to adult medicaid coreset and click on the CPA-AD measure
3. Scroll to Definition of Denominator section and make sure that the wording is what matches what is requested in the [ticket](https://jiraent.cms.gov/browse/CMDCT-3928)
4. Repeat steps 2 & 3 for chip coreset
