### PR TITLE
[BUGFIX] IU-HH OMS Render Bug

### DIFF
--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/NDR/ndrSets.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/NDR/ndrSets.tsx
@@ -38,14 +38,13 @@ const IUHHNDRSets = ({ name }: NdrProps) => {
 
   return (
     <>
-      {ageGroupsOptions ||
-        (isLegacyLabel() && (
-          <QMR.Checkbox
-            name={`${name}.iuhh-rate.options`}
-            key={`${name}.iuhh-rate.options`}
-            options={ageGroupsOptions}
-          />
-        ))}
+      {isLegacyLabel() && (
+        <QMR.Checkbox
+          name={`${name}.iuhh-rate.options`}
+          key={`${name}.iuhh-rate.options`}
+          options={ageGroupsOptions}
+        />
+      )}
       {calcTotal && (
         <TotalNDRSets
           componentFlag={"IU"}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
There was an unexpected bug in IU-HH which was causing the render to error out. `ageGroupOptions` object somehow got into the render and it is not suppose to be there. Might have been a merge issue, might have been a refactoring error, who knows.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, [stateuserWA@test.com](mailto:stateuserDC@test.com)
2) Add a Health Home CoreSet
3) Go to IU-HH, fill out: 
    - Measure Specification - Select the first radio button
    - Performance Measure - Fill out an N/D/R set that is not the total
    - Optional Measure Stratification - Fill out any of them
4) Save

If you were able to fill out OMS without the page turning white, that means the bug is fixed.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
