### PR TITLE
Skip combined rate calculations for DEV-CH and WCC-CH age groups

### DIFF
--- a/services/app-api/handlers/rate/rateNDRCalculations.test.ts
+++ b/services/app-api/handlers/rate/rateNDRCalculations.test.ts
@@ -62,6 +62,55 @@ describe("NDR calculations for Combined Rates", () => {
     ]);
   });
 
+  it("Should exclude certain rates from the payload", () => {
+    const dataSources = {
+      Medicaid: {},
+      CHIP: {},
+    } as CombinedRatesPayload["DataSources"];
+
+    const medicaidMeasure = {
+      data: {
+        DataSource: ["AdministrativeData"],
+        PerformanceMeasure: {
+          rates: {
+            cat0: [
+              {
+                uid: "cat0.qual0",
+                label: "mock rate",
+                numerator: "2",
+                denominator: "10",
+                rate: "20",
+              },
+            ],
+            rnFOY6: [
+              {
+                uid: "rnFOY6.V9moUD",
+                label: "Children screened by 12 months of age",
+                numerator: "2",
+                denominator: "10",
+                rate: "20",
+              },
+            ],
+          },
+        },
+      } as Measure["data"],
+    } as Measure;
+
+    // Most measures: percentage
+    let result = combineRates(
+      "ZZZ-AD",
+      dataSources,
+      medicaidMeasure,
+      undefined
+    );
+
+    expect(result.length).toBe(1);
+    expect(result.find((rate) => rate.uid === "cat0.qual0")).toBeDefined();
+    expect(
+      result.find((rate) => rate.uid === "rnFOY6.V9moUD")
+    ).not.toBeDefined();
+  });
+
   it("Should use special transformations for certain measures", () => {
     const dataSources = {
       Medicaid: {},

--- a/services/app-api/handlers/rate/rateNDRCalculations.ts
+++ b/services/app-api/handlers/rate/rateNDRCalculations.ts
@@ -27,10 +27,11 @@ export const combineRates = (
     .map((measure) => measure?.data?.PerformanceMeasure?.rates ?? {})
     .map((rateMap) => Object.values(rateMap).flat(1).filter(isRateNDRShape));
 
-  const uniqueRateIds = [...medicaidRates, ...chipRates]
+  let uniqueRateIds = [...medicaidRates, ...chipRates]
     .map((rate) => rate.uid)
     .filter(isDefined)
-    .filter((uid, i, arr) => i === arr.indexOf(uid));
+    .filter((uid, i, arr) => i === arr.indexOf(uid))
+    .filter((uid) => !ratesToNeverShow.includes(uid));
 
   if (
     DataSources.Medicaid.requiresWeightedCalc ||
@@ -206,6 +207,20 @@ export const combineRates = (
     });
   }
 };
+
+/**
+ * For certain measures, CMS uses a different formula for certain qualifiers.
+ * However, for those measures, the "Total" qualifier still ends up correct.
+ *
+ * I am writing this comment two days from go-live, so our decision is
+ * to hide the rates for those individual qualifiers.
+ */
+const ratesToNeverShow = [
+  // DEV-CH: never show the individual age group rates
+  "rnFOY6.V9moUD",
+  "rnFOY6.8syeJa",
+  "rnFOY6.UjlL0h",
+];
 
 /**
  * Most measures display as a percentage, but certain measures are expressed

--- a/services/app-api/handlers/rate/rateNDRCalculations.ts
+++ b/services/app-api/handlers/rate/rateNDRCalculations.ts
@@ -213,13 +213,20 @@ export const combineRates = (
  * However, for those measures, the "Total" qualifier still ends up correct.
  *
  * I am writing this comment two days from go-live, so our decision is
- * to hide the rates for those individual qualifiers.
+ * to simply hide the rates for those individual qualifiers.
  */
 const ratesToNeverShow = [
   // DEV-CH: never show the individual age group rates
-  "rnFOY6.V9moUD",
-  "rnFOY6.8syeJa",
-  "rnFOY6.UjlL0h",
+  "rnFOY6.V9moUD", // by 12 months
+  "rnFOY6.8syeJa", // by 24 months
+  "rnFOY6.UjlL0h", // by 36 months
+  // WCC-CH: never show the individual age group rates
+  "4TXd3h.iWwR8Z", // BMI, 3-11
+  "4TXd3h.BFwD7g", // BMI, 12-17
+  "cKH5gj.iWwR8Z", // Nutrition, 3-11
+  "cKH5gj.BFwD7g", // Nutrition, 12-17
+  "1POxYx.iWwR8Z", // Activity, 3-11
+  "1POxYx.BFwD7g", // Activity, 12-17
 ];
 
 /**


### PR DESCRIPTION
### Description
For certain measures with multiple age group qualifiers, CMS uses unique calculations for combining the rates. Our calculated combined rates do not match theirs, for those individual qualifiers. However, ours _do_ match theirs for the "total" qualifiers on those measures.

Since our final, total combined rates are correct, the most expedient fix is to hide those intermediate, individual rates. We will skip the calculation, and therefore they will not display on the Combined Rates page.

This applies to DEV-CH and WCC-CH.

### Related ticket(s)
CMDCT-3946
CMDCT-3947

---
### How to test
1. Fill out individual medicaid and chip measures for DEV-CH
2. Look at the combined rates page. Note that only the "total" rate is present.
3. Repeat for WCC-CH. Note that only the three "total" rates (one per category) are present.

### Notes
n/a

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~

