### PR TITLE
CMDCT-3928: Adding specific language to definition of denom for CPA-AD measure because why not

### DIFF
--- a/services/ui-src/src/measures/2024/CPAAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/index.tsx
@@ -33,7 +33,7 @@ export const CPAAD = ({
         <>
           <Q.HowDidYouReport />
           <Q.DataSource type="adult" />
-          <Q.DefinitionOfPopulation coreSetId={coreSetId as string} />
+          <CMQ.DefinitionOfPopulation />
           <Q.PerformanceMeasure />
         </>
       )}

--- a/services/ui-src/src/measures/2024/CPAAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/index.tsx
@@ -36,6 +36,29 @@ const defOfDenomOptions: CMQ.CoreSetSpecificOptions = {
       </>
     ),
   },
+  ACS: {
+    options: [
+      {
+        displayValue: "Medicaid (Title XIX)",
+        value: "Medicaid (Title XIX)",
+      },
+      {
+        displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
+        value: "SurveySampleIncMedicareMedicaidDualEligible",
+      },
+    ],
+    helpText: (
+      <>
+        <CUI.Text mt="3" mb="3">
+          Please select all populations that are included in the survey sample.
+          For example, if your survey sample includes both non-dual Medicaid
+          (Title XIX) beneficiaries and Individuals Dually Eligible for Medicare
+          and Medicaid, select both Medicaid population (Title XIX) and
+          Individuals Dually Eligible for Medicare and Medicaid.
+        </CUI.Text>
+      </>
+    ),
+  },
   ACSC: {
     options: [
       {

--- a/services/ui-src/src/measures/2024/CPAAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/index.tsx
@@ -2,10 +2,64 @@ import * as Q from "./questions";
 import * as CMQ from "measures/2023/shared/CommonQuestions";
 import { useParams } from "react-router-dom";
 import * as QMR from "components";
+import * as CUI from "@chakra-ui/react";
 import { useFormContext } from "react-hook-form";
 import { FormData } from "./types";
 import { validationFunctions } from "./validation";
 import { useEffect } from "react";
+
+const defOfDenomOptions: CMQ.CoreSetSpecificOptions = {
+  ACSM: {
+    options: [
+      {
+        displayValue: "Medicaid (Title XIX)",
+        value: "Medicaid (Title XIX)",
+      },
+      {
+        displayValue: "Medicaid-Expansion CHIP (Title XXI)",
+        value: "SurveySampleIncCHIP",
+      },
+      {
+        displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
+        value: "SurveySampleIncMedicareMedicaidDualEligible",
+      },
+    ],
+    helpText: (
+      <>
+        <CUI.Text mt="3" mb="3">
+          Please select all populations that are included in the survey sample.
+          For example, if your survey sample includes both non-dual Medicaid
+          (Title XIX) beneficiaries and Individuals Dually Eligible for Medicare
+          and Medicaid, select both Medicaid population (Title XIX) and
+          Individuals Dually Eligible for Medicare and Medicaid.
+        </CUI.Text>
+      </>
+    ),
+  },
+  ACSC: {
+    options: [
+      {
+        displayValue: "Separate CHIP (Title XXI)",
+        value: "Separate CHIP (Title XXI)",
+      },
+      {
+        displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
+        value: "Individuals Dually Eligible for Medicare and Medicaid",
+      },
+    ],
+    helpText: (
+      <>
+        <CUI.Text mt="3" mb="3">
+          Please select all populations that are included in the survey sample.
+          For example, if your survey sample includes both Separate CHIP (Title
+          XXI) beneficiaries and Individuals Dually Eligible for Medicare and
+          Medicaid, select both Separate CHIP (Title XXI) and Individuals Dually
+          Eligible for Medicare and Medicaid.
+        </CUI.Text>
+      </>
+    ),
+  },
+};
 
 export const CPAAD = ({
   name,
@@ -33,7 +87,7 @@ export const CPAAD = ({
         <>
           <Q.HowDidYouReport />
           <Q.DataSource type="adult" />
-          <CMQ.DefinitionOfPopulation />
+          <CMQ.DefinitionOfPopulation coreSetOptions={defOfDenomOptions} />
           <Q.PerformanceMeasure />
         </>
       )}

--- a/services/ui-src/src/measures/2024/CPAAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/index.tsx
@@ -33,7 +33,7 @@ export const CPAAD = ({
         <>
           <Q.HowDidYouReport />
           <Q.DataSource type="adult" />
-          <CMQ.DefinitionOfPopulation />
+          <Q.DefinitionOfPopulation coreSetId={coreSetId as string} />
           <Q.PerformanceMeasure />
         </>
       )}

--- a/services/ui-src/src/measures/2024/CPAAD/questions/DefinitionOfPopulation.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/questions/DefinitionOfPopulation.tsx
@@ -3,55 +3,50 @@ import * as CUI from "@chakra-ui/react";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { FormData } from "../types";
 
-export const DefinitionOfPopulation = ({ coresetId }: any) => {
+interface DefOfDenomOption {
+  displayValue: string;
+  value: string;
+}
+interface CoreSetSpecificOptions {
+  [coreSetId: string]: {
+    options: DefOfDenomOption[];
+    helpText: string;
+  };
+}
+
+export const DefinitionOfPopulation = ({ coreSetId }: any) => {
   const register = useCustomRegister<FormData>();
 
-  // default options
-  const ACSMOptions = [
-    {
-      displayValue: "Medicaid (Title XIX)",
-      value: "Medicaid (Title XIX)",
-    },
-    {
-      displayValue: "Medicaid-Expansion CHIP (Title XXI)",
-      value: "SurveySampleIncCHIP",
-    },
-    {
-      displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
-      value: "SurveySampleIncMedicareMedicaidDualEligible",
-    },
-    {
-      displayValue: "Other",
-      value: "Other",
-      children: [
-        <QMR.TextArea
-          label="Define the Other survey population:"
-          name="define-the-other-survey-population"
-        />,
+  const coreSetSpecificOptions: CoreSetSpecificOptions = {
+    ACSM: {
+      options: [
+        {
+          displayValue: "Medicaid (Title XIX)",
+          value: "Medicaid (Title XIX)",
+        },
+        {
+          displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
+          value: "SurveySampleIncMedicareMedicaidDualEligible",
+        },
       ],
+      helpText:
+        "Please select all populations that are included in the survey sample. For example, if your survey sample includes both non-dual Medicaid (Title XIX) beneficiaries and Individuals Dually Eligible for Medicare and Medicaid, select both Medicaid population (Title XIX) and Individuals Dually Eligible for Medicare and Medicaid.",
     },
-  ];
-
-  const ACSCOptions = [
-    {
-      displayValue: "Separate CHIP (Title XXI)",
-      value: "Separate CHIP (Title XXI)",
-    },
-    {
-      displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
-      value: "Individuals Dually Eligible for Medicare and Medicaid",
-    },
-    {
-      displayValue: "Other",
-      value: "Other",
-      children: [
-        <QMR.TextArea
-          label="Define the Other survey population:"
-          name="define-the-other-survey-population"
-        />,
+    ACSC: {
+      options: [
+        {
+          displayValue: "Separate CHIP (Title XXI)",
+          value: "Separate CHIP (Title XXI)",
+        },
+        {
+          displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
+          value: "Individuals Dually Eligible for Medicare and Medicaid",
+        },
       ],
+      helpText:
+        "Please select all populations that are included in the survey sample. For example, if your survey sample includes both Separate CHIP (Title XXI) beneficiaries and Individuals Dually Eligible for Medicare and Medicaid, select both Separate CHIP (Title XXI) and Individuals Dually Eligible for Medicare and Medicaid.",
     },
-  ];
+  };
 
   return (
     <QMR.CoreQuestionWrapper
@@ -59,25 +54,29 @@ export const DefinitionOfPopulation = ({ coresetId }: any) => {
       label="Definition of Population Included in the Measure"
     >
       <CUI.Heading size="sm" as="h3">
-        Definition of population included in the survey sample
+        Definition of denominator
       </CUI.Heading>
       <CUI.Text mt="3" mb="3">
-        Please select all populations that are included. For example, if your
-        survey sample includes both non-dual Medicaid (Title XIX) beneficiaries
-        and Individuals Dually Eligible for Medicare and Medicaid, select both
-        Medicaid (Title XIX) and Individuals Dually Eligible for Medicare and
-        Medicaid. 
+        {coreSetSpecificOptions[coreSetId].helpText}
       </CUI.Text>
 
       <QMR.Checkbox
         {...register("DefinitionOfSurveySample")}
-        options={
-          coresetId === "ACSC" || coresetId === "CCSC"
-            ? ACSCOptions
-            : ACSMOptions
-        }
+        options={[
+          ...coreSetSpecificOptions[coreSetId].options,
+          {
+            displayValue: "Other",
+            value: "Other",
+            children: [
+              <QMR.TextArea
+                label="Define the Other survey population:"
+                name="define-the-other-survey-population"
+              />,
+            ],
+          },
+        ]}
       />
-      {coresetId === "ACSM" && (
+      {coreSetId === "ACSM" && (
         <QMR.TextArea
           label="If this measure has been reported by the state previously and there has been a change in the included population, please provide any available context below:"
           formControlProps={{ paddingTop: "15px" }}

--- a/services/ui-src/src/measures/2024/CPAAD/questions/DefinitionOfPopulation.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/questions/DefinitionOfPopulation.tsx
@@ -3,50 +3,55 @@ import * as CUI from "@chakra-ui/react";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { FormData } from "../types";
 
-interface DefOfDenomOption {
-  displayValue: string;
-  value: string;
-}
-interface CoreSetSpecificOptions {
-  [coreSetId: string]: {
-    options: DefOfDenomOption[];
-    helpText: string;
-  };
-}
-
-export const DefinitionOfPopulation = ({ coreSetId }: any) => {
+export const DefinitionOfPopulation = ({ coresetId }: any) => {
   const register = useCustomRegister<FormData>();
 
-  const coreSetSpecificOptions: CoreSetSpecificOptions = {
-    ACSM: {
-      options: [
-        {
-          displayValue: "Medicaid (Title XIX)",
-          value: "Medicaid (Title XIX)",
-        },
-        {
-          displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
-          value: "SurveySampleIncMedicareMedicaidDualEligible",
-        },
-      ],
-      helpText:
-        "Please select all populations that are included in the survey sample. For example, if your survey sample includes both non-dual Medicaid (Title XIX) beneficiaries and Individuals Dually Eligible for Medicare and Medicaid, select both Medicaid population (Title XIX) and Individuals Dually Eligible for Medicare and Medicaid.",
+  // default options
+  const ACSMOptions = [
+    {
+      displayValue: "Medicaid (Title XIX)",
+      value: "Medicaid (Title XIX)",
     },
-    ACSC: {
-      options: [
-        {
-          displayValue: "Separate CHIP (Title XXI)",
-          value: "Separate CHIP (Title XXI)",
-        },
-        {
-          displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
-          value: "Individuals Dually Eligible for Medicare and Medicaid",
-        },
-      ],
-      helpText:
-        "Please select all populations that are included in the survey sample. For example, if your survey sample includes both Separate CHIP (Title XXI) beneficiaries and Individuals Dually Eligible for Medicare and Medicaid, select both Separate CHIP (Title XXI) and Individuals Dually Eligible for Medicare and Medicaid.",
+    {
+      displayValue: "Medicaid-Expansion CHIP (Title XXI)",
+      value: "SurveySampleIncCHIP",
     },
-  };
+    {
+      displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
+      value: "SurveySampleIncMedicareMedicaidDualEligible",
+    },
+    {
+      displayValue: "Other",
+      value: "Other",
+      children: [
+        <QMR.TextArea
+          label="Define the Other survey population:"
+          name="define-the-other-survey-population"
+        />,
+      ],
+    },
+  ];
+
+  const ACSCOptions = [
+    {
+      displayValue: "Separate CHIP (Title XXI)",
+      value: "Separate CHIP (Title XXI)",
+    },
+    {
+      displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
+      value: "Individuals Dually Eligible for Medicare and Medicaid",
+    },
+    {
+      displayValue: "Other",
+      value: "Other",
+      children: [
+        <QMR.TextArea
+          label="Define the Other survey population:"
+          name="define-the-other-survey-population"
+        />,
+      ],
+    },
+  ];
 
   return (
     <QMR.CoreQuestionWrapper
@@ -54,29 +59,25 @@ export const DefinitionOfPopulation = ({ coreSetId }: any) => {
       label="Definition of Population Included in the Measure"
     >
       <CUI.Heading size="sm" as="h3">
-        Definition of denominator
+        Definition of population included in the survey sample
       </CUI.Heading>
       <CUI.Text mt="3" mb="3">
-        {coreSetSpecificOptions[coreSetId].helpText}
+        Please select all populations that are included. For example, if your
+        survey sample includes both non-dual Medicaid (Title XIX) beneficiaries
+        and Individuals Dually Eligible for Medicare and Medicaid, select both
+        Medicaid (Title XIX) and Individuals Dually Eligible for Medicare and
+        Medicaid. 
       </CUI.Text>
 
       <QMR.Checkbox
         {...register("DefinitionOfSurveySample")}
-        options={[
-          ...coreSetSpecificOptions[coreSetId].options,
-          {
-            displayValue: "Other",
-            value: "Other",
-            children: [
-              <QMR.TextArea
-                label="Define the Other survey population:"
-                name="define-the-other-survey-population"
-              />,
-            ],
-          },
-        ]}
+        options={
+          coresetId === "ACSC" || coresetId === "CCSC"
+            ? ACSCOptions
+            : ACSMOptions
+        }
       />
-      {coreSetId === "ACSM" && (
+      {coresetId === "ACSM" && (
         <QMR.TextArea
           label="If this measure has been reported by the state previously and there has been a change in the included population, please provide any available context below:"
           formControlProps={{ paddingTop: "15px" }}

--- a/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
@@ -11,79 +11,25 @@ import * as DC from "dataConstants";
 import { useContext } from "react";
 import SharedContext from "shared/SharedContext";
 import { AnyObject } from "types";
-import { useParams, useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 interface Props {
   childMeasure?: boolean;
   hybridMeasure?: boolean;
   populationSampleSize?: boolean;
   healthHomeMeasure?: boolean;
+  coreSetOptions?: CoreSetSpecificOptions;
 }
 interface DefOfDenomOption {
   displayValue: string;
   value: string;
 }
-interface CoreSetSpecificOptions {
+export interface CoreSetSpecificOptions {
   [coreSetId: string]: {
     options: DefOfDenomOption[];
     helpText: JSX.Element;
   };
 }
-
-const surveyMeasures = ["CPA-AD"];
-
-const surveyMeasureOptions: CoreSetSpecificOptions = {
-  ACSM: {
-    options: [
-      {
-        displayValue: "Medicaid (Title XIX)",
-        value: "Medicaid (Title XIX)",
-      },
-      {
-        displayValue: "Medicaid-Expansion CHIP (Title XXI)",
-        value: "SurveySampleIncCHIP",
-      },
-      {
-        displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
-        value: "SurveySampleIncMedicareMedicaidDualEligible",
-      },
-    ],
-    helpText: (
-      <>
-        <CUI.Text mt="3" mb="3">
-          Please select all populations that are included in the survey sample.
-          For example, if your survey sample includes both non-dual Medicaid
-          (Title XIX) beneficiaries and Individuals Dually Eligible for Medicare
-          and Medicaid, select both Medicaid population (Title XIX) and
-          Individuals Dually Eligible for Medicare and Medicaid.
-        </CUI.Text>
-      </>
-    ),
-  },
-  ACSC: {
-    options: [
-      {
-        displayValue: "Separate CHIP (Title XXI)",
-        value: "Separate CHIP (Title XXI)",
-      },
-      {
-        displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
-        value: "Individuals Dually Eligible for Medicare and Medicaid",
-      },
-    ],
-    helpText: (
-      <>
-        <CUI.Text mt="3" mb="3">
-          Please select all populations that are included in the survey sample.
-          For example, if your survey sample includes both Separate CHIP (Title
-          XXI) beneficiaries and Individuals Dually Eligible for Medicare and
-          Medicaid, select both Separate CHIP (Title XXI) and Individuals Dually
-          Eligible for Medicare and Medicaid.
-        </CUI.Text>
-      </>
-    ),
-  },
-};
 
 const defOfDenomOptions: { [coreSetType: string]: DefOfDenomOption[] } = {
   standard: [
@@ -355,12 +301,9 @@ const CoreSetSpecificDefinitions = (
   register: any,
   labels: AnyObject,
   coreSetType: string,
-  measureName?: string
+  coreSetOptions?: CoreSetSpecificOptions
 ) => {
-  const options =
-    measureName && surveyMeasures.includes(measureName)
-      ? surveyMeasureOptions
-      : coreSetSpecificOptions;
+  const options = coreSetOptions ?? coreSetSpecificOptions;
   return (
     <CUI.Box>
       {options[coreSetType].helpText}
@@ -458,6 +401,7 @@ export const DefinitionOfPopulation = ({
   populationSampleSize,
   hybridMeasure,
   healthHomeMeasure,
+  coreSetOptions,
 }: Props) => {
   const register = useCustomRegister<Types.DefinitionOfPopulation>();
 
@@ -465,13 +409,7 @@ export const DefinitionOfPopulation = ({
   const labels: any = useContext(SharedContext);
 
   const params = useParams();
-  const { pathname } = useLocation();
   const coreSetType = healthHomeMeasure ? "HHCS" : params.coreSetId;
-
-  const measureName = pathname.substring(
-    pathname.lastIndexOf("/") + 1,
-    pathname.length
-  );
 
   return (
     <QMR.CoreQuestionWrapper
@@ -486,7 +424,7 @@ export const DefinitionOfPopulation = ({
             register,
             labels.DefinitionsOfPopulation,
             coreSetType,
-            measureName
+            coreSetOptions
           )
         : childMeasure
         ? ChildDefinitions(register)

--- a/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
@@ -40,13 +40,17 @@ const surveyMeasureOptions: CoreSetSpecificOptions = {
         value: "Medicaid (Title XIX)",
       },
       {
+        displayValue: "Medicaid-Expansion CHIP (Title XXI)",
+        value: "SurveySampleIncCHIP",
+      },
+      {
         displayValue: "Individuals Dually Eligible for Medicare and Medicaid",
         value: "SurveySampleIncMedicareMedicaidDualEligible",
       },
     ],
     helpText: (
       <>
-        <CUI.Text mt="3">
+        <CUI.Text mt="3" mb="3">
           Please select all populations that are included in the survey sample.
           For example, if your survey sample includes both non-dual Medicaid
           (Title XIX) beneficiaries and Individuals Dually Eligible for Medicare
@@ -69,7 +73,7 @@ const surveyMeasureOptions: CoreSetSpecificOptions = {
     ],
     helpText: (
       <>
-        <CUI.Text mt="3">
+        <CUI.Text mt="3" mb="3">
           Please select all populations that are included in the survey sample.
           For example, if your survey sample includes both Separate CHIP (Title
           XXI) beneficiaries and Individuals Dually Eligible for Medicare and


### PR DESCRIPTION
### Description
CPA-AD needs custom definition of denominator options and helper text. I did this by adding custom options to the CPA-AD index file and passing them in as an optional prop to DefinitionsOfPopulation common component. Then either render the prop or default coreset specific ones. Thanks to @ailZhou for that solution!


### Related ticket(s)
CMDCT-3928

---
### How to test
1. Login as user with separate medicaid and chip coresets
2. Navigate to adult medicaid and to the CPA-AD measure
3. Make sure that the text under "Definition of Denominator" matches what is in the [ticket](https://jiraent.cms.gov/browse/CMDCT-3928)
4. Repeat steps 2 & 3 for adult chip