### PR TITLE
CMDCT-3918: adding gross ternary to render health home question

### DIFF
--- a/services/ui-src/src/labels/2021/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2021/commonQuestionsLabel.tsx
@@ -58,8 +58,10 @@ export const commonQuestionsLabel = {
   DefinitionsOfPopulation: {
     defineDenomOther: "Define the other denominator population:",
     measureEligiblePopDenom: {
-      question:
-        "Does this denominator represent your total measure-eligible population as defined by the Technical Specifications for this measure?",
+      question: {
+        default:
+          "Does this denominator represent your total measure-eligible population as defined by the Technical Specifications for this measure?",
+      },
       optionYes:
         "Yes, this denominator represents the total measure-eligible population as defined by the Technical Specifications for this measure.",
       optionNo:

--- a/services/ui-src/src/labels/2022/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2022/commonQuestionsLabel.tsx
@@ -57,8 +57,10 @@ export const commonQuestionsLabel = {
   DefinitionsOfPopulation: {
     defineDenomOther: "Define the other denominator population:",
     measureEligiblePopDenom: {
-      question:
-        "Does this denominator represent your total measure-eligible population as defined by the Technical Specifications for this measure?",
+      question: {
+        default:
+          "Does this denominator represent your total measure-eligible population as defined by the Technical Specifications for this measure?",
+      },
       optionYes:
         "Yes, this denominator represents the total measure-eligible population as defined by the Technical Specifications for this measure.",
       optionNo:

--- a/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
@@ -61,8 +61,10 @@ export const commonQuestionsLabel = {
     defineDenomOther:
       "Define the other denominator population (<em>text in this field is included in publicly-reported state-specific comments</em>):",
     measureEligiblePopDenom: {
-      question:
-        "Does this denominator represent your total measure-eligible population as defined by the Technical Specifications for this measure?",
+      question: {
+        default:
+          "Does this denominator represent your total measure-eligible population as defined by the Technical Specifications for this measure?",
+      },
       optionYes:
         "Yes, this denominator represents the total measure-eligible population as defined by the Technical Specifications for this measure.",
       optionNo:

--- a/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
@@ -68,6 +68,8 @@ export const commonQuestionsLabel = {
     measureEligiblePopDenom: {
       question:
         "Does this denominator represent your total measure-eligible population as defined by the technical specifications for this measure? This includes beneficiaries who move between programs (Medicaid and CHIP), plans, or delivery systems during the measurement year but met continuous enrollment requirements at the state level.",
+      healthHomeQuestion:
+        "Does this denominator represent your total measure-eligible population as defined by the technical specifications for this measure? This includes enrollees who move between health home providers, plans, or delivery systems during the measurement year but met continuous enrollment requirements at the state level.",
       optionYes:
         "Yes, this denominator includes the total measure-eligible population as defined by the Technical Specifications for this measure.",
       optionNo:

--- a/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
@@ -66,10 +66,11 @@ export const commonQuestionsLabel = {
   DefinitionsOfPopulation: {
     defineDenomOther: "Define the other denominator population:",
     measureEligiblePopDenom: {
-      question:
-        "Does this denominator represent your total measure-eligible population as defined by the technical specifications for this measure? This includes beneficiaries who move between programs (Medicaid and CHIP), plans, or delivery systems during the measurement year but met continuous enrollment requirements at the state level.",
-      healthHomeQuestion:
-        "Does this denominator represent your total measure-eligible population as defined by the technical specifications for this measure? This includes enrollees who move between health home providers, plans, or delivery systems during the measurement year but met continuous enrollment requirements at the state level.",
+      question: {
+        default:
+          "Does this denominator represent your total measure-eligible population as defined by the technical specifications for this measure? This includes beneficiaries who move between programs (Medicaid and CHIP), plans, or delivery systems during the measurement year but met continuous enrollment requirements at the state level.",
+        HHCS: "Does this denominator represent your total measure-eligible population as defined by the technical specifications for this measure? This includes enrollees who move between health home providers, plans, or delivery systems during the measurement year but met continuous enrollment requirements at the state level.",
+      },
       optionYes:
         "Yes, this denominator includes the total measure-eligible population as defined by the Technical Specifications for this measure.",
       optionNo:

--- a/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
@@ -411,6 +411,8 @@ export const DefinitionOfPopulation = ({
   const params = useParams();
   const coreSetType = healthHomeMeasure ? "HHCS" : params.coreSetId;
 
+  const mepDenomLabels = labels.DefinitionsOfPopulation.measureEligiblePopDenom;
+
   return (
     <QMR.CoreQuestionWrapper
       testid="definition-of-population"
@@ -445,19 +447,18 @@ export const DefinitionOfPopulation = ({
         <QMR.RadioButton
           formLabelProps={{ fontWeight: "600" }}
           label={
-            labels.DefinitionsOfPopulation.measureEligiblePopDenom.question
+            healthHomeMeasure && mepDenomLabels.healthHomeQuestion
+              ? mepDenomLabels.healthHomeQuestion
+              : mepDenomLabels.question
           }
           {...register(DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC)}
           options={[
             {
-              displayValue:
-                labels.DefinitionsOfPopulation.measureEligiblePopDenom
-                  .optionYes,
+              displayValue: mepDenomLabels.optionYes,
               value: DC.YES,
             },
             {
-              displayValue:
-                labels.DefinitionsOfPopulation.measureEligiblePopDenom.optionNo,
+              displayValue: mepDenomLabels.optionNo,
               value: DC.NO,
               children: [
                 <QMR.TextArea

--- a/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
@@ -411,8 +411,6 @@ export const DefinitionOfPopulation = ({
   const params = useParams();
   const coreSetType = healthHomeMeasure ? "HHCS" : params.coreSetId;
 
-  const mepDenomLabels = labels.DefinitionsOfPopulation.measureEligiblePopDenom;
-
   return (
     <QMR.CoreQuestionWrapper
       testid="definition-of-population"
@@ -447,18 +445,23 @@ export const DefinitionOfPopulation = ({
         <QMR.RadioButton
           formLabelProps={{ fontWeight: "600" }}
           label={
-            healthHomeMeasure && mepDenomLabels.healthHomeQuestion
-              ? mepDenomLabels.healthHomeQuestion
-              : mepDenomLabels.question
+            labels.DefinitionsOfPopulation.measureEligiblePopDenom.question[
+              coreSetType!
+            ] ??
+            labels.DefinitionsOfPopulation.measureEligiblePopDenom.question
+              .default
           }
           {...register(DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC)}
           options={[
             {
-              displayValue: mepDenomLabels.optionYes,
+              displayValue:
+                labels.DefinitionsOfPopulation.measureEligiblePopDenom
+                  .optionYes,
               value: DC.YES,
             },
             {
-              displayValue: mepDenomLabels.optionNo,
+              displayValue:
+                labels.DefinitionsOfPopulation.measureEligiblePopDenom.optionNo,
               value: DC.NO,
               children: [
                 <QMR.TextArea


### PR DESCRIPTION
### Description
This is gross and I hate it. Basically adding a healthHomeQuestion label to 2024 labels and rendering that if it exists and is a health home measure. otherwise rendering the question


### Related ticket(s)
CMDCT-3918

---
### How to test
1. Navigate to user with HH measures (DC is one)
2. Click into any health home measure and make sure that the "Does this denominator represent..." question has the same wording that is requested in the [ticket](https://jiraent.cms.gov/browse/CMDCT-3918)
3. Click into any adult measure and make sure the "Does this denominator represent..." question does not reference health home
