### PR TITLE
Measure Header Updates 

### DIFF
--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -26,6 +26,7 @@ import { measureDescriptions } from "measures/measureDescriptions";
 import { CompleteCoreSets } from "./complete";
 import SharedContext from "shared/SharedContext";
 import * as Labels from "labels/Labels";
+import { coreSetBreadCrumbTitle } from "shared/coreSetByYear";
 
 const LastModifiedBy = ({ user }: { user: string | undefined }) => {
   if (!user) return null;
@@ -402,12 +403,7 @@ export const MeasureWrapper = ({
     return null;
   }
 
-  const separatedCoreSet: { [key: string]: string } = {
-    [CoreSetAbbr.ACSC]: "(Separate CHIP)",
-    [CoreSetAbbr.ACSM]: "(Medicaid (Title XIX & XXI)))",
-    [CoreSetAbbr.CCSC]: "(Separate CHIP)",
-    [CoreSetAbbr.CCSM]: "(Medicaid (Title XIX & XXI)))",
-  };
+  const separatedCoreSet = coreSetBreadCrumbTitle(year);
 
   const formatTitle = (customDescription?: string) => {
     const foundMeasureDescription =
@@ -417,7 +413,7 @@ export const MeasureWrapper = ({
   };
 
   const breadCrumbName =
-    separatedCoreSet[params.coreSetId] ??
+    separatedCoreSet?.[params.coreSetId] ??
     `${measureId} ${
       apiData?.Item ? `- ${formatTitle(apiData?.Item?.description)}` : ""
     }`;
@@ -465,7 +461,7 @@ export const MeasureWrapper = ({
                   <LastModifiedBy user={measureData?.lastAlteredBy} />
                   {measureId !== "CSQ" && (
                     <>
-                      {Object.keys(separatedCoreSet).includes(
+                      {Object.keys(separatedCoreSet ?? []).includes(
                         params.coreSetId as CoreSetAbbr
                       ) && (
                         <CUI.Heading size="md" mb={6}>

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -463,7 +463,7 @@ export const MeasureWrapper = ({
                         params.coreSetId as CoreSetAbbr
                       ) && (
                         <CUI.Heading size="md" mb={6}>
-                          {formatTitle()}
+                          {measureId}: {formatTitle()}
                         </CUI.Heading>
                       )}
                       <CUI.Text fontSize="sm">

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -402,12 +402,25 @@ export const MeasureWrapper = ({
     return null;
   }
 
+  const separatedCoreSet: { [key: string]: string } = {
+    [CoreSetAbbr.ACSC]: "(Separate CHIP)",
+    [CoreSetAbbr.ACSM]: "(Medicaid (Title XIX & XXI)))",
+    [CoreSetAbbr.CCSC]: "(Separate CHIP)",
+    [CoreSetAbbr.CCSM]: "(Medicaid (Title XIX & XXI)))",
+  };
+
   const formatTitle = (customDescription?: string) => {
     const foundMeasureDescription =
       measureDescriptions?.[year]?.[measureId] || customDescription;
 
     return foundMeasureDescription || "";
   };
+
+  const breadCrumbName =
+    separatedCoreSet[params.coreSetId] ??
+    `${measureId} ${
+      apiData?.Item ? `- ${formatTitle(apiData?.Item?.description)}` : ""
+    }`;
 
   return (
     <FormProvider {...methods}>
@@ -429,11 +442,7 @@ export const MeasureWrapper = ({
             path: `/${params.state}/${year}/${params.coreSetId}/${measureId}`,
             name:
               defaultVals?.title ??
-              `${measureId} ${
-                apiData?.Item
-                  ? `- ${formatTitle(apiData?.Item?.description)}`
-                  : ""
-              }`,
+              `${measureId} ${apiData?.Item ? breadCrumbName : ""}`,
           },
         ]}
         buttons={
@@ -455,13 +464,22 @@ export const MeasureWrapper = ({
                   <QMR.SessionTimeout handleSave={handleSave} />
                   <LastModifiedBy user={measureData?.lastAlteredBy} />
                   {measureId !== "CSQ" && (
-                    <CUI.Text fontSize="sm">
-                      For technical questions regarding use of this application,
-                      please reach out to MDCT_Help@cms.hhs.gov. For
-                      content-related questions about measure specifications, or
-                      what information to enter in each field, please reach out
-                      to MACQualityTA@cms.hhs.gov.
-                    </CUI.Text>
+                    <>
+                      {Object.keys(separatedCoreSet).includes(
+                        params.coreSetId as CoreSetAbbr
+                      ) && (
+                        <CUI.Heading size="md" mb={6}>
+                          {formatTitle()}
+                        </CUI.Heading>
+                      )}
+                      <CUI.Text fontSize="sm">
+                        For technical questions regarding use of this
+                        application, please reach out to MDCT_Help@cms.hhs.gov.
+                        For content-related questions about measure
+                        specifications, or what information to enter in each
+                        field, please reach out to MACQualityTA@cms.hhs.gov.
+                      </CUI.Text>
+                    </>
                   )}
                   <SharedContext.Provider value={shared}>
                     <Measure

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -414,9 +414,7 @@ export const MeasureWrapper = ({
 
   const breadCrumbName =
     separatedCoreSet?.[params.coreSetId] ??
-    `${measureId} ${
-      apiData?.Item ? `- ${formatTitle(apiData?.Item?.description)}` : ""
-    }`;
+    `- ${formatTitle(apiData?.Item?.description)}`;
 
   return (
     <FormProvider {...methods}>

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -1,5 +1,5 @@
 import { SPA } from "libs/spaLib";
-import { AnyObject } from "types";
+import { AnyObject, CoreSetAbbr } from "types";
 
 export type CoreSetType = "coreSet" | "text";
 
@@ -24,12 +24,12 @@ const getHHStates = (year: string) => {
 
 export const coreSetType = (abbr: string) => {
   const list = {
-    Adult: ["ACS", "ACSM", "ACSC"],
-    Child: ["CCS", "CCSM", "CCSC"],
-    "Health Home": ["HHCS"],
+    Adult: [CoreSetAbbr.ACS, CoreSetAbbr.ACSM, CoreSetAbbr.ACSC],
+    Child: [CoreSetAbbr.CCS, CoreSetAbbr.CCSM, CoreSetAbbr.CCSC],
+    "Health Home": [CoreSetAbbr.HHCS],
   };
   for (const [key, value] of Object.entries(list)) {
-    if (value.includes(abbr)) return key;
+    if (value.includes(abbr as CoreSetAbbr)) return key;
   }
   return;
 };
@@ -65,6 +65,21 @@ export const coreSetTitles = (year: string, abbr: string, type?: string) => {
   const subType = type || "Measures";
   let name = `${coreSetType(abbr)} Core Set ${subType}`;
   return subTitle ? `${name}: ${subTitle}` : name;
+};
+
+//seperated coresets have unique titles for their breadcrumb menu. this is only for 2024 and onward
+export const coreSetBreadCrumbTitle = (
+  year: string
+): { [key: string]: string } | undefined => {
+  if (parseInt(year) >= 2024)
+    return {
+      [CoreSetAbbr.ACSC]: "(Separate CHIP)",
+      [CoreSetAbbr.ACSM]: "(Medicaid (Title XIX & XXI)))",
+      [CoreSetAbbr.CCSC]: "(Separate CHIP)",
+      [CoreSetAbbr.CCSM]: "(Medicaid (Title XIX & XXI)))",
+    };
+
+  return undefined;
 };
 
 export const coreSets: CoreSetFields = {

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -74,9 +74,9 @@ export const coreSetBreadCrumbTitle = (
   if (parseInt(year) >= 2024)
     return {
       [CoreSetAbbr.ACSC]: "(Separate CHIP)",
-      [CoreSetAbbr.ACSM]: "(Medicaid (Title XIX & XXI)))",
+      [CoreSetAbbr.ACSM]: "(Medicaid (Title XIX & XXI))",
       [CoreSetAbbr.CCSC]: "(Separate CHIP)",
-      [CoreSetAbbr.CCSM]: "(Medicaid (Title XIX & XXI)))",
+      [CoreSetAbbr.CCSM]: "(Medicaid (Title XIX & XXI))",
     };
 
   return undefined;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The BOs want the breadcrumb bar to display a different title for separated Adult and Child CoreSet so that it's more clear if they are looking at a Medicaid or a Chip measure. 

The descriptive long time is now added to the measure page itself, under the breadcrumb bar.

![Screenshot 2024-08-22 at 11 35 59 AM](https://github.com/user-attachments/assets/899ecdc4-940b-4bae-872a-85b7f8810350)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3937

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d31k45qp5ojk8b.cloudfront.net/

1) Sign into QMR, any separate coreSet users i.e. [stateuser1@test.com](mailto:stateuser1@test.com) 
2) In reporting year 2024, go to any adult or chip measure
3) The title will look like this if the measure's program type is _Medicaid_
![Screenshot 2024-08-22 at 11 37 17 AM](https://github.com/user-attachments/assets/e66fc184-bea5-4a25-82e0-2d9ce8cdf82c)

- and like this for _CHIP_
![Screenshot 2024-08-22 at 11 37 46 AM](https://github.com/user-attachments/assets/99ca4f23-e424-45ab-b888-bf68320ee2d7)


4) Check that the other years and non-split coreSets still have the old style title
![Screenshot 2024-08-22 at 11 21 12 AM](https://github.com/user-attachments/assets/523aeff5-46aa-4850-b964-b4c7cff68a4b)



### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
