### PR TITLE
CMDCT-3926 - MSC-AD Question Order

### DIFF
--- a/services/ui-src/src/measures/2024/CPAAD/questions/WhyDidYouNotCollect.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/questions/WhyDidYouNotCollect.tsx
@@ -9,7 +9,7 @@ export const WhyDidYouNotCollect = () => {
   return (
     <QMR.CoreQuestionWrapper
       testid="why-did-you-not-collect"
-      label="Why did you not collect this measure"
+      label="Why did you not collect this measure?"
     >
       <QMR.Checkbox
         {...register("WhyDidYouNotCollect")}

--- a/services/ui-src/src/measures/2024/MSCAD/index.tsx
+++ b/services/ui-src/src/measures/2024/MSCAD/index.tsx
@@ -10,11 +10,8 @@ import * as DC from "dataConstants";
 import { NotCollectingOMS } from "shared/commonQuestions/NotCollectingOMS";
 
 export const MSCAD = ({
-  name,
   year,
-  measureId,
   setValidationFunctions,
-
   isPrimaryMeasureSpecSelected,
   showOptionalMeasureStrat,
   isOtherMeasureSpecSelected,
@@ -29,42 +26,39 @@ export const MSCAD = ({
 
   return (
     <>
-      <Q.Reporting
-        reportingYear={year}
-        measureName={name}
-        measureAbbreviation={measureId}
-      />
+      <Q.Reporting reportingYear={year} />
       {data["DidCollect"] !== "no" && (
         <>
           <Q.HowDidYouReport
             reportingYear={year}
-            // is this a health home
             healthHomeMeasure
             removeLessThan30
           />
-          {data[DC.DID_REPORT] !== DC.NO && (
-            <>
-              <CMQ.StatusOfData />
-              <CMQ.MeasurementSpecification type="HEDIS" coreset="adult" />
-              <Q.DataSource type="adult" />
-              <CMQ.DateRange type="adult" />
-              <CMQ.DefinitionOfPopulation />
-              {isPrimaryMeasureSpecSelected && (
-                <>
-                  <CMQ.PerformanceMeasure
-                    data={PMD.data}
-                    rateReadOnly={false}
-                  />
-                  <CMQ.DeviationFromMeasureSpec />
-                </>
-              )}
-              {/* Show Other Performance Measures when isHedis is not true  */}
-              {isOtherMeasureSpecSelected && (
-                <CMQ.OtherPerformanceMeasure rateAlwaysEditable />
-              )}
-              {showOptionalMeasureStrat && <NotCollectingOMS year={year} />}
-            </>
-          )}
+          <>
+            {data[DC.DID_REPORT] !== DC.NO && (
+              <>
+                <CMQ.StatusOfData />
+                <CMQ.MeasurementSpecification type="HEDIS" coreset="adult" />
+                <Q.DataSource type="adult" />
+                <CMQ.DateRange type="adult" />
+                <CMQ.DefinitionOfPopulation />
+                {isPrimaryMeasureSpecSelected && (
+                  <>
+                    <CMQ.PerformanceMeasure
+                      data={PMD.data}
+                      rateReadOnly={false}
+                    />
+                    <CMQ.DeviationFromMeasureSpec />
+                  </>
+                )}
+                {/* Show Other Performance Measures when isHedis is not true  */}
+                {isOtherMeasureSpecSelected && (
+                  <CMQ.OtherPerformanceMeasure rateAlwaysEditable />
+                )}
+                {showOptionalMeasureStrat && <NotCollectingOMS year={year} />}
+              </>
+            )}
+          </>
         </>
       )}
       <CMQ.AdditionalNotes />

--- a/services/ui-src/src/measures/2024/MSCAD/index.tsx
+++ b/services/ui-src/src/measures/2024/MSCAD/index.tsx
@@ -29,11 +29,7 @@ export const MSCAD = ({
       <Q.Reporting reportingYear={year} />
       {data["DidCollect"] !== "no" && (
         <>
-          <Q.HowDidYouReport
-            reportingYear={year}
-            healthHomeMeasure
-            removeLessThan30
-          />
+          <Q.HowDidYouReport reportingYear={year} />
           <>
             {data[DC.DID_REPORT] !== DC.NO && (
               <>

--- a/services/ui-src/src/measures/2024/MSCAD/index.tsx
+++ b/services/ui-src/src/measures/2024/MSCAD/index.tsx
@@ -34,29 +34,37 @@ export const MSCAD = ({
         measureName={name}
         measureAbbreviation={measureId}
       />
-      <Q.HowDidYouReport
-        reportingYear={year}
-        healthHomeMeasure
-        removeLessThan30
-      />
-      {data[DC.DID_REPORT] !== DC.NO && (
+      {data["DidCollect"] !== "no" && (
         <>
-          <CMQ.StatusOfData />
-          <CMQ.MeasurementSpecification type="HEDIS" coreset="adult" />
-          <Q.DataSource type="adult" />
-          <CMQ.DateRange type="adult" />
-          <CMQ.DefinitionOfPopulation />
-          {isPrimaryMeasureSpecSelected && (
+          <Q.HowDidYouReport
+            reportingYear={year}
+            // is this a health home
+            healthHomeMeasure
+            removeLessThan30
+          />
+          {data[DC.DID_REPORT] !== DC.NO && (
             <>
-              <CMQ.PerformanceMeasure data={PMD.data} rateReadOnly={false} />
-              <CMQ.DeviationFromMeasureSpec />
+              <CMQ.StatusOfData />
+              <CMQ.MeasurementSpecification type="HEDIS" coreset="adult" />
+              <Q.DataSource type="adult" />
+              <CMQ.DateRange type="adult" />
+              <CMQ.DefinitionOfPopulation />
+              {isPrimaryMeasureSpecSelected && (
+                <>
+                  <CMQ.PerformanceMeasure
+                    data={PMD.data}
+                    rateReadOnly={false}
+                  />
+                  <CMQ.DeviationFromMeasureSpec />
+                </>
+              )}
+              {/* Show Other Performance Measures when isHedis is not true  */}
+              {isOtherMeasureSpecSelected && (
+                <CMQ.OtherPerformanceMeasure rateAlwaysEditable />
+              )}
+              {showOptionalMeasureStrat && <NotCollectingOMS year={year} />}
             </>
           )}
-          {/* Show Other Performance Measures when isHedis is not true  */}
-          {isOtherMeasureSpecSelected && (
-            <CMQ.OtherPerformanceMeasure rateAlwaysEditable />
-          )}
-          {showOptionalMeasureStrat && <NotCollectingOMS year={year} />}
         </>
       )}
       <CMQ.AdditionalNotes />

--- a/services/ui-src/src/measures/2024/MSCAD/index.tsx
+++ b/services/ui-src/src/measures/2024/MSCAD/index.tsx
@@ -27,7 +27,7 @@ export const MSCAD = ({
   return (
     <>
       <Q.Reporting reportingYear={year} />
-      {data["DidCollect"] !== "no" && (
+      {data[DC.DID_COLLECT] !== DC.NO && (
         <>
           <Q.HowDidYouReport reportingYear={year} />
           <>

--- a/services/ui-src/src/measures/2024/MSCAD/questions/HowDidYouReport.tsx
+++ b/services/ui-src/src/measures/2024/MSCAD/questions/HowDidYouReport.tsx
@@ -3,9 +3,6 @@ import * as CUI from "@chakra-ui/react";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { FormData } from "../types";
 import * as DC from "dataConstants";
-import { WhyAreYouNotReporting } from "shared/commonQuestions/WhyAreYouNotReporting";
-import { useFormContext } from "react-hook-form";
-import * as Types from "../types";
 
 interface Props {
   reportingYear: string;
@@ -13,14 +10,8 @@ interface Props {
   removeLessThan30?: boolean;
 }
 
-export const HowDidYouReport = ({
-  healthHomeMeasure,
-  removeLessThan30,
-  reportingYear,
-}: Props) => {
+export const HowDidYouReport = ({ reportingYear }: Props) => {
   const register = useCustomRegister<FormData>();
-  const { watch } = useFormContext<Types.FormData>();
-  const watchRadioStatus = watch(DC.DID_REPORT);
 
   return (
     <QMR.CoreQuestionWrapper
@@ -53,12 +44,6 @@ export const HowDidYouReport = ({
                     },
                   ]}
                 />
-                {watchRadioStatus === DC.NO && (
-                  <WhyAreYouNotReporting
-                    healthHomeMeasure={healthHomeMeasure}
-                    removeLessThan30={removeLessThan30}
-                  />
-                )}
               </QMR.CoreQuestionWrapper>,
             ],
           },

--- a/services/ui-src/src/measures/2024/MSCAD/questions/HowDidYouReport.tsx
+++ b/services/ui-src/src/measures/2024/MSCAD/questions/HowDidYouReport.tsx
@@ -6,8 +6,6 @@ import * as DC from "dataConstants";
 
 interface Props {
   reportingYear: string;
-  healthHomeMeasure?: boolean;
-  removeLessThan30?: boolean;
 }
 
 export const HowDidYouReport = ({ reportingYear }: Props) => {

--- a/services/ui-src/src/measures/2024/MSCAD/questions/Reporting.tsx
+++ b/services/ui-src/src/measures/2024/MSCAD/questions/Reporting.tsx
@@ -7,15 +7,9 @@ import { WhyAreYouNotReporting } from "shared/commonQuestions/WhyAreYouNotReport
 
 interface Props {
   reportingYear: string;
-  healthHomeMeasure?: boolean;
-  removeLessThan30?: boolean;
 }
 
-export const Reporting = ({
-  reportingYear,
-  healthHomeMeasure,
-  removeLessThan30,
-}: Props) => {
+export const Reporting = ({ reportingYear }: Props) => {
   const register = useCustomRegister<FormData>();
   const { watch } = useFormContext<FormData>();
   const watchRadioStatus = watch(DC.DID_COLLECT);
@@ -40,12 +34,7 @@ export const Reporting = ({
           ]}
         />
       </QMR.CoreQuestionWrapper>
-      {watchRadioStatus === DC.NO && (
-        <WhyAreYouNotReporting
-          healthHomeMeasure={healthHomeMeasure}
-          removeLessThan30={removeLessThan30}
-        />
-      )}
+      {watchRadioStatus === DC.NO && <WhyAreYouNotReporting />}
     </>
   );
 };

--- a/services/ui-src/src/measures/2024/MSCAD/questions/Reporting.tsx
+++ b/services/ui-src/src/measures/2024/MSCAD/questions/Reporting.tsx
@@ -1,6 +1,7 @@
 import * as QMR from "components";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { useFormContext } from "react-hook-form";
+import * as DC from "dataConstants";
 import { FormData } from "../types";
 import { WhyAreYouNotReporting } from "shared/commonQuestions/WhyAreYouNotReporting";
 
@@ -17,7 +18,7 @@ export const Reporting = ({
 }: Props) => {
   const register = useCustomRegister<FormData>();
   const { watch } = useFormContext<FormData>();
-  const watchRadioStatus = watch("DidCollect");
+  const watchRadioStatus = watch(DC.DID_COLLECT);
 
   return (
     <>
@@ -26,20 +27,20 @@ export const Reporting = ({
         label="Did you collect this measure?"
       >
         <QMR.RadioButton
-          {...register("DidCollect")}
+          {...register(DC.DID_COLLECT)}
           options={[
             {
               displayValue: `Yes, we did collect data for Medical Assistance with Smoking and Tobacco Use Cessation (MSC-AD) for FFY ${reportingYear} quality measure reporting.`,
-              value: "yes",
+              value: DC.YES,
             },
             {
               displayValue: `No, we did not collect data for Medical Assistance with Smoking and Tobacco Use Cessation (MSC-AD) for FFY ${reportingYear} quality measure reporting.`,
-              value: "no",
+              value: DC.NO,
             },
           ]}
         />
       </QMR.CoreQuestionWrapper>
-      {watchRadioStatus?.includes("no") && (
+      {watchRadioStatus === DC.NO && (
         <WhyAreYouNotReporting
           healthHomeMeasure={healthHomeMeasure}
           removeLessThan30={removeLessThan30}

--- a/services/ui-src/src/measures/2024/MSCAD/questions/Reporting.tsx
+++ b/services/ui-src/src/measures/2024/MSCAD/questions/Reporting.tsx
@@ -1,16 +1,23 @@
 import * as QMR from "components";
 import { useCustomRegister } from "hooks/useCustomRegister";
-import * as Types from "../types";
-import * as DC from "dataConstants";
+import { useFormContext } from "react-hook-form";
+import { FormData } from "../types";
+import { WhyAreYouNotReporting } from "shared/commonQuestions/WhyAreYouNotReporting";
 
 interface Props {
-  measureName: string;
-  measureAbbreviation: string;
   reportingYear: string;
+  healthHomeMeasure?: boolean;
+  removeLessThan30?: boolean;
 }
 
-export const Reporting = ({ reportingYear }: Props) => {
-  const register = useCustomRegister<Types.FormData>();
+export const Reporting = ({
+  reportingYear,
+  healthHomeMeasure,
+  removeLessThan30,
+}: Props) => {
+  const register = useCustomRegister<FormData>();
+  const { watch } = useFormContext<FormData>();
+  const watchRadioStatus = watch("DidCollect");
 
   return (
     <>
@@ -19,19 +26,25 @@ export const Reporting = ({ reportingYear }: Props) => {
         label="Did you collect this measure?"
       >
         <QMR.RadioButton
-          {...register(DC.DID_COLLECT)}
+          {...register("DidCollect")}
           options={[
             {
               displayValue: `Yes, we did collect data for Medical Assistance with Smoking and Tobacco Use Cessation (MSC-AD) for FFY ${reportingYear} quality measure reporting.`,
-              value: DC.YES,
+              value: "yes",
             },
             {
               displayValue: `No, we did not collect data for Medical Assistance with Smoking and Tobacco Use Cessation (MSC-AD) for FFY ${reportingYear} quality measure reporting.`,
-              value: DC.NO,
+              value: "no",
             },
           ]}
         />
       </QMR.CoreQuestionWrapper>
+      {watchRadioStatus?.includes("no") && (
+        <WhyAreYouNotReporting
+          healthHomeMeasure={healthHomeMeasure}
+          removeLessThan30={removeLessThan30}
+        />
+      )}
     </>
   );
 };

--- a/services/ui-src/src/measures/2024/MSCAD/validation.ts
+++ b/services/ui-src/src/measures/2024/MSCAD/validation.ts
@@ -16,9 +16,14 @@ const MSCADValidation = (data: Types.DefaultFormData) => {
   const deviationReason = data[DC.DEVIATION_REASON];
 
   let errorArray: any[] = [];
-  if (data[DC.DID_REPORT] === "no") {
+  if (data[DC.DID_COLLECT] === "no") {
     errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
     return errorArray;
+  }
+
+  // this prevents all the errors for filling out form to show up
+  if (data[DC.DID_REPORT] === "no") {
+    return [];
   }
 
   errorArray = [


### PR DESCRIPTION
### Description
For MSC-AD if the user selects no on the first question we should be showing them the same options as when a user decides to not report a measure, Including the questions currently nested under "no" on the second question.

  - Fix behavior when a user is not reporting

  - Move nested questions out of "no" option in question 2


### Related ticket(s)
CMDCT-3926

---
### How to test

Deploy link: https://d1iqzk6i53axpx.cloudfront.net/

1. Sign into QMR, with stateuser1@test.com

3. Click on Adult Core Set Measures: Medicaid (Title XIX & XXI) and/or Adult Core Set Measures: Separate CHIP

4. Click on MSC-AD measure

5. Select No for "Did you collect this measure?"
![did-you-collect](https://github.com/user-attachments/assets/a94cc650-8217-45e0-8bdb-d555f3584836)

6. Click "Validate Measure" button & this should prompt an error
![why-not-reporting-error](https://github.com/user-attachments/assets/21bd6f11-f4fa-4804-b865-c6fbd98d2b88)

7. Select an option for question: "Why are you not reporting on this measure?"
![why-are-you-not-reporting](https://github.com/user-attachments/assets/d5645cd9-653d-41a6-b5a1-f90627653a25)

8. Click "Validate Measure" button & this should prompt a "Success" message.
![success-message](https://github.com/user-attachments/assets/8fc1bb17-c852-496a-9101-88862b0df90c)

9. Go back to "Did you collect this measure?" question and select Yes so that all questions show on the page
![Yes-to-1st-question](https://github.com/user-attachments/assets/5cdb9fe2-3c6f-4387-8be1-de74cb16958c)

10. Answer Yes on the 2nd question, but No on the subquestion
![2nd-question](https://github.com/user-attachments/assets/1bb2d9c8-f67b-4287-b9f4-59576e0aac34)

11. Validate and see success validation again.

12. It that's confusing, watch this screen recording 😄 

https://github.com/user-attachments/assets/b763a1b4-b83b-4421-900b-bc9786c8df60

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
