### PR TITLE
CMDCT-4101: removing unused measures, coreSets and rates tables

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -12,13 +12,10 @@ S3_LOCAL_ENDPOINT=http://localhost:4569
 
 ## DYNAMO TABLES
 bannerTableName=local-banners
-coreSetTableName=local-coreSets
 DYNAMO_TABLE_ARN=local_nonsense_if_unset_we_search_CF_for
-measureTableName=local-measures
 measureTable=local-measure
 coreSetTable=local-coreSet
 rateTable=local-rate
-rateTableName=local-rates
 
 # LAUNCHDARKLY
 LD_PROJECT_KEY=op://mdct_devs/qmr_secrets/LD_PROJECT_KEY

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -43,13 +43,13 @@ custom:
     path: ../../.env
   docraptorApiKey: ${env:docraptorApiKey, ssm:/${self:custom.stage}/pdf/docraptorApiKey, ssm:/default/pdf/docraptorApiKey}
   bootstrapBrokerStringTls: ${ssm:/configuration/${self:custom.stage}/qmr/bootstrapBrokerStringTls, ssm:/configuration/default/qmr/bootstrapBrokerStringTls, ''}
-  coreSetTableStreamArn: ${env:DYNAMO_TABLE_ARN, param:CoreSetTableStreamArn}
   measureTable: ${env:measureTable, param:MeasureTable}
   coreSetTable: ${env:coreSetTable, param:CoreSetTable}
   rateTable: ${env:rateTable, param:RateTable}
-  measureTableStreamArn: ${env:DYNAMO_TABLE_ARN, param:MeasureTableStreamArn}
-  rateTableStreamArn: ${env:DYNAMO_TABLE_ARN, param:RateTableStreamArn}
   bannerTableName: ${env:bannerTableName, param:BannerTableName}
+  measureTableStreamArn: ${env:DYNAMO_TABLE_ARN, param:MeasureTableStreamArn}
+  coreSetTableStreamArn: ${env:DYNAMO_TABLE_ARN, param:CoreSetTableStreamArn}
+  rateTableStreamArn: ${env:DYNAMO_TABLE_ARN, param:RateTableStreamArn}
   webAclName: ${self:service}-${self:custom.stage}-webacl-waf
   vpcId: ${ssm:/configuration/${self:custom.stage}/vpc/id, ssm:/configuration/default/vpc/id, ''}
   privateSubnets:

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -16,10 +16,7 @@ custom:
       - master
       - val
       - prod
-  coreSetTableName: ${self:custom.stage}-coreSets
-  measureTableName: ${self:custom.stage}-measures
   bannerTableName: ${self:custom.stage}-banners
-  rateTableName: ${self:custom.stage}-rates
   measureTable: ${self:custom.stage}-measure
   coreSetTable: ${self:custom.stage}-coreSet
   rateTable: ${self:custom.stage}-rate
@@ -41,63 +38,6 @@ provider:
 
 resources:
   Resources:
-    CoreSetTable:
-      Type: AWS::DynamoDB::Table
-      Properties:
-        TableName: ${self:custom.coreSetTableName}
-        PointInTimeRecoverySpecification:
-          PointInTimeRecoveryEnabled: true
-        StreamSpecification:
-          StreamViewType: NEW_AND_OLD_IMAGES
-        AttributeDefinitions:
-          - AttributeName: compoundKey
-            AttributeType: S
-          - AttributeName: coreSet
-            AttributeType: S
-        KeySchema:
-          - AttributeName: compoundKey
-            KeyType: HASH
-          - AttributeName: coreSet
-            KeyType: RANGE
-        BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
-    RateTable:
-      Type: AWS::DynamoDB::Table
-      Properties:
-        TableName: ${self:custom.rateTableName}
-        PointInTimeRecoverySpecification:
-          PointInTimeRecoveryEnabled: true
-        StreamSpecification:
-          StreamViewType: NEW_AND_OLD_IMAGES
-        AttributeDefinitions:
-          - AttributeName: compoundKey
-            AttributeType: S
-          - AttributeName: measure
-            AttributeType: S
-        KeySchema:
-          - AttributeName: compoundKey
-            KeyType: HASH
-          - AttributeName: measure
-            KeyType: RANGE
-        BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
-    MeasureTable:
-      Type: AWS::DynamoDB::Table
-      Properties:
-        TableName: ${self:custom.measureTableName}
-        PointInTimeRecoverySpecification:
-          PointInTimeRecoveryEnabled: true
-        StreamSpecification:
-          StreamViewType: NEW_AND_OLD_IMAGES
-        AttributeDefinitions:
-          - AttributeName: compoundKey
-            AttributeType: S
-          - AttributeName: coreSet
-            AttributeType: S
-        KeySchema:
-          - AttributeName: compoundKey
-            KeyType: HASH
-          - AttributeName: coreSet
-            KeyType: RANGE
-        BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     BannerTable:
       Type: AWS::DynamoDB::Table
       Properties:


### PR DESCRIPTION
### Description
This is the cleanup work involved with all the table rekeying we did last month. Just removing the old tables that aren't being used anymore. 


### Related ticket(s)
CMDCT-4101

---
### How to test
https://dvvnje2vq4dct.cloudfront.net/
No functionality changes. Just a general smoke test to make sure everything looks good.
