### PR TITLE
CMDCT-3883: Adding a featuresByYear that will replace year checks around the application

### DIFF
--- a/services/ui-src/src/components/ComplexRate/index.tsx
+++ b/services/ui-src/src/components/ComplexRate/index.tsx
@@ -6,8 +6,8 @@ import objectPath from "object-path";
 import { useEffect, useLayoutEffect } from "react";
 import { IRate } from "components";
 import { defaultRateCalculation } from "utils/rateFormulas";
-import { getMeasureYear } from "utils/getMeasureYear";
 import { ndrFormula } from "types";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface Props extends QMR.InputWrapperProps {
   rates: IRate[];
@@ -159,8 +159,7 @@ export const ComplexRate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      // human readable text for Mathematica only needed for FFY 2023+
-      if (getMeasureYear() >= 2023) {
+      if (featuresByYear.humanReadableTextForMathematica) {
         prevRate[index]["category"] = categoryName ?? undefined;
       }
     });

--- a/services/ui-src/src/components/ComplexRate/index.tsx
+++ b/services/ui-src/src/components/ComplexRate/index.tsx
@@ -159,7 +159,7 @@ export const ComplexRate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      if (featuresByYear.humanReadableTextForMathematica) {
+      if (featuresByYear.setCategoryForComplexRate) {
         prevRate[index]["category"] = categoryName ?? undefined;
       }
     });

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -415,7 +415,7 @@ export const MeasureWrapper = ({
     return null;
   }
 
-  const separatedCoreSet = coreSetBreadCrumbTitle(year);
+  const separatedCoreSet = coreSetBreadCrumbTitle();
 
   const formatTitle = (customDescription?: string) => {
     const foundMeasureDescription =

--- a/services/ui-src/src/components/Rate/index.tsx
+++ b/services/ui-src/src/components/Rate/index.tsx
@@ -80,7 +80,7 @@ export const Rate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      if (featuresByYear.humanReadableTextForMathematica && categoryName) {
+      if (featuresByYear.setCategoryForComplexRate && categoryName) {
         prevRate[index]["category"] = categoryName;
       }
     });

--- a/services/ui-src/src/components/Rate/index.tsx
+++ b/services/ui-src/src/components/Rate/index.tsx
@@ -5,7 +5,6 @@ import objectPath from "object-path";
 import { useEffect } from "react";
 import { getLabelText } from "utils";
 import { defaultRateCalculation } from "utils/rateFormulas";
-import { getMeasureYear } from "utils/getMeasureYear";
 
 import {
   allNumbers,
@@ -14,6 +13,7 @@ import {
   rateThatAllowsOneDecimal,
   allPositiveIntegersWith8Digits,
 } from "utils";
+import { featuresByYear } from "utils/featuresByYear";
 export interface IRate {
   label?: string;
   id: number;
@@ -80,8 +80,7 @@ export const Rate = ({
       }
       prevRate[index]["label"] = rate.label ?? undefined;
       prevRate[index]["uid"] = rate.uid ?? undefined;
-      // human readable text for Mathematica only needed for FFY 2023+
-      if (getMeasureYear() >= 2023 && categoryName) {
+      if (featuresByYear.humanReadableTextForMathematica && categoryName) {
         prevRate[index]["category"] = categoryName;
       }
     });

--- a/services/ui-src/src/components/Table/columns/measures.tsx
+++ b/services/ui-src/src/components/Table/columns/measures.tsx
@@ -84,7 +84,7 @@ export const measuresColumns = (
         );
       },
     },
-    ...(featuresByYear.displayMandatoryColumn
+    ...(featuresByYear.displayMandatoryMeasuresColumn
       ? [
           {
             header: "Mandatory",

--- a/services/ui-src/src/components/Table/columns/measures.tsx
+++ b/services/ui-src/src/components/Table/columns/measures.tsx
@@ -4,6 +4,7 @@ import { BsCheck } from "react-icons/bs";
 import { Link } from "react-router-dom";
 import { format } from "date-fns";
 import { MeasureTableItem, TableColumn } from "../types";
+import { featuresByYear } from "utils/featuresByYear";
 
 // Get status string from measure data
 const getStatus = (data: MeasureTableItem.Data): MeasureTableItem.Status => {
@@ -55,7 +56,6 @@ const MeasureStatusText = ({
 export const measuresColumns = (
   year: string
 ): TableColumn<MeasureTableItem.Data>[] => {
-  const displayMandatoryColumn = year >= "2024";
   return [
     {
       header: "Abbreviation",
@@ -84,7 +84,7 @@ export const measuresColumns = (
         );
       },
     },
-    ...(displayMandatoryColumn
+    ...(featuresByYear.displayMandatoryColumn
       ? [
           {
             header: "Mandatory",

--- a/services/ui-src/src/hooks/api/useGetCoreSets.tsx
+++ b/services/ui-src/src/hooks/api/useGetCoreSets.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "react-query";
 import { getAllCoreSets } from "libs/api";
 import { useParams } from "react-router-dom";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface GetCoreSets {
   state: string;
@@ -16,7 +17,11 @@ const getCoreSets = async ({ state, year }: GetCoreSets) => {
 
 export const useGetCoreSets = (releasedTwentyTwentyFive: boolean) => {
   const { state, year } = useParams();
-  if (state && year && (releasedTwentyTwentyFive || year !== "2025")) {
+  if (
+    state &&
+    year &&
+    (releasedTwentyTwentyFive || featuresByYear.yearIsNot2025)
+  ) {
     return useQuery(["coreSets", state, year], () =>
       getCoreSets({ state, year })
     );

--- a/services/ui-src/src/hooks/api/useGetCoreSets.tsx
+++ b/services/ui-src/src/hooks/api/useGetCoreSets.tsx
@@ -20,7 +20,7 @@ export const useGetCoreSets = (releasedTwentyTwentyFive: boolean) => {
   if (
     state &&
     year &&
-    (releasedTwentyTwentyFive || featuresByYear.yearIsNot2025)
+    (releasedTwentyTwentyFive || featuresByYear.reportingYearReleased)
   ) {
     return useQuery(["coreSets", state, year], () =>
       getCoreSets({ state, year })

--- a/services/ui-src/src/shared/Qualifiers/deliverySystems.tsx
+++ b/services/ui-src/src/shared/Qualifiers/deliverySystems.tsx
@@ -31,9 +31,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
     <CUI.ListItem m="4">
       <Common.QualifierHeader
         header="Delivery System"
-        description={data.qualifierHeader(
-          year ? `${parseInt(year) - 1}` : "2020"
-        )}
+        description={data.qualifierHeader(`${parseInt(year) - 1}`)}
       />
       <CUI.Table variant="simple" mt="4" size="md" verticalAlign="top">
         <CUI.Thead>

--- a/services/ui-src/src/shared/commonQuestions/DateRange.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DateRange.test.tsx
@@ -5,9 +5,14 @@ import fireEvent from "@testing-library/user-event";
 import SharedContext from "shared/SharedContext";
 import commonQuestionsLabel2022 from "labels/2022/commonQuestionsLabel";
 import commonQuestionsLabel2024 from "labels/2024/commonQuestionsLabel";
+import { getMeasureYear } from "utils/getMeasureYear";
+
+jest.mock("../../utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 describe("DateRange component, adult", () => {
   beforeEach(() => {
+    mockGetMeasureYear.mockReturnValue(2024);
     renderWithHookForm(
       <SharedContext.Provider
         value={{ ...commonQuestionsLabel2024, year: "2024" }}
@@ -126,6 +131,7 @@ describe("DateRange component, Health Home", () => {
 
 describe("DateRange component renders correctly for < 2023", () => {
   beforeEach(() => {
+    mockGetMeasureYear.mockReturnValue(2022);
     renderWithHookForm(
       <SharedContext.Provider
         value={{ ...commonQuestionsLabel2022, year: "2022" }}

--- a/services/ui-src/src/shared/commonQuestions/DateRange.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DateRange.tsx
@@ -6,6 +6,7 @@ import * as DC from "dataConstants";
 import { useContext } from "react";
 import SharedContext from "shared/SharedContext";
 import { AnyObject } from "types";
+import { featuresByYear } from "utils/featuresByYear";
 
 const measurementPeriodTableLinks = {
   adult:
@@ -91,12 +92,9 @@ export const DateRange = ({ type }: Props) => {
   //WIP: using form context to get the labels for this component temporarily.
   const labels: any = useContext(SharedContext);
 
-  //tracking date range had switched to being optional starting 2023
-  const useRadioDateRange: boolean = labels.year >= 2023;
-
   return (
     <QMR.CoreQuestionWrapper testid="date-range" label="Date Range">
-      {useRadioDateRange
+      {featuresByYear.optionalDateRangeTracking
         ? RadioDateRangeElement(labels.DateRange, link, register)
         : StandardDateRangeElement(labels.DateRange, link, register)}
     </QMR.CoreQuestionWrapper>

--- a/services/ui-src/src/shared/commonQuestions/DateRange.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DateRange.tsx
@@ -94,7 +94,7 @@ export const DateRange = ({ type }: Props) => {
 
   return (
     <QMR.CoreQuestionWrapper testid="date-range" label="Date Range">
-      {featuresByYear.optionalDateRangeTracking
+      {featuresByYear.allowImplicitMeasureDates
         ? RadioDateRangeElement(labels.DateRange, link, register)
         : StandardDateRangeElement(labels.DateRange, link, register)}
     </QMR.CoreQuestionWrapper>

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -8,6 +8,7 @@ import { SubCatSection } from "./subCatClassification";
 import { NDRSets } from "./NDR/ndrSets";
 import { cleanString } from "utils/cleanString";
 import { AnyObject } from "types";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface CheckboxChildrenProps extends OmsNode {
   /** name for react-hook-form registration */
@@ -101,12 +102,12 @@ const renderRadioButtonOptions = ({
   omsNode,
   name,
   label,
-  year,
 }: ChildCheckBoxOptionProps) => {
   //this was the legacy way of displaying the sub categories
-  const flagYesSubCat = year! <= 2022 && !!omsNode?.flagSubCat;
+  const flagYesSubCat =
+    featuresByYear.hasQualCatLabels && !!omsNode?.flagSubCat;
   //in 2023, we moved the sub categories to the no option and changed the yes
-  const flagNoSubCat = year! >= 2023;
+  const flagNoSubCat = !featuresByYear.hasQualCatLabels;
 
   return [
     {
@@ -130,7 +131,6 @@ const buildChildCheckboxOption = ({
   omsNode,
   name,
   label,
-  year,
 }: ChildCheckBoxOptionProps) => {
   let children = [];
   const id = omsNode?.id ? cleanString(omsNode.id) : "ID_NOT_SET";
@@ -146,7 +146,7 @@ const buildChildCheckboxOption = ({
       <QMR.RadioButton
         name={`${name}.aggregate`}
         key={`${name}.aggregate`}
-        options={renderRadioButtonOptions({ omsNode, name, label, year })}
+        options={renderRadioButtonOptions({ omsNode, name, label })}
         label={label?.checkboxOpt}
       />,
     ];
@@ -183,7 +183,6 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
               omsNode: lvlTwoOption,
               name: `${props.name}.selections.${cleanedId}`,
               label: labels,
-              year: props.year,
             });
           }),
         ]}

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -30,36 +30,31 @@ interface NdrNodeProps {
   flagSubCat: boolean;
 }
 
-const omsLabels = (year: number, omsNode: OmsNode) => {
-  switch (year) {
-    case 2022:
-    case 2021: {
-      return {
-        checkboxOpt: `Are you only reporting aggregated data for all ${
-          omsNode.aggregateTitle || omsNode.id
-        } categories?`,
-        YesAggregateData: `Yes, we are only reporting aggregated data for all ${
-          omsNode?.aggregateTitle || omsNode?.id
-        } categories.`,
-        NoIndependentData: `No, we are reporting independent data for all ${
-          omsNode?.aggregateTitle || omsNode?.id
-        } categories`,
-      };
-    }
-    default: {
-      return {
-        checkboxOpt: `Are you reporting aggregate data for the ${
-          omsNode.aggregateTitle || omsNode.label
-        } category?`,
-        YesAggregateData: `Yes, we are reporting aggregate data for the ${
-          omsNode?.aggregateTitle || omsNode?.label
-        } categories.`,
-        NoIndependentData: `No, we are reporting disaggregated data for ${
-          omsNode?.aggregateTitle || omsNode?.label
-        } sub-categories`,
-      };
-    }
+const omsLabels = (omsNode: OmsNode) => {
+  if (featuresByYear.hasStreamlinedOms) {
+    return {
+      checkboxOpt: `Are you reporting aggregate data for the ${
+        omsNode.aggregateTitle || omsNode.label
+      } category?`,
+      YesAggregateData: `Yes, we are reporting aggregate data for the ${
+        omsNode?.aggregateTitle || omsNode?.label
+      } categories.`,
+      NoIndependentData: `No, we are reporting disaggregated data for ${
+        omsNode?.aggregateTitle || omsNode?.label
+      } sub-categories`,
+    };
   }
+  return {
+    checkboxOpt: `Are you only reporting aggregated data for all ${
+      omsNode.aggregateTitle || omsNode.id
+    } categories?`,
+    YesAggregateData: `Yes, we are only reporting aggregated data for all ${
+      omsNode?.aggregateTitle || omsNode?.id
+    } categories.`,
+    NoIndependentData: `No, we are reporting independent data for all ${
+      omsNode?.aggregateTitle || omsNode?.id
+    } categories`,
+  };
 };
 
 const NdrNode = ({ flagSubCat, name }: NdrNodeProps) => {
@@ -177,7 +172,7 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
             const cleanedId =
               cleanString(lvlTwoOption?.id) ?? "LVL_TWO_ID_NOT_SET";
 
-            const labels = omsLabels(props.year!, lvlTwoOption);
+            const labels = omsLabels(lvlTwoOption);
 
             return buildChildCheckboxOption({
               omsNode: lvlTwoOption,

--- a/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.tsx
@@ -11,6 +11,7 @@ import { useFlags } from "launchdarkly-react-client-sdk";
 import { usePathParams } from "hooks/api/usePathParams";
 import { useContext } from "react";
 import SharedContext from "shared/SharedContext";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface Props {
   data: PerformanceMeasureData;
@@ -213,7 +214,7 @@ export const PerformanceMeasure = ({
   const { year } = usePathParams();
   //for years after 2023, we use a flag to determine showing the covid message
   const pheIsCurrent =
-    parseInt(year!) < 2023 || useFlags()?.[`periodOfHealthEmergency${year}`];
+    featuresByYear.pheYear || useFlags()?.[`periodOfHealthEmergency${year}`];
 
   const dataSourceWatch = useWatch<Types.DataSource>({
     name: DC.DATA_SOURCE,

--- a/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.tsx
@@ -214,7 +214,8 @@ export const PerformanceMeasure = ({
   const { year } = usePathParams();
   //for years after 2023, we use a flag to determine showing the covid message
   const pheIsCurrent =
-    featuresByYear.pheYear || useFlags()?.[`periodOfHealthEmergency${year}`];
+    featuresByYear.periodOfHealthEmergency ||
+    useFlags()?.[`periodOfHealthEmergency${year}`];
 
   const dataSourceWatch = useWatch<Types.DataSource>({
     name: DC.DATA_SOURCE,

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -1,5 +1,6 @@
 import { SPA } from "libs/spaLib";
 import { AnyObject, CoreSetAbbr } from "types";
+import { featuresByYear } from "utils/featuresByYear";
 
 export type CoreSetType = "coreSet" | "text";
 
@@ -34,12 +35,12 @@ export const coreSetType = (abbr: string) => {
   return;
 };
 
-export const coreSetSubTitles = (year: string, abbr: string) => {
+export const coreSetSubTitles = (abbr: string) => {
   let lastChar = abbr[abbr.length - 1];
   let coreType = coreSetType(abbr) || "";
   let list: AnyObject = {};
   //using the last char of the abbr, we can determine if there's a subtitle
-  if (parseInt(year) <= 2023) {
+  if (!featuresByYear.uniqueCoreSetTitles) {
     list = {
       C: "Chip",
       M: "Medicaid",
@@ -60,18 +61,18 @@ export const coreSetSubTitles = (year: string, abbr: string) => {
   return list[lastChar] || "";
 };
 
-export const coreSetTitles = (year: string, abbr: string, type?: string) => {
-  const subTitle = coreSetSubTitles(year, abbr);
+export const coreSetTitles = (abbr: string, type?: string) => {
+  const subTitle = coreSetSubTitles(abbr);
   const subType = type || "Measures";
   let name = `${coreSetType(abbr)} Core Set ${subType}`;
   return subTitle ? `${name}: ${subTitle}` : name;
 };
 
 //seperated coresets have unique titles for their breadcrumb menu. this is only for 2024 and onward
-export const coreSetBreadCrumbTitle = (
-  year: string
-): { [key: string]: string } | undefined => {
-  if (parseInt(year) >= 2024)
+export const coreSetBreadCrumbTitle = ():
+  | { [key: string]: string }
+  | undefined => {
+  if (featuresByYear.uniqueCoreSetTitles)
     return {
       [CoreSetAbbr.ACSC]: "(Separate CHIP)",
       [CoreSetAbbr.ACSM]: "(Medicaid (Title XIX & XXI))",

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -40,7 +40,7 @@ export const coreSetSubTitles = (abbr: string) => {
   let coreType = coreSetType(abbr) || "";
   let list: AnyObject = {};
   //using the last char of the abbr, we can determine if there's a subtitle
-  if (!featuresByYear.uniqueCoreSetTitles) {
+  if (!featuresByYear.hasCombinedRates) {
     list = {
       C: "Chip",
       M: "Medicaid",
@@ -72,7 +72,7 @@ export const coreSetTitles = (abbr: string, type?: string) => {
 export const coreSetBreadCrumbTitle = ():
   | { [key: string]: string }
   | undefined => {
-  if (featuresByYear.uniqueCoreSetTitles)
+  if (featuresByYear.hasCombinedRates)
     return {
       [CoreSetAbbr.ACSC]: "(Separate CHIP)",
       [CoreSetAbbr.ACSM]: "(Medicaid (Title XIX & XXI))",

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -1,6 +1,7 @@
 import { SPA } from "libs/spaLib";
-import { AnyObject, CoreSetAbbr } from "types";
+import { CoreSetAbbr } from "types";
 import { featuresByYear } from "utils/featuresByYear";
+import { assertExhaustive } from "utils/typing";
 
 export type CoreSetType = "coreSet" | "text";
 
@@ -36,29 +37,40 @@ export const coreSetType = (abbr: string) => {
 };
 
 export const coreSetSubTitles = (abbr: string) => {
-  let lastChar = abbr[abbr.length - 1];
-  let coreType = coreSetType(abbr) || "";
-  let list: AnyObject = {};
-  //using the last char of the abbr, we can determine if there's a subtitle
-  if (!featuresByYear.hasCombinedRates) {
-    list = {
-      C: "Chip",
-      M: "Medicaid",
-      MC: "Medicaid & CHIP",
-    };
-    lastChar = lastChar === "S" && coreType === "Child" ? "MC" : lastChar;
+  if (featuresByYear.hasCombinedRates) {
+    switch (abbr) {
+      case CoreSetAbbr.ACS:
+      case CoreSetAbbr.ACSM:
+      case CoreSetAbbr.CCS:
+      case CoreSetAbbr.CCSM:
+        return "Medicaid (Title XIX & XXI)";
+      case CoreSetAbbr.ACSC:
+      case CoreSetAbbr.CCSC:
+        return "Separate CHIP";
+      case CoreSetAbbr.HHCS:
+        return "";
+      default:
+        assertExhaustive(abbr as never);
+        return "";
+    }
   } else {
-    list = {
-      C: "Separate CHIP",
-      M: "Medicaid (Title XIX & XXI)",
-      MC: "Medicaid (Title XIX & XXI)",
-    };
-    lastChar =
-      lastChar === "S" && (coreType === "Adult" || coreType === "Child")
-        ? "MC"
-        : lastChar;
+    switch (abbr) {
+      case CoreSetAbbr.CCS:
+        return "Medicaid & CHIP";
+      case CoreSetAbbr.ACSM:
+      case CoreSetAbbr.CCSM:
+        return "Medicaid";
+      case CoreSetAbbr.ACSC:
+      case CoreSetAbbr.CCSC:
+        return "CHIP";
+      case CoreSetAbbr.ACS:
+      case CoreSetAbbr.HHCS:
+        return "";
+      default:
+        assertExhaustive(abbr as never);
+        return "";
+    }
   }
-  return list[lastChar] || "";
 };
 
 export const coreSetTitles = (abbr: string, type?: string) => {

--- a/services/ui-src/src/shared/coreSetByYear.tsx
+++ b/services/ui-src/src/shared/coreSetByYear.tsx
@@ -36,7 +36,7 @@ export const coreSetType = (abbr: string) => {
   return;
 };
 
-export const coreSetSubTitles = (abbr: string) => {
+export const coreSetSubTitles = (abbr: CoreSetAbbr) => {
   if (featuresByYear.hasCombinedRates) {
     switch (abbr) {
       case CoreSetAbbr.ACS:
@@ -50,7 +50,7 @@ export const coreSetSubTitles = (abbr: string) => {
       case CoreSetAbbr.HHCS:
         return "";
       default:
-        assertExhaustive(abbr as never);
+        assertExhaustive(abbr);
         return "";
     }
   } else {
@@ -67,14 +67,14 @@ export const coreSetSubTitles = (abbr: string) => {
       case CoreSetAbbr.HHCS:
         return "";
       default:
-        assertExhaustive(abbr as never);
+        assertExhaustive(abbr);
         return "";
     }
   }
 };
 
 export const coreSetTitles = (abbr: string, type?: string) => {
-  const subTitle = coreSetSubTitles(abbr);
+  const subTitle = coreSetSubTitles(abbr as CoreSetAbbr);
   const subType = type || "Measures";
   let name = `${coreSetType(abbr)} Core Set ${subType}`;
   return subTitle ? `${name}: ${subTitle}` : name;

--- a/services/ui-src/src/shared/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
+++ b/services/ui-src/src/shared/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
@@ -3,7 +3,7 @@ import { FormRateField } from "shared/types/TypeValidations";
 import { featuresByYear } from "utils/featuresByYear";
 
 export const getLabels = (errorReplacementText: string) => {
-  if (featuresByYear.displayCheckmarkWarning) {
+  if (featuresByYear.shouldValidateDuallyEligibleCheckbox) {
     return {
       checkmarkWarning: `Information has been included in the ${errorReplacementText} Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing`,
       missingDataWarning: `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for ${errorReplacementText}`,

--- a/services/ui-src/src/shared/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
+++ b/services/ui-src/src/shared/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
@@ -1,21 +1,17 @@
 import * as DC from "dataConstants";
 import { FormRateField } from "shared/types/TypeValidations";
-import { getMeasureYear } from "utils/getMeasureYear";
+import { featuresByYear } from "utils/featuresByYear";
 
-export const getLabels = (year: number, errorReplacementText: string) => {
-  switch (year) {
-    case 2021:
-    case 2022:
-    case 2023:
-      return {
-        checkmarkWarning: `Information has been included in the ${errorReplacementText} Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing`,
-        missingDataWarning: `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for ${errorReplacementText}`,
-      };
-    default:
-      return {
-        missingDataWarning: `"Individuals Dually Eligible for Medicare and Medicaid" is selected in the "Definition of Denominator" question but you are missing performance measure data for ${errorReplacementText}`,
-      };
+export const getLabels = (errorReplacementText: string) => {
+  if (featuresByYear.displayCheckmarkWarning) {
+    return {
+      checkmarkWarning: `Information has been included in the ${errorReplacementText} Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing`,
+      missingDataWarning: `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for ${errorReplacementText}`,
+    };
   }
+  return {
+    missingDataWarning: `"Individuals Dually Eligible for Medicare and Medicaid" is selected in the "Definition of Denominator" question but you are missing performance measure data for ${errorReplacementText}`,
+  };
 };
 
 export const ComplexValidateDualPopInformation = (
@@ -27,8 +23,7 @@ export const ComplexValidateDualPopInformation = (
   if (OPM) {
     return [];
   }
-  const year = getMeasureYear();
-  const labels = getLabels(year, errorReplacementText);
+  const labels = getLabels(errorReplacementText);
   const dualEligible = DefinitionOfDenominator
     ? DefinitionOfDenominator.indexOf(
         DC.DENOMINATOR_INC_MEDICAID_DUAL_ELIGIBLE

--- a/services/ui-src/src/shared/globalValidations/validateDeviationTextFieldFilled/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDeviationTextFieldFilled/index.ts
@@ -1,21 +1,17 @@
-import { getMeasureYear } from "utils/getMeasureYear";
+import { featuresByYear } from "utils/featuresByYear";
 
 // When a user indicates that there is a deviation, they must add an explanation in the textarea.
-const getLabels = (year: number) => {
-  switch (year) {
-    case 2021:
-    case 2022:
-    case 2023:
-      return {
-        location: "Deviations from Measure Specifications",
-        message: "Deviation(s) must be explained",
-      };
-    default:
-      return {
-        location: "Variations from Measure Specifications",
-        message: "Variation(s) must be explained",
-      };
+const getLabels = () => {
+  if (featuresByYear.displayDeviationlanguage) {
+    return {
+      location: "Deviations from Measure Specifications",
+      message: "Deviation(s) must be explained",
+    };
   }
+  return {
+    location: "Variations from Measure Specifications",
+    message: "Variation(s) must be explained",
+  };
 };
 
 export const validateDeviationTextFieldFilled = (
@@ -26,8 +22,7 @@ export const validateDeviationTextFieldFilled = (
   let errorArray: FormError[] = [];
   let reasonGiven: boolean = false;
 
-  const year = getMeasureYear();
-  const labels = getLabels(year);
+  const labels = getLabels();
 
   if (didCalculationsDeviate) {
     if (!!deviationReason) {

--- a/services/ui-src/src/shared/globalValidations/validateDualPopInformation/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDualPopInformation/index.ts
@@ -3,7 +3,7 @@ import { FormRateField } from "shared/types/TypeValidations";
 import { featuresByYear } from "utils/featuresByYear";
 
 export const getLabels = (errorReplacementText: string) => {
-  if (featuresByYear.displayCheckmarkWarning) {
+  if (featuresByYear.shouldValidateDuallyEligibleCheckbox) {
     return {
       checkmarkWarning: `Information has been included in the ${errorReplacementText} Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing`,
       missingDataWarning: `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for ${errorReplacementText}`,

--- a/services/ui-src/src/shared/globalValidations/validateDualPopInformation/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDualPopInformation/index.ts
@@ -1,21 +1,17 @@
 import * as DC from "dataConstants";
 import { FormRateField } from "shared/types/TypeValidations";
-import { getMeasureYear } from "utils/getMeasureYear";
+import { featuresByYear } from "utils/featuresByYear";
 
-export const getLabels = (year: number, errorReplacementText: string) => {
-  switch (year) {
-    case 2021:
-    case 2022:
-    case 2023:
-      return {
-        checkmarkWarning: `Information has been included in the ${errorReplacementText} Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing`,
-        missingDataWarning: `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for ${errorReplacementText}`,
-      };
-    default:
-      return {
-        missingDataWarning: `"Individuals Dually Eligible for Medicare and Medicaid" is selected in the "Definition of Denominator" question but you are missing performance measure data for ${errorReplacementText}`,
-      };
+export const getLabels = (errorReplacementText: string) => {
+  if (featuresByYear.displayCheckmarkWarning) {
+    return {
+      checkmarkWarning: `Information has been included in the ${errorReplacementText} Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing`,
+      missingDataWarning: `The checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is checked but you are missing performance measure data for ${errorReplacementText}`,
+    };
   }
+  return {
+    missingDataWarning: `"Individuals Dually Eligible for Medicare and Medicaid" is selected in the "Definition of Denominator" question but you are missing performance measure data for ${errorReplacementText}`,
+  };
 };
 
 export const validateDualPopInformationPM = (
@@ -29,8 +25,7 @@ export const validateDualPopInformationPM = (
     return [];
   }
 
-  const year = getMeasureYear();
-  const labels = getLabels(year, errorReplacementText);
+  const labels = getLabels(errorReplacementText);
 
   const dualEligible = DefinitionOfDenominator
     ? DefinitionOfDenominator.indexOf(

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -89,4 +89,15 @@ export const featuresByYear = {
   get displayDeviationlanguage() {
     return getMeasureYear() >= 2023;
   },
+  /**
+   * Prior to 2023, the OMS section included every rate from the PM section,
+   * allowed for subcategorization of every category, and included categories
+   * such as "primary language" and "disability status".
+   *
+   * In 2023 we excluded some rates, disabled some custom subcategorizations,
+   * and removed several categories and sub-categories entirely.
+   */
+  get hasStreamlinedOms() {
+    return getMeasureYear() >= 2023;
+  },
 };

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -1,36 +1,91 @@
 import { getMeasureYear } from "./getMeasureYear";
 
 export const featuresByYear = {
+  /**
+   * Prior to 2024, Adult Core Sets were always reported combined.
+   * In 2024, we separated Adult-CHIP from Adult-Medicaid, for some states.
+   * At the same time, we added the Combined Rates feature,
+   * to provide a summary view for data across the new separation.
+   * This goes hand-in-hand with other small features,
+   * like more specific core set titles in the header and breadcrumbs.
+   */
   get hasCombinedRates() {
     return getMeasureYear() >= 2024;
   },
+  /**
+   * Prior to 2023, rate identification was largely done by string manipulation.
+   * IDs were generated on the fly by joining the qualifier to the category.
+   * For example, the first rate of APM-CH was `Ages1to11.BloodGlucose`
+   *
+   * In 2023, we introduced short programmatic IDs, separate from label text.
+   * Unique rate-level IDs are the category's ID, joined to the qualifier's.
+   * For example, the first rate of APM-CH is now `rcmfbq.rJQSKZ`
+   *
+   * Note that in addition to swapping "cleaned" labels for IDs,
+   * we changed the order from `qual.cat` to `cat.qual`
+   */
   get hasQualCatLabels() {
     return getMeasureYear() <= 2022;
   },
+  /**
+   * Beginning in 2024, states are required to report all of the measures
+   * on the child core set and the behavioral health measures on the adult
+   * core set. Also states with health home are required to report all of
+   * the measures on the health home core sets.
+   */
   get hasMandatoryReporting() {
     return getMeasureYear() >= 2024;
   },
-  get pheYear() {
+  /**
+   * Prior to 2023, we always displayed a message acknowledging
+   * the difficulty of data collection during the Covid pandemic.
+   * In 2023, we switched to controlling this message with a LaunchDarkly flag
+   */
+  get periodOfHealthEmergency() {
     return getMeasureYear() < 2023;
   },
-  get optionalDateRangeTracking() {
+  /**
+   * Prior to 2023, users were always required to fill out the measure dates,
+   * even when they matched the Core Set's standard, specified range.
+   * In 2023, we wrapped the dates in a "are your dates standard?" radio button,
+   * so that users could just click "yes" and save some typing.
+   */
+  get allowImplicitMeasureDates() {
     return getMeasureYear() >= 2023;
   },
-  get uniqueCoreSetTitles() {
-    return getMeasureYear() >= 2024;
-  },
-  get yearIsNot2025() {
+  /**
+   * All years have been released except for 2025 so this checks to make sure
+   * the year is any year except 2025
+   */
+  get reportingYearReleased() {
     return getMeasureYear() !== 2025;
   },
-  get displayMandatoryColumn() {
+  /**
+   * Prior to 2024, we didn't distinguish mandatory measures from optional ones.
+   * In 2024, we added a the mandatory flag as column in the measure table,
+   * so that users can see at a glance which measures are mandatory.
+   */
+  get displayMandatoryMeasuresColumn() {
     return getMeasureYear() >= 2024;
   },
-  get humanReadableTextForMathematica() {
+  /**
+   * Beginning in 2023, the category for a complex rate needs to be set to
+   * human readable label for display in Mathematica
+   */
+  get setCategoryForComplexRate() {
     return getMeasureYear() >= 2023;
   },
-  get displayCheckmarkWarning() {
+  /**
+   * Prior to 2024, we would display a warning if users entered rates for 65+
+   * qualifiers, without marking Dual-Eligible in the Definition of Population.
+   * In 2024, we removed this validation at the request of CMS.
+   */ get shouldValidateDuallyEligibleCheckbox() {
     return getMeasureYear() >= 2023;
   },
+  /**
+   * Prior to 2024, we asked if measurements had "deviations" from the spec.
+   * In 2024, we rephrased this question to ask about "variations" instead.
+   */
   get displayDeviationlanguage() {
     return getMeasureYear() >= 2023;
   },

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -62,7 +62,7 @@ export const featuresByYear = {
   },
   /**
    * Prior to 2024, we didn't distinguish mandatory measures from optional ones.
-   * In 2024, we added a the mandatory flag as column in the measure table,
+   * In 2024, we added the mandatory flag as column in the measure table,
    * so that users can see at a glance which measures are mandatory.
    */
   get displayMandatoryMeasuresColumn() {

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -1,0 +1,37 @@
+import { getMeasureYear } from "./getMeasureYear";
+
+export const featuresByYear = {
+  get hasCombinedRates() {
+    return getMeasureYear() >= 2024;
+  },
+  get hasQualCatLabels() {
+    return getMeasureYear() <= 2022;
+  },
+  get hasMandatoryReporting() {
+    return getMeasureYear() >= 2024;
+  },
+  get pheYear() {
+    return getMeasureYear() < 2023;
+  },
+  get optionalDateRangeTracking() {
+    return getMeasureYear() >= 2023;
+  },
+  get uniqueCoreSetTitles() {
+    return getMeasureYear() >= 2024;
+  },
+  get yearIsNot2025() {
+    return getMeasureYear() !== 2025;
+  },
+  get displayMandatoryColumn() {
+    return getMeasureYear() >= 2024;
+  },
+  get humanReadableTextForMathematica() {
+    return getMeasureYear() >= 2023;
+  },
+  get displayCheckmarkWarning() {
+    return getMeasureYear() >= 2023;
+  },
+  get displayDeviationlanguage() {
+    return getMeasureYear() >= 2023;
+  },
+};

--- a/services/ui-src/src/utils/getLabelText.tsx
+++ b/services/ui-src/src/utils/getLabelText.tsx
@@ -3,6 +3,7 @@ import { data as data2022 } from "../measures/2022/rateLabelText";
 import { data as data2023 } from "../measures/2023/rateLabelText";
 import { data as data2024 } from "../measures/2024/rateLabelText";
 import { data as data2025 } from "../measures/2025/rateLabelText";
+import { featuresByYear } from "./featuresByYear";
 
 type LabelText = { [key: string]: string };
 export interface LabelData {
@@ -42,8 +43,5 @@ export const getLabelText = (): { [key: string]: string } => {
 
 //pre-2023, the system was using string types for categories & qualifiers. we want to be able to identify it as it determines our data structure for those years
 export const isLegacyLabel = () => {
-  const { pathname } = window.location;
-  const params = pathname.split("/");
-  const year = Number(params[2]);
-  return year < 2023;
+  return featuresByYear.hasQualCatLabels;
 };

--- a/services/ui-src/src/utils/typing.ts
+++ b/services/ui-src/src/utils/typing.ts
@@ -1,0 +1,5 @@
+/**
+ * Instructs Typescript to complain if it detects that this function may be reachable.
+ * Useful for the default branch of a switch statement that verifiably covers every case.
+ */
+export const assertExhaustive = (_: never): void => {};

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -20,6 +20,7 @@ import { useUser } from "hooks/authHooks";
 import { coreSetTitles } from "shared/coreSetByYear";
 import { Alert } from "@cmsgov/design-system";
 import { parseLabelToHTML } from "utils";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface HandleDeleteMeasureData {
   coreSet: CoreSetAbbr;
@@ -92,7 +93,7 @@ const QualifiersStatusAndLink = ({ coreSetId }: { coreSetId: CoreSetAbbr }) => {
       <CUI.Text>Core Set Qualifiers</CUI.Text>
       <Link to={"CSQ"}>
         <CUI.Text color="blue" data-cy="core-set-qualifiers-link">
-          {coreSetTitles(year!, coreSetInfo[0], "Questions") + spaName}
+          {coreSetTitles(coreSetInfo[0], "Questions") + spaName}
         </CUI.Text>
       </Link>
 
@@ -326,19 +327,20 @@ export const CoreSet = () => {
         { path: `/${state}/${year}`, name: `FFY ${year}` },
         {
           path: `/${state}/${year}/${coreSetId}`,
-          name: coreSetTitles(year, coreSet[0]) + spaName,
+          name: coreSetTitles(coreSet[0]) + spaName,
         },
       ]}
     >
-      {Number(year) >= 2024 && coreSetInstructions[coreSetPrefix] && (
-        <CUI.Box mb="8">
-          <Alert heading="Mandatory Reporting">
-            <CUI.Text sx={{ "& a": { textDecoration: "underline" } }}>
-              {parseLabelToHTML(coreSetInstructions[coreSetPrefix])}
-            </CUI.Text>
-          </Alert>
-        </CUI.Box>
-      )}
+      {featuresByYear.hasMandatoryReporting &&
+        coreSetInstructions[coreSetPrefix] && (
+          <CUI.Box mb="8">
+            <Alert heading="Mandatory Reporting">
+              <CUI.Text sx={{ "& a": { textDecoration: "underline" } }}>
+                {parseLabelToHTML(coreSetInstructions[coreSetPrefix])}
+              </CUI.Text>
+            </Alert>
+          </CUI.Box>
+        )}
       <QMR.UpdateInfoModal
         closeModal={closeModal}
         handleModalResponse={handleModalResponse}

--- a/services/ui-src/src/views/StateHome/__tests__/index.test.tsx
+++ b/services/ui-src/src/views/StateHome/__tests__/index.test.tsx
@@ -8,6 +8,7 @@ import { useParams } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import { useUser } from "hooks/authHooks";
 import { CoreSetAbbr } from "types";
+import { getMeasureYear } from "utils/getMeasureYear";
 expect.extend(toHaveNoViolations);
 
 const queryClient = new QueryClient();
@@ -15,6 +16,9 @@ const queryClient = new QueryClient();
 const mockedNavigate = jest.fn();
 
 const mockUseParams = useParams as jest.Mock;
+
+jest.mock("../../../utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 const mockMutate = jest.fn((_variables: CoreSetAbbr, options?: any) => {
   if (typeof options?.onSuccess === "function") return options.onSuccess();
@@ -120,6 +124,7 @@ describe("Test 2023 state without health home core sets", () => {
 describe("Test StateHome 2024", () => {
   beforeEach(() => {
     mockUseUser.mockImplementation(() => useUser);
+    mockGetMeasureYear.mockReturnValue(2024);
     mockUseParams.mockReturnValue({
       year: "2024",
       state: "IN",

--- a/services/ui-src/src/views/StateHome/helpers.ts
+++ b/services/ui-src/src/views/StateHome/helpers.ts
@@ -84,7 +84,7 @@ export const formatTableItems = ({
           : "";
 
       const type = getCoreSetType(tempSet[0] as CoreSetAbbr);
-      const title = coreSetTitles(year.toString(), tempSet[0]) + tempTitle;
+      const title = coreSetTitles(tempSet[0]) + tempTitle;
 
       const coreSetCards = coreSets[
         year as keyof typeof coreSets

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -21,6 +21,7 @@ import { coreSets, CoreSetField } from "shared/coreSetByYear";
 import { useFlags } from "launchdarkly-react-client-sdk";
 import { Link } from "react-router-dom";
 import { statesWithoutCombinedRates } from "utils";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface HandleDeleteData {
   state: string;
@@ -101,7 +102,7 @@ const ReportingYear = () => {
           </option>
         ))}
       </CUI.Select>
-      {year! >= "2024" && showCombinedRatesButton && (
+      {featuresByYear.hasCombinedRates && showCombinedRatesButton && (
         <CUI.Box mt="22px">
           <Link
             to={`/${state}/${year}/combined-rates`}


### PR DESCRIPTION
### Description
Instead of checking what year it is and rendering something for that year like:
```
if (year >= 2024) { 
// render something specific to years 2024 and beyond
}
```
we want to create a `featuresByYear` file that has a bunch of functions. These functions do the same exact year check, except the value add is that they document the feature. So for example for showing the combined rates button for years 2024+, instead of doing that year check (if year >= 2024, render combined rates button), we have a function in the featuresByYear folder that is called `hasCombinedRates` or something. Then that function returns year >= 2024, but when we call it in app, we'll call `featuresByYear.hasCombinedRates` which will document the feature and will make it easier to read and figure out what the code is doing. 

I'm very VERY open to any suggestions here on how to improve this solution. I don't really like what i'm doing here, I think it's clunky and weird and I had tons of trouble actually coming up with useful and descriptive names for a lot of the features. So open to more descriptive names or just another way to do it in general. 

Also, I know this is a pain in the ass to review so let me know if a walk through of the PR may be more helpful.

### Related ticket(s)
CMDCT-3883

---
### How to test
https://d3oh08q9m9o734.cloudfront.net/
This is a pretty sweeping PR so I would think a general smoke test is in order here. Just make sure things all look as they should basically.