### PR TITLE
PHE Flag Text Update

### DIFF
--- a/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
@@ -129,6 +129,9 @@ export const commonQuestionsLabel = {
     section:
       "If this measure is also reported by additional classifications/sub-categories, e.g. racial, ethnic, sex, or geography, complete the following as applicable. If your state reported classifications/sub-categories other than those listed below, or reported different rate sets, please click on “Add Another Sub-Category” to add Additional/Alternative Classification/Sub-categories as needed. Please note that CMS may add in additional categories for language and disability status in future reporting years.",
   },
+  PerformanceMeasure: {
+    phe: "CMS recognizes that social distancing will make onsite medical chart reviews inadvisable during the COVID-19 pandemic. As such, hybrid measures that rely on such techniques will be particularly challenging during this time. While reporting of the Core Sets is voluntary, CMS encourages states that can collect information safely to continue reporting the measures they have reported in the past.",
+  },
   WhyAreYouNotReporting: {
     periodOfHealthEmergencyFlag: true,
     limitWithDataCollection:

--- a/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
@@ -108,6 +108,9 @@ export const commonQuestionsLabel = {
     additionalContext:
       "If the state would like to provide additional context about the reported stratified data, including stratification categories, please add notes below (optional)",
   },
+  PerformanceMeasure: {
+    phe: "CMS recognizes that social distancing will make onsite medical chart reviews inadvisable during the COVID-19 pandemic. As such, hybrid measures that rely on such techniques will be particularly challenging during this time. CMS encourages states that can collect information safely to continue reporting the measures they have reported in the past.",
+  },
   WhyAreYouNotReporting: {
     periodOfHealthEmergencyFlag: true,
     limitWithDataCollection:

--- a/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.test.tsx
@@ -11,12 +11,16 @@ import { screen } from "@testing-library/react";
 import { PCRRate } from "components";
 import { mockLDFlags } from "../../../../setupJest";
 import { LabelData } from "utils";
+import SharedContext from "shared/SharedContext";
+import commonQuestionsLabel2024 from "labels/2024/commonQuestionsLabel";
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useParams: jest.fn().mockReturnValue({
+jest.mock("hooks/api/usePathParams", () => ({
+  ...jest.requireActual("hooks/api/usePathParams"),
+  usePathParams: jest.fn().mockReturnValue({
+    state: "DC",
     year: "2024",
-    state: "OH",
+    coreSet: "HHCS",
+    measureId: "PCR-HH",
   }),
 }));
 
@@ -38,13 +42,15 @@ const renderComponent = ({
   hybridMeasure,
 }: Props) =>
   renderWithHookForm(
-    <PerformanceMeasure
-      data={data}
-      calcTotal={calcTotal}
-      RateComponent={component}
-      rateReadOnly={rateReadOnly}
-      hybridMeasure={hybridMeasure}
-    />
+    <SharedContext.Provider value={commonQuestionsLabel2024}>
+      <PerformanceMeasure
+        data={data}
+        calcTotal={calcTotal}
+        RateComponent={component}
+        rateReadOnly={rateReadOnly}
+        hybridMeasure={hybridMeasure}
+      />
+    </SharedContext.Provider>
   );
 
 // TODO: Mock the datasource change to trigger rate editability

--- a/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.tsx
@@ -8,7 +8,9 @@ import { useWatch } from "react-hook-form";
 import { getLabelText, isLegacyLabel, LabelData } from "utils";
 import { ndrFormula } from "types";
 import { useFlags } from "launchdarkly-react-client-sdk";
-import { useParams } from "react-router-dom";
+import { usePathParams } from "hooks/api/usePathParams";
+import { useContext } from "react";
+import SharedContext from "shared/SharedContext";
 
 interface Props {
   data: PerformanceMeasureData;
@@ -208,7 +210,7 @@ export const PerformanceMeasure = ({
   RateComponent = QMR.Rate, // Default to QMR.Rate
 }: Props) => {
   const register = useCustomRegister<Types.PerformanceMeasure>();
-  const { year } = useParams();
+  const { year } = usePathParams();
   //for years after 2023, we use a flag to determine showing the covid message
   const pheIsCurrent =
     parseInt(year!) < 2023 || useFlags()?.[`periodOfHealthEmergency${year}`];
@@ -227,6 +229,8 @@ export const PerformanceMeasure = ({
   }
 
   data.questionText = data.questionText ?? [];
+  //WIP: using form context to get the labels for this component temporarily.
+  const labels: any = useContext(SharedContext);
 
   return (
     <QMR.CoreQuestionWrapper
@@ -299,14 +303,7 @@ export const PerformanceMeasure = ({
       )}
       {hybridMeasure && pheIsCurrent && (
         <CUI.Box my="5">
-          <CUI.Text>
-            CMS recognizes that social distancing will make onsite medical chart
-            reviews inadvisable during the COVID-19 pandemic. As such, hybrid
-            measures that rely on such techniques will be particularly
-            challenging during this time. While reporting of the Core Sets is
-            voluntary, CMS encourages states that can collect information safely
-            to continue reporting the measures they have reported in the past.
-          </CUI.Text>
+          <CUI.Text>{labels?.PerformanceMeasure?.phe}</CUI.Text>
           <QMR.TextArea
             formLabelProps={{ mt: 5 }}
             {...register("PerformanceMeasure.hybridExplanation")}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
There was an issue seeing period of health emergency text that is controlled by a launch darkly flag. This text is only visible in a hybrid measure. 

So what happened is the year was not being returned when using `useParams()` so I switched it over to `usePathParams()`

The BO's also wanted the text updated for 2024. So it should look like this now under the performance measure.

<img width="1243" alt="Screenshot 2024-08-29 at 4 24 23 PM" src="https://github.com/user-attachments/assets/2f0d3108-d695-48f0-8bb7-2a910be7dd7f">



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://dggnsm7sl3vbr.cloudfront.net/

1) Sign into QMR, any user
2) Go to CCS-AD (a hybrid measure)
3) Select the first radio button in the **Measurement Specification** section
4) Scroll down to the **Performance Measure** section
5) The text from the image above should be displayed

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
