### PR TITLE
[QMR] Remove content - Child core set qualifiers 

### DIFF
--- a/services/ui-src/src/measures/2024/shared/Qualifiers/data.ts
+++ b/services/ui-src/src/measures/2024/shared/Qualifiers/data.ts
@@ -184,7 +184,7 @@ const ChildMedicaidData: DataDriven = {
   title: "Child Core Set Qualifiers: Medicaid",
   questionTitle: "Child Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of September 30, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system (optional)?`,
+    `As of September 30, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system?`,
   textTable: [["Medicaid (Title XIX & XXI)", "Under Age 21"]],
   fieldValues: ["UnderTwentyOne"],
   formData: {


### PR DESCRIPTION
### Description
The tiniest content update. 
Remove the word "optional" from the banner for Child Core Set Qualifiers.

### Related ticket(s)
CMDCT-3942

---
### How to test
Deploy Link: https://d2bhc7t034vv5w.cloudfront.net/

1. Sign into QMR, with stateuserWA@test.com and/or stateuser1@test.com

2. Click on `Child Core Set Measures: Medicaid (Title XIX & XXI)`
![Child_CoreSet_Measures_Link](https://github.com/user-attachments/assets/8207542c-e939-45b4-9c92-2e181fe134fb)

3. Click on `Child Core Set Questions: Medicaid (Title XIX & XXI)`
![Child_CoreSet_Qualifier_Questions](https://github.com/user-attachments/assets/cd154a1d-f674-4b27-8c02-b0036bb50536)

4. Confirm `(optional)` is removed from the following sentence: 
![DeliverySystem_Question](https://github.com/user-attachments/assets/08a2f83f-263a-44ab-9008-0f2f8fd86b49)

> 1. Delivery System
> As of September 30, 2023, what percentage of your Medicaid (Title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system (optional)?

### Notes

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary