### PR TITLE
Date Picker Rendering

### DIFF
--- a/services/ui-src/src/components/DateRange/index.tsx
+++ b/services/ui-src/src/components/DateRange/index.tsx
@@ -87,16 +87,18 @@ export const DateRangeError = ({ name }: { name: string }) => {
 export const DateRange = ({ name }: Props) => {
   return (
     <CUI.Stack>
-      <CUI.FormControl>
-        <CUI.FormLabel id={`${name}.startDate-label`} fontWeight={500}>
-          {"Start Date"}
-        </CUI.FormLabel>
-        <MonthPicker name={`${name}.startDate`} />
-        <CUI.FormLabel pt={5} fontWeight={500}>
-          {"End Date"}
-        </CUI.FormLabel>
-        <MonthPicker name={`${name}.endDate`} />
-      </CUI.FormControl>
+      <CUI.Box height="212px">
+        <CUI.FormControl position="absolute" height="auto">
+          <CUI.FormLabel id={`${name}.startDate-label`} fontWeight={500}>
+            {"Start Date"}
+          </CUI.FormLabel>
+          <MonthPicker name={`${name}.startDate`} />
+          <CUI.FormLabel pt={5} fontWeight={500}>
+            {"End Date"}
+          </CUI.FormLabel>
+          <MonthPicker name={`${name}.endDate`} />
+        </CUI.FormControl>
+      </CUI.Box>
       <DateRangeError name={name} />
     </CUI.Stack>
   );

--- a/services/ui-src/src/components/DateRange/index.tsx
+++ b/services/ui-src/src/components/DateRange/index.tsx
@@ -88,7 +88,7 @@ export const DateRange = ({ name }: Props) => {
   return (
     <CUI.Stack>
       <CUI.Box height="212px">
-        <CUI.FormControl position="absolute" height="auto">
+        <CUI.FormControl position="absolute">
           <CUI.FormLabel id={`${name}.startDate-label`} fontWeight={500}>
             {"Start Date"}
           </CUI.FormLabel>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
A fix for the issue with 2023+ date pickers where the component rendering is being half hidden due to it being layered as a child of the radio button.

![Screenshot 2024-10-23 at 2 38 17 PM](https://github.com/user-attachments/assets/63767b8c-75e9-40cd-8a38-c677e359aa89)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3873

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d7i4tmshon0x.cloudfront.net/

1) Sign into QMR, any user
2) Go into any measure that has the Date Range section
3) Select "No, our state used a different measurement period." to open up the date picker
4) Use the date picker to select the month of reporting, make sure there's no issue with the rendering of the date picker component.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
