### PR TITLE
[NO TICKET]: updating transform measure table script to handle missing state, year, measure fields

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -15,6 +15,7 @@ bannerTableName=local-banners
 coreSetTableName=local-coreSets
 DYNAMO_TABLE_ARN=local_nonsense_if_unset_we_search_CF_for
 measureTableName=local-measures
+measureTable=local-measure
 rateTableName=local-rates
 
 # LAUNCHDARKLY

--- a/services/database/scripts/transformMeasureTable.ts
+++ b/services/database/scripts/transformMeasureTable.ts
@@ -38,14 +38,30 @@ async function* scan(client: DynamoDBDocumentClient, table: string) {
 }
 
 async function add(client: DynamoDBDocumentClient, table: string, entry: any) {
-  const newCompoundKey = `${entry.state}${entry.year}${entry.coreSet}`;
+  const { compoundKey, coreSet } = entry;
+
+  const state = entry.state || compoundKey.substring(0, 2);
+  const year = entry.year || compoundKey.substring(2, 6);
+  let measure = entry.measure;
+  if (!measure) {
+    const coreSetIndex = compoundKey.indexOf(coreSet);
+    measure = compoundKey.substring(
+      coreSetIndex + coreSet.length,
+      compoundKey.length
+    );
+  }
+  const newCompoundKey = `${state}${year}${coreSet}`;
   const params = {
     TableName: table,
     Item: {
       ...entry,
       compoundKey: newCompoundKey,
+      state,
+      year,
+      measure,
     },
   };
+
   await client.send(new PutCommand(params));
 }
 


### PR DESCRIPTION
The DB migration script for the measures table was failing when coming across bad measure data in dev that doesn't have fields for state, year and measure. Since the new `measure` table requires a `measure` field as the sort key, it could not create a new item so the script would fail and only part of the data would be properly migrated.

The fix here is if those fields don't exist for a particular measure, I extract all those fields out of the compoundKey because the compoundKey for the old measures table """""SHOULD"""" always have all 4 concated together (like `AL2024ACSMAAB-AD`). @ailZhou or @benmartin-coforma can correct me if I am wrong about the compoundKey being guaranteed to always have all 4 values. If it's not somehow guaranteed, then this script needs to further revised to account for sheer bloody madness.

---
### How to test
If you insist on testing the logic i added here, I would suggest the following steps: 
1. log into kion on the command line with `kion s` (make sure your EUA username and password are in your `~/.kion.yml` file). Select either dev or impl qmr
2. IMPORTANT: comment out the actual put command on line 65 so that we aren't actually writing to any tables for this manual test
3. Add the following chunk of code on line 64 after you've built up the params:
```
if (!entry.measure) {
    console.log("OLD COMPOUND KEY:", compoundKey)
    console.log("NEW ITEM TO BE ADDED TO NEW TABLE:", params.Item)
}
```
4. run the script: `npx tsx transformMeasureTable.ts`
5. when it asks if you want to run locally say `N`
6. when it asks for an env, try with dev (`master`) or with impl (`val`)
7. Look at the console output (do ctrl find for OLD COMPOUND KEY. Make sure that the year, state, and measure of the Item output matches what's in the compoundKey output. 



For example this is the output I see in val. The old compound key gets correctly broken down into a state, year and measure for the new table item. 

<img width="325" alt="Screenshot 2024-09-25 at 9 36 17 AM" src="https://github.com/user-attachments/assets/e72ab050-25dd-4195-9c3e-d1667789cd7f">
