### PR TITLE
Remove Combined Rate(s) Question From Measures (Health Home)

### DIFF
--- a/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
@@ -11,22 +11,6 @@ export const commonQuestionsLabel = {
     },
   },
   CombinedRates: {
-    header: "Combined Rate(s) from Multiple Reporting Units",
-    healthHome: {
-      question:
-        "Did you combine rates from multiple reporting units (e.g. Health Home Providers) to create a Health Home Program-Level rate?",
-      optionYes:
-        "Yes, we combined rates from multiple reporting units to create a Health Home Program-Level rate.",
-      optionNo:
-        "No, we did not combine rates from multiple reporting units to create a Program-Level rate for Health Home measures.",
-      notWeightedRate:
-        "The rates are not weighted based on the size of the measure-eligible population. All reporting units are given equal weights when calculating a Program-Level rate.",
-      weightedRate:
-        "The rates are weighted based on the size of the measure-eligible population for each reporting unit.",
-      weightedRateOther:
-        "The rates are weighted based on another weighting factor.",
-      weightedRateOtherExplain: "Describe the other weighting factor:",
-    },
     notHealthHome: {
       question:
         "Did you combine rates from multiple reporting units (e.g. health plans, delivery systems, programs) to create a State-Level rate?",

--- a/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
@@ -10,23 +10,6 @@ export const commonQuestionsLabel = {
         "Please add any additional notes or comments on the measure not otherwise captured above (<em>text in this field is included in publicly-reported state-specific comments</em>):",
     },
   },
-  CombinedRates: {
-    notHealthHome: {
-      question:
-        "Did you combine rates from multiple reporting units (e.g. health plans, delivery systems, programs) to create a State-Level rate?",
-      optionYes:
-        "Yes, we combined rates from multiple reporting units to create a State-Level rate.",
-      optionNo:
-        "No, we did not combine rates from multiple reporting units to create a State-Level rate.",
-      notWeightedRate:
-        "The rates are not weighted based on the size of the measure-eligible population. All reporting units are given equal weights when calculating a State-Level rate.",
-      weightedRate:
-        "The rates are weighted based on the size of the measure-eligible population for each reporting unit.",
-      weightedRateOther:
-        "The rates are weighted based on another weighting factor.",
-      weightedRateOtherExplain: "Describe the other weighting factor:",
-    },
-  },
   DataSource: {
     ehrSrc: "Describe the data source:",
     describeDataSrc:

--- a/services/ui-src/src/shared/commonQuestions/CombinedRates.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRates.test.tsx
@@ -3,12 +3,12 @@ import { CombinedRates } from "./CombinedRates";
 import { screen } from "@testing-library/react";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import SharedContext from "shared/SharedContext";
-import commonQuestionsLabel from "labels/2024/commonQuestionsLabel";
+import commonQuestionsLabel from "labels/2023/commonQuestionsLabel";
 
 describe("Test CombinedRates component", () => {
   beforeEach(() => {
     renderWithHookForm(
-      <SharedContext.Provider value={commonQuestionsLabel}>
+      <SharedContext.Provider value={{ ...commonQuestionsLabel, year: 2023 }}>
         <CombinedRates />
       </SharedContext.Provider>
     );
@@ -99,7 +99,7 @@ describe("Test CombinedRates component", () => {
 describe("Test CombinedRates component for Health Homes", () => {
   beforeEach(() => {
     renderWithHookForm(
-      <SharedContext.Provider value={commonQuestionsLabel}>
+      <SharedContext.Provider value={{ ...commonQuestionsLabel, year: 2023 }}>
         <CombinedRates healthHomeMeasure />
       </SharedContext.Provider>
     );

--- a/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
@@ -21,65 +21,67 @@ export const CombinedRates = ({ healthHomeMeasure }: Props) => {
     : labels.CombinedRates.notHealthHome;
 
   return (
-    <QMR.CoreQuestionWrapper
-      testid="combined-rates"
-      label={labels.CombinedRates.header}
-    >
-      <CUI.Text fontWeight={600}>{combinedLabel?.question}</CUI.Text>
-      <CUI.Text mb={2}>
-        For additional information refer to the{" "}
-        <CUI.Link
-          href="https://www.medicaid.gov/medicaid/quality-of-care/downloads/state-level-rates-brief.pdf"
-          color="blue"
-          isExternal
-          aria-label="Additional state level brief information"
-        >
-          <u>State-Level Rate Brief</u>
-        </CUI.Link>
-        .
-      </CUI.Text>
-      <QMR.RadioButton
-        options={[
-          {
-            displayValue: combinedLabel.optionYes,
-            value: DC.YES,
-            children: [
-              <QMR.RadioButton
-                {...register(DC.COMBINED_RATES_COMBINED_RATES)}
-                options={[
-                  {
-                    displayValue: combinedLabel.notWeightedRate,
-                    value: DC.COMBINED_NOT_WEIGHTED_RATES,
-                  },
-                  {
-                    displayValue: combinedLabel.weightedRate,
-                    value: DC.COMBINED_WEIGHTED_RATES,
-                  },
-                  {
-                    displayValue: combinedLabel.weightedRateOther,
-                    value: DC.COMBINED_WEIGHTED_RATES_OTHER,
-                    children: [
-                      <QMR.TextArea
-                        {...register(
-                          DC.COMBINED_WEIGHTED_RATES_OTHER_EXPLAINATION
-                        )}
-                        label={combinedLabel.weightedRateOtherExplain}
-                        formLabelProps={{ fontWeight: 400 }}
-                      />,
-                    ],
-                  },
-                ]}
-              />,
-            ],
-          },
-          {
-            displayValue: combinedLabel.optionNo,
-            value: DC.NO,
-          },
-        ]}
-        renderHelperTextAbove
-        {...register(DC.COMBINED_RATES)}
-      />
-    </QMR.CoreQuestionWrapper>
+    labels.year < 2024 && (
+      <QMR.CoreQuestionWrapper
+        testid="combined-rates"
+        label={labels.CombinedRates.header}
+      >
+        <CUI.Text fontWeight={600}>{combinedLabel?.question}</CUI.Text>
+        <CUI.Text mb={2}>
+          For additional information refer to the{" "}
+          <CUI.Link
+            href="https://www.medicaid.gov/medicaid/quality-of-care/downloads/state-level-rates-brief.pdf"
+            color="blue"
+            isExternal
+            aria-label="Additional state level brief information"
+          >
+            <u>State-Level Rate Brief</u>
+          </CUI.Link>
+          .
+        </CUI.Text>
+        <QMR.RadioButton
+          options={[
+            {
+              displayValue: combinedLabel.optionYes,
+              value: DC.YES,
+              children: [
+                <QMR.RadioButton
+                  {...register(DC.COMBINED_RATES_COMBINED_RATES)}
+                  options={[
+                    {
+                      displayValue: combinedLabel.notWeightedRate,
+                      value: DC.COMBINED_NOT_WEIGHTED_RATES,
+                    },
+                    {
+                      displayValue: combinedLabel.weightedRate,
+                      value: DC.COMBINED_WEIGHTED_RATES,
+                    },
+                    {
+                      displayValue: combinedLabel.weightedRateOther,
+                      value: DC.COMBINED_WEIGHTED_RATES_OTHER,
+                      children: [
+                        <QMR.TextArea
+                          {...register(
+                            DC.COMBINED_WEIGHTED_RATES_OTHER_EXPLAINATION
+                          )}
+                          label={combinedLabel.weightedRateOtherExplain}
+                          formLabelProps={{ fontWeight: 400 }}
+                        />,
+                      ],
+                    },
+                  ]}
+                />,
+              ],
+            },
+            {
+              displayValue: combinedLabel.optionNo,
+              value: DC.NO,
+            },
+          ]}
+          renderHelperTextAbove
+          {...register(DC.COMBINED_RATES)}
+        />
+      </QMR.CoreQuestionWrapper>
+    )
   );
 };

--- a/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
@@ -20,8 +20,6 @@ export const CombinedRates = ({ healthHomeMeasure }: Props) => {
     ? labels.CombinedRates.healthHome
     : labels.CombinedRates.notHealthHome;
 
-  console.log(labels);
-
   return (
     <>
       {Number(labels.year) < 2024 && (

--- a/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
@@ -17,12 +17,12 @@ export const CombinedRates = ({ healthHomeMeasure }: Props) => {
   const labels: any = useContext(SharedContext);
 
   const combinedLabel = healthHomeMeasure
-    ? labels.CombinedRates.healthHome
-    : labels.CombinedRates.notHealthHome;
+    ? labels.CombinedRates?.healthHome
+    : labels.CombinedRates?.notHealthHome;
 
   return (
     <>
-      {Number(labels.year) < 2024 && (
+      {labels.CombinedRates && (
         <QMR.CoreQuestionWrapper
           testid="combined-rates"
           label={labels.CombinedRates.header}

--- a/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
@@ -20,68 +20,72 @@ export const CombinedRates = ({ healthHomeMeasure }: Props) => {
     ? labels.CombinedRates.healthHome
     : labels.CombinedRates.notHealthHome;
 
+  console.log(labels);
+
   return (
-    labels.year < 2024 && (
-      <QMR.CoreQuestionWrapper
-        testid="combined-rates"
-        label={labels.CombinedRates.header}
-      >
-        <CUI.Text fontWeight={600}>{combinedLabel?.question}</CUI.Text>
-        <CUI.Text mb={2}>
-          For additional information refer to the{" "}
-          <CUI.Link
-            href="https://www.medicaid.gov/medicaid/quality-of-care/downloads/state-level-rates-brief.pdf"
-            color="blue"
-            isExternal
-            aria-label="Additional state level brief information"
-          >
-            <u>State-Level Rate Brief</u>
-          </CUI.Link>
-          .
-        </CUI.Text>
-        <QMR.RadioButton
-          options={[
-            {
-              displayValue: combinedLabel.optionYes,
-              value: DC.YES,
-              children: [
-                <QMR.RadioButton
-                  {...register(DC.COMBINED_RATES_COMBINED_RATES)}
-                  options={[
-                    {
-                      displayValue: combinedLabel.notWeightedRate,
-                      value: DC.COMBINED_NOT_WEIGHTED_RATES,
-                    },
-                    {
-                      displayValue: combinedLabel.weightedRate,
-                      value: DC.COMBINED_WEIGHTED_RATES,
-                    },
-                    {
-                      displayValue: combinedLabel.weightedRateOther,
-                      value: DC.COMBINED_WEIGHTED_RATES_OTHER,
-                      children: [
-                        <QMR.TextArea
-                          {...register(
-                            DC.COMBINED_WEIGHTED_RATES_OTHER_EXPLAINATION
-                          )}
-                          label={combinedLabel.weightedRateOtherExplain}
-                          formLabelProps={{ fontWeight: 400 }}
-                        />,
-                      ],
-                    },
-                  ]}
-                />,
-              ],
-            },
-            {
-              displayValue: combinedLabel.optionNo,
-              value: DC.NO,
-            },
-          ]}
-          renderHelperTextAbove
-          {...register(DC.COMBINED_RATES)}
-        />
-      </QMR.CoreQuestionWrapper>
-    )
+    <>
+      {Number(labels.year) < 2024 && (
+        <QMR.CoreQuestionWrapper
+          testid="combined-rates"
+          label={labels.CombinedRates.header}
+        >
+          <CUI.Text fontWeight={600}>{combinedLabel?.question}</CUI.Text>
+          <CUI.Text mb={2}>
+            For additional information refer to the{" "}
+            <CUI.Link
+              href="https://www.medicaid.gov/medicaid/quality-of-care/downloads/state-level-rates-brief.pdf"
+              color="blue"
+              isExternal
+              aria-label="Additional state level brief information"
+            >
+              <u>State-Level Rate Brief</u>
+            </CUI.Link>
+            .
+          </CUI.Text>
+          <QMR.RadioButton
+            options={[
+              {
+                displayValue: combinedLabel.optionYes,
+                value: DC.YES,
+                children: [
+                  <QMR.RadioButton
+                    {...register(DC.COMBINED_RATES_COMBINED_RATES)}
+                    options={[
+                      {
+                        displayValue: combinedLabel.notWeightedRate,
+                        value: DC.COMBINED_NOT_WEIGHTED_RATES,
+                      },
+                      {
+                        displayValue: combinedLabel.weightedRate,
+                        value: DC.COMBINED_WEIGHTED_RATES,
+                      },
+                      {
+                        displayValue: combinedLabel.weightedRateOther,
+                        value: DC.COMBINED_WEIGHTED_RATES_OTHER,
+                        children: [
+                          <QMR.TextArea
+                            {...register(
+                              DC.COMBINED_WEIGHTED_RATES_OTHER_EXPLAINATION
+                            )}
+                            label={combinedLabel.weightedRateOtherExplain}
+                            formLabelProps={{ fontWeight: 400 }}
+                          />,
+                        ],
+                      },
+                    ]}
+                  />,
+                ],
+              },
+              {
+                displayValue: combinedLabel.optionNo,
+                value: DC.NO,
+              },
+            ]}
+            renderHelperTextAbove
+            {...register(DC.COMBINED_RATES)}
+          />
+        </QMR.CoreQuestionWrapper>
+      )}
+    </>
   );
 };

--- a/tests/cypress/cypress/e2e/userflow_adult.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_adult.spec.ts
@@ -47,8 +47,8 @@ describe("Measure: CDF-AD", () => {
   });
 
   it("Ensure correct sections display if user is/not reporting", () => {
-    cy.displaysSectionsWhenUserNotReporting(abbr);
-    cy.displaysSectionsWhenUserIsReporting(abbr);
+    cy.displaysSectionsWhenUserNotReporting(abbr, testingYear);
+    cy.displaysSectionsWhenUserIsReporting(abbr, testingYear);
   });
 
   it(

--- a/tests/cypress/cypress/e2e/userflow_child.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_child.spec.ts
@@ -41,8 +41,8 @@ describe("Measure: CCW-CH", () => {
   });
 
   it("Ensure correct sections display if user is/not reporting", () => {
-    cy.displaysSectionsWhenUserNotReporting(abbr);
-    cy.displaysSectionsWhenUserIsReporting(abbr);
+    cy.displaysSectionsWhenUserNotReporting(abbr, testingYear);
+    cy.displaysSectionsWhenUserIsReporting(abbr, testingYear);
   });
 
   it(

--- a/tests/cypress/cypress/e2e/userflow_healthhome.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_healthhome.spec.ts
@@ -27,8 +27,8 @@ describe("Measure: AMB-HH", () => {
   });
 
   it("Ensure correct sections display if user is/not reporting", () => {
-    cy.displaysSectionsWhenUserNotReporting("HHCS");
-    cy.displaysSectionsWhenUserIsReporting("HHCS");
+    cy.displaysSectionsWhenUserNotReporting("HHCS", testingYear);
+    cy.displaysSectionsWhenUserIsReporting("HHCS", testingYear);
   });
 
   it(

--- a/tests/cypress/helper.d.ts
+++ b/tests/cypress/helper.d.ts
@@ -30,10 +30,16 @@ declare namespace Cypress {
     goToMeasure(measure: MeasureList | string): Chainable<Element>;
 
     // Correct sections visible when user is reporting data on measure
-    displaysSectionsWhenUserIsReporting(coreSet: string): Chainable<Element>;
+    displaysSectionsWhenUserIsReporting(
+      coreSet: string,
+      year: string
+    ): Chainable<Element>;
 
     // Correct sections visible when user is not reporting data on measure
-    displaysSectionsWhenUserNotReporting(coreSet: string): Chainable<Element>;
+    displaysSectionsWhenUserNotReporting(
+      coreSet: string,
+      year: string
+    ): Chainable<Element>;
 
     // removes child core set from main page
     deleteChildCoreSets(): Chainable<Element>;

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -101,7 +101,7 @@ Cypress.Commands.add("goToMeasure", (measure) => {
 // Correct sections visible when user is reporting data on measure
 Cypress.Commands.add(
   "displaysSectionsWhenUserIsReporting",
-  (coreSet: string) => {
+  (coreSet: string, year: string) => {
     cy.get('[data-cy="DidReport0"]').click();
 
     // these sections should not exist when a user selects they are reporting
@@ -118,7 +118,7 @@ Cypress.Commands.add(
       '[data-cy="Definition of Population Included in the Measure"]'
     ).should("be.visible");
 
-    if (coreSet === "HHCS") {
+    if (coreSet === "HHCS" && Number(year) < 2024) {
       cy.get(
         '[data-cy="Combined Rate(s) from Multiple Reporting Units"]'
       ).should("be.visible");
@@ -133,7 +133,7 @@ Cypress.Commands.add(
 // Correct sections visible when user is not reporting data on measure
 Cypress.Commands.add(
   "displaysSectionsWhenUserNotReporting",
-  (coreSet: string) => {
+  (coreSet: string, year) => {
     cy.wait(1000);
     cy.get('[data-cy="DidReport1"]').click();
 
@@ -146,7 +146,7 @@ Cypress.Commands.add(
       '[data-cy="Definition of Population Included in the Measure"]'
     ).should("not.exist");
 
-    if (coreSet === "HHCS") {
+    if (coreSet === "HHCS" && Number(year) < 2024) {
       cy.get(
         '[data-cy="Combined Rate(s) from Multiple Reporting Units"]'
       ).should("not.exist");

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -133,7 +133,7 @@ Cypress.Commands.add(
 // Correct sections visible when user is not reporting data on measure
 Cypress.Commands.add(
   "displaysSectionsWhenUserNotReporting",
-  (coreSet: string, year) => {
+  (coreSet: string, year: string) => {
     cy.wait(1000);
     cy.get('[data-cy="DidReport1"]').click();
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3930

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Add Health home core set for 2024
2. Pick a HH measure, fill it out and confirm that the "Combined Rate(s) from Multiple Reporting Units" section does not display (more details about how the section looks is in the ticket) 
3. Check other reporting years and confirm section exists for 2021,2022, and 2023

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
