### PR TITLE
CMDCT-4034: Removing FFY language for 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/07b73163d1474a114cb9/test_coverage)](https://codeclimate.com/repos/644971d1d763981eff6ed851/test_coverage)
 
 ### Integration Environment Deploy Status:
-| Branch  | Build Status |
-| ------------- | ------------- |
-| master  | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/workflows/deploy.yml/badge.svg)  |
-| val  | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/workflows/deploy.yml/badge.svg?branch=val)  |
-| prod  | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/workflows/deploy.yml/badge.svg?branch=prod)  |
 
+| Branch | Build Status                                                                                                     |
+| ------ | ---------------------------------------------------------------------------------------------------------------- |
+| master | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/workflows/deploy.yml/badge.svg)             |
+| val    | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/workflows/deploy.yml/badge.svg?branch=val)  |
+| prod   | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/workflows/deploy.yml/badge.svg?branch=prod) |
 
 QMR is the CMCS MDCT application for collecting state data for related to measuring and quantifying healthcare processes and ensuring quality healthcare for Medicaid beneficiaries. The collected data assists CMCS in monitoring, managing, and better understanding Medicaid and CHIP programs.
 
@@ -73,9 +73,10 @@ QMR is the CMCS MDCT application for collecting state data for related to measur
 ## Local Development Setup
 
 ### Running MDCT Workspace Setup
-Team members are encouraged to setup all MDCT Products using the script located in the [MDCT Tools Repository](https://github.com/Enterprise-CMCS/macpro-mdct-tools). Please refer to the README for instructions running the MDCT Workspace Setup. After Running workspace setup team members can refer to the Running the project locally section below to proceed with running the application. 
 
-The following are prerequisites for local development.  **If you have run the MDCT Workspace setup script please ignore this section it is not needed.**
+Team members are encouraged to setup all MDCT Products using the script located in the [MDCT Tools Repository](https://github.com/Enterprise-CMCS/macpro-mdct-tools). Please refer to the README for instructions running the MDCT Workspace Setup. After Running workspace setup team members can refer to the Running the project locally section below to proceed with running the application.
+
+The following are prerequisites for local development. **If you have run the MDCT Workspace setup script please ignore this section it is not needed.**
 
 1. [Create an SSH Key and link it to your Github account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
 1. Clone this repository locally
@@ -195,16 +196,14 @@ yarn install
 
 To run the end-to-end (E2E) `Cypress` tests:
 
-
 from the root of the directory
+
 ```
 ./run update-env
 yarn test
 ```
 
 **note:** this will ensure you are using the latest values from 1Password and update your .env files
-
-
 
 The `Cypress` application will kick off, where you can find a list of all the available E2E tests.
 
@@ -399,7 +398,7 @@ A known issue with this utility is that right now it only `ands` arguments, so i
 
 ## Database
 
-We are using DynamoDb for our database solution for QMR. When looking for the databases in AWS search for `branchName-tableName` to find the tables for your branch.
+We are using DynamoDB for our database solution for QMR. When looking for the databases in AWS search for `branchName-tableName` to find the tables for your branch.
 
 ### Tables
 
@@ -571,7 +570,7 @@ to make in order to get that year working.
 
 15. In `services/ui-src/src/config.ts` change `currentReportingYear` to the new reporting year.
 
-### Cypress 
+### Cypress
 
 1. In `test/cypress/support/constants.ts` change the const from measureAbbrList{year} to the coming year and do a quick search and replace for any instance of that variable call.
 

--- a/services/ui-src/src/components/AutocompletedMeasureTemplate/index.test.tsx
+++ b/services/ui-src/src/components/AutocompletedMeasureTemplate/index.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import { RouterWrappedComp } from "utils/testing";
 import { AutocompletedMeasureTemplate } from ".";
+import { getMeasureYear } from "utils/getMeasureYear";
+
+jest.mock("utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 beforeEach(() => {
+  mockGetMeasureYear.mockReturnValue(2021);
   render(
     <RouterWrappedComp>
       <AutocompletedMeasureTemplate

--- a/services/ui-src/src/components/AutocompletedMeasureTemplate/index.tsx
+++ b/services/ui-src/src/components/AutocompletedMeasureTemplate/index.tsx
@@ -2,6 +2,7 @@ import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
 import { Link } from "react-router-dom";
 import { useParams } from "react-router-dom";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface Props {
   measureTitle: string;
@@ -64,7 +65,9 @@ export const AutocompletedMeasureTemplate = ({
               return <CUI.Text key={`subText.${idx}`}>{text}</CUI.Text>;
             })}
           <CUI.Text fontWeight="700">
-            {`States are not asked to report data for this measure for FFY ${year} Core Set reporting in the online
+            {`States are not asked to report data for this measure for ${
+              featuresByYear.displayFFYLanguage ? "FFY" : ""
+            } ${year} Core Set reporting in the online
             reporting system.`}
           </CUI.Text>
         </CUI.Stack>

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -27,6 +27,7 @@ import { CompleteCoreSets } from "./complete";
 import SharedContext from "shared/SharedContext";
 import * as Labels from "labels/Labels";
 import { coreSetBreadCrumbTitle } from "shared/coreSetByYear";
+import { featuresByYear } from "utils/featuresByYear";
 
 const LastModifiedBy = ({ user }: { user: string | undefined }) => {
   if (!user) return null;
@@ -438,7 +439,10 @@ export const MeasureWrapper = ({
       />
       <QMR.StateLayout
         breadcrumbItems={[
-          { path: `/${params.state}/${year}`, name: `FFY ${year}` },
+          {
+            path: `/${params.state}/${year}`,
+            name: `${featuresByYear.displayFFYLanguage ? "FFY" : ""} ${year}`,
+          },
           // This next path object is to bring the user back to the measures list with the back button
           {
             path: `/${params.state}/${year}/${params.coreSetId}`,

--- a/services/ui-src/src/components/SubmitCoreSet/index.test.tsx
+++ b/services/ui-src/src/components/SubmitCoreSet/index.test.tsx
@@ -6,9 +6,13 @@ import { screen } from "@testing-library/react";
 import { SubmitCoreSetButton } from ".";
 import { useApiMock } from "utils/testUtils/useApiMock";
 import { useUser } from "hooks/authHooks";
+import { getMeasureYear } from "utils/getMeasureYear";
 
 jest.mock("hooks/authHooks");
 const mockUseUser = useUser as jest.Mock;
+
+jest.mock("utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 interface Props {
   coreSet: CoreSetAbbr;
@@ -19,6 +23,7 @@ interface Props {
 }
 
 const renderTestComponent = (props: Props) => {
+  mockGetMeasureYear.mockReturnValue(2021);
   mockUseUser.mockImplementation(() => {
     return { isStateUser: props.isStateUser };
   });

--- a/services/ui-src/src/components/SubmitCoreSet/index.tsx
+++ b/services/ui-src/src/components/SubmitCoreSet/index.tsx
@@ -6,6 +6,7 @@ import { useEditCoreSet } from "hooks/api";
 import { useParams } from "react-router-dom";
 import { useUser } from "hooks/authHooks";
 import { useQueryClient } from "react-query";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface Props {
   coreSet: CoreSetAbbr;
@@ -59,7 +60,9 @@ export const SubmitCoreSetButton = ({
         return " ";
     }
   };
-  const helperText = `Complete all ${helperTextFiller()}Core Set Questions${subSetTextFiller()}and ${helperTextFiller()}Core Set Measures${subSetTextFiller()}to submit FFY ${year}`;
+  const helperText = `Complete all ${helperTextFiller()}Core Set Questions${subSetTextFiller()}and ${helperTextFiller()}Core Set Measures${subSetTextFiller()}to submit ${
+    featuresByYear.displayFFYLanguage ? "FFY" : ""
+  } ${year}`;
   const { mutate, isLoading } = useEditCoreSet();
   const queryClient = useQueryClient();
   const userInfo = useUser();

--- a/services/ui-src/src/components/Table/columns/measures.tsx
+++ b/services/ui-src/src/components/Table/columns/measures.tsx
@@ -109,7 +109,8 @@ export const measuresColumns = (
         ]
       : []),
     {
-      header: "Reporting FFY " + year,
+      header:
+        `Reporting ${featuresByYear.displayFFYLanguage ? "FFY" : ""} ` + year,
       id: "reporting_column_header",
       styleProps: { textAlign: "center" },
       cell: (data: MeasureTableItem.Data) => {

--- a/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
@@ -21,7 +21,7 @@ export const commonQuestionsLabel = {
       "If you report using Other Data Source, CMS will not be able to produce a combined Medicaid & CHIP rate for public reporting. If the information reported in the Data Source field is accurate, please continue reporting this measure.",
     warning: {
       [DC.ELECTRONIC_CLINIC_DATA_SYSTEMS]:
-        "If you report using Electronic Clinical Data Systems (ECDS), CMS will not be able to produce a combined Medicaid & CHIP rate for public reporting for FFY 2025. If the information reported in the Data Source field is accurate, please continue reporting this measure.",
+        "If you report using Electronic Clinical Data Systems (ECDS), CMS will not be able to produce a combined Medicaid & CHIP rate for public reporting for 2025. If the information reported in the Data Source field is accurate, please continue reporting this measure.",
     },
   },
   DataSourceCahps: {
@@ -87,15 +87,15 @@ export const commonQuestionsLabel = {
       "If your state substantially varied from the measure specifications (including different methodology, timeframe, or reported age groups), please report your data using “Other” specifications.",
     options: [
       {
-        displayValue: "HEDIS MY 2024 (FFY 2025 Core Set Reporting)",
+        displayValue: "HEDIS MY 2024 (2025 Core Set Reporting)",
         value: DC.HEDIS_MY_2023,
       },
       {
-        displayValue: "HEDIS MY 2023 (FFY 2024 Core Set Reporting)",
+        displayValue: "HEDIS MY 2023 (2024 Core Set Reporting)",
         value: DC.HEDIS_MY_2022,
       },
       {
-        displayValue: "HEDIS MY 2022 (FFY 2023 Core Set Reporting)",
+        displayValue: "HEDIS MY 2022 (2023 Core Set Reporting)",
         value: DC.HEDIS_MY_2021,
       },
     ],

--- a/services/ui-src/src/measures/2025/CPAAD/questions/Reporting.tsx
+++ b/services/ui-src/src/measures/2025/CPAAD/questions/Reporting.tsx
@@ -25,11 +25,11 @@ export const Reporting = ({ reportingYear }: Props) => {
           {...register("DidCollect")}
           options={[
             {
-              displayValue: `Yes, we did collect data for the Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H, Adult Version (Medicaid) (CPA-AD) for FFY ${reportingYear} quality measure reporting.`,
+              displayValue: `Yes, we did collect data for the Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H, Adult Version (Medicaid) (CPA-AD) for ${reportingYear} quality measure reporting.`,
               value: "yes",
             },
             {
-              displayValue: `No, we did not collect data for the Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H, Adult Version (Medicaid) (CPA-AD) for FFY ${reportingYear} quality measure reporting.`,
+              displayValue: `No, we did not collect data for the Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H, Adult Version (Medicaid) (CPA-AD) for ${reportingYear} quality measure reporting.`,
               value: "no",
             },
           ]}

--- a/services/ui-src/src/measures/2025/CPCCH/questions/Reporting.tsx
+++ b/services/ui-src/src/measures/2025/CPCCH/questions/Reporting.tsx
@@ -25,11 +25,11 @@ export const Reporting = ({ reportingYear }: Props) => {
           {...register("DidCollect")}
           options={[
             {
-              displayValue: `Yes, we did collect data for the Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H - Child Version Including Medicaid and Children with Chronic Conditions Supplemental Items (CPC-CH) for FFY ${reportingYear} quality measure reporting`,
+              displayValue: `Yes, we did collect data for the Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H - Child Version Including Medicaid and Children with Chronic Conditions Supplemental Items (CPC-CH) for ${reportingYear} quality measure reporting`,
               value: "yes",
             },
             {
-              displayValue: `No, we did not collect data for the Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H - Child Version Including Medicaid and Children with Chronic Conditions Supplemental Items (CPC-CH) for FFY ${reportingYear} quality measure reporting`,
+              displayValue: `No, we did not collect data for the Consumer Assessment of Healthcare Providers and Systems (CAHPS®) Health Plan Survey 5.1H - Child Version Including Medicaid and Children with Chronic Conditions Supplemental Items (CPC-CH) for ${reportingYear} quality measure reporting`,
               value: "no",
             },
           ]}

--- a/services/ui-src/src/measures/2025/MSCAD/questions/HowDidYouReport.tsx
+++ b/services/ui-src/src/measures/2025/MSCAD/questions/HowDidYouReport.tsx
@@ -30,14 +30,14 @@ export const HowDidYouReport = ({ reportingYear }: Props) => {
               <QMR.CoreQuestionWrapper testid="did-report" label="">
                 <QMR.RadioButton
                   {...register(DC.DID_REPORT)}
-                  label={`Would you like to enter data for this measure in the QMR system for FFY ${reportingYear} reporting?`}
+                  label={`Would you like to enter data for this measure in the QMR system for ${reportingYear} reporting?`}
                   options={[
                     {
-                      displayValue: `Yes, I would like to enter data for this measure in the QMR system for FFY ${reportingYear} reporting.`,
+                      displayValue: `Yes, I would like to enter data for this measure in the QMR system for ${reportingYear} reporting.`,
                       value: DC.YES,
                     },
                     {
-                      displayValue: `No, I would not like to enter data for this measure in the QMR system for FFY ${reportingYear} reporting.`,
+                      displayValue: `No, I would not like to enter data for this measure in the QMR system for ${reportingYear} reporting.`,
                       value: DC.NO,
                     },
                   ]}

--- a/services/ui-src/src/measures/2025/MSCAD/questions/Reporting.tsx
+++ b/services/ui-src/src/measures/2025/MSCAD/questions/Reporting.tsx
@@ -24,11 +24,11 @@ export const Reporting = ({ reportingYear }: Props) => {
           {...register(DC.DID_COLLECT)}
           options={[
             {
-              displayValue: `Yes, we did collect data for Medical Assistance with Smoking and Tobacco Use Cessation (MSC-AD) for FFY ${reportingYear} quality measure reporting.`,
+              displayValue: `Yes, we did collect data for Medical Assistance with Smoking and Tobacco Use Cessation (MSC-AD) for ${reportingYear} quality measure reporting.`,
               value: DC.YES,
             },
             {
-              displayValue: `No, we did not collect data for Medical Assistance with Smoking and Tobacco Use Cessation (MSC-AD) for FFY ${reportingYear} quality measure reporting.`,
+              displayValue: `No, we did not collect data for Medical Assistance with Smoking and Tobacco Use Cessation (MSC-AD) for ${reportingYear} quality measure reporting.`,
               value: DC.NO,
             },
           ]}

--- a/services/ui-src/src/measures/2025/OEVCH/data.ts
+++ b/services/ui-src/src/measures/2025/OEVCH/data.ts
@@ -5,7 +5,7 @@ export const { categories, qualifiers } = getCatQualLabels("OEV-CH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
-    "Percentage of enrolled children under age 21 who received a comprehensive or periodic oral evaluation within the measurement year. For FFY 2025 Child Core Set reporting, the following rate is required: Total ages < 1 to 20.",
+    "Percentage of enrolled children under age 21 who received a comprehensive or periodic oral evaluation within the measurement year. For 2025 Child Core Set reporting, the following rate is required: Total ages < 1 to 20.",
   ],
   categories,
   qualifiers,

--- a/services/ui-src/src/measures/2025/TFLCH/data.ts
+++ b/services/ui-src/src/measures/2025/TFLCH/data.ts
@@ -5,7 +5,7 @@ export const { categories, qualifiers } = getCatQualLabels("TFL-CH");
 export const data: DataDrivenTypes.PerformanceMeasure = {
   questionText: [
     "Percentage of enrolled children ages 1 through 20 who received at least two topical fluoride applications as: (1) dental or oral health services, (2) dental services, and (3) oral health services within the measurement year.",
-    "For FFY 2025 Child Core Set reporting, the following three rates are required: (1) Dental or oral health services: Total ages 1 through 20; (2) Dental services: Total ages 1 through 20; and (3) Oral health services: Total ages 1 through 20.",
+    "For 2025 Child Core Set reporting, the following three rates are required: (1) Dental or oral health services: Total ages 1 through 20; (2) Dental services: Total ages 1 through 20; and (3) Oral health services: Total ages 1 through 20.",
   ],
   questionListItems: [],
   categories,

--- a/services/ui-src/src/shared/Qualifiers/Common/costSavingsData.tsx
+++ b/services/ui-src/src/shared/Qualifiers/Common/costSavingsData.tsx
@@ -5,6 +5,7 @@ import * as Common from ".";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "./../../types/TypeQualifierForm";
 import { allPositiveIntegersWith10Digits } from "utils";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface Props {
   year: string;
@@ -21,7 +22,9 @@ export const CostSavingsData = ({ year }: Props) => {
         {...register("yearlyCostSavings")}
         mask={allPositiveIntegersWith10Digits}
         formLabelProps={{ fontWeight: "400", padding: padding }}
-        label={`Amount of cost savings for FFY ${parseInt(year) - 1}`}
+        label={`Amount of cost savings for ${
+          featuresByYear.displayFFYLanguage ? "FFY" : ""
+        } ${parseInt(year) - 1}`}
       />
       <QMR.TextArea
         {...register("costSavingsMethodology")}

--- a/services/ui-src/src/shared/commonQuestions/AdditionalNotes.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/AdditionalNotes.test.tsx
@@ -6,6 +6,10 @@ import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import SharedContext from "shared/SharedContext";
 import { commonQuestionsLabel as commonQuestionsLabels2024 } from "labels/2024/commonQuestionsLabel";
 import { commonQuestionsLabel as commonQuestionsLabels2023 } from "labels/2023/commonQuestionsLabel";
+import { getMeasureYear } from "utils/getMeasureYear";
+
+jest.mock("utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 const isReportingTextAreaLabel =
   "Please add any additional notes or comments on the measure not otherwise captured above (text in this field is included in publicly-reported state-specific comments):";
@@ -14,6 +18,7 @@ const isNotReportingTextAreaLabel =
 
 describe("Test AdditionalNotes component for 2024", () => {
   beforeEach(() => {
+    mockGetMeasureYear.mockReturnValue(2024);
     renderWithHookForm(
       <SharedContext.Provider value={commonQuestionsLabels2024}>
         <Reporting

--- a/services/ui-src/src/shared/commonQuestions/NotCollectingOMS.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/NotCollectingOMS.test.tsx
@@ -1,9 +1,14 @@
 import { screen } from "@testing-library/react";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { NotCollectingOMS } from "./NotCollectingOMS";
+import { getMeasureYear } from "utils/getMeasureYear";
+
+jest.mock("utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 describe("NotCollectingOMS component", () => {
   beforeEach(() => {
+    mockGetMeasureYear.mockReturnValue(2024);
     renderWithHookForm(<NotCollectingOMS year="2024" />);
   });
 

--- a/services/ui-src/src/shared/commonQuestions/NotCollectingOMS.tsx
+++ b/services/ui-src/src/shared/commonQuestions/NotCollectingOMS.tsx
@@ -1,5 +1,6 @@
 import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface Props {
   year: string;
@@ -12,7 +13,9 @@ export const NotCollectingOMS = ({ year }: Props) => {
       label="Optional Measure Stratification"
     >
       <CUI.Text>
-        {`CMS is not collecting stratified data for this measure for FFY ${year} Core
+        {`CMS is not collecting stratified data for this measure for ${
+          featuresByYear.displayFFYLanguage ? "FFY" : ""
+        } ${year} Core
         Set Reporting.`}
       </CUI.Text>
     </QMR.CoreQuestionWrapper>

--- a/services/ui-src/src/shared/commonQuestions/Reporting.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/Reporting.test.tsx
@@ -2,9 +2,14 @@ import fireEvent from "@testing-library/user-event";
 import { Reporting } from "./Reporting";
 import { screen } from "@testing-library/react";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
+import { getMeasureYear } from "utils/getMeasureYear";
+
+jest.mock("utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 describe("Test Reporting component", () => {
   beforeEach(() => {
+    mockGetMeasureYear.mockReturnValue(2021);
     renderWithHookForm(
       <Reporting
         measureName="My Test Measure"

--- a/services/ui-src/src/shared/commonQuestions/Reporting.tsx
+++ b/services/ui-src/src/shared/commonQuestions/Reporting.tsx
@@ -4,6 +4,7 @@ import * as Types from "../types";
 import * as DC from "dataConstants";
 import { useFormContext } from "react-hook-form";
 import { WhyAreYouNotReporting } from "shared/commonQuestions/WhyAreYouNotReporting";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface Props {
   measureName: string;
@@ -34,11 +35,15 @@ export const Reporting = ({
           {...register(DC.DID_REPORT)}
           options={[
             {
-              displayValue: `Yes, I am reporting ${measureName} (${measureAbbreviation}) for FFY ${reportingYear} quality measure reporting.`,
+              displayValue: `Yes, I am reporting ${measureName} (${measureAbbreviation}) for ${
+                featuresByYear.displayFFYLanguage ? "FFY" : ""
+              } ${reportingYear} quality measure reporting.`,
               value: DC.YES,
             },
             {
-              displayValue: `No, I am not reporting ${measureName} (${measureAbbreviation}) for FFY ${reportingYear} quality measure reporting.`,
+              displayValue: `No, I am not reporting ${measureName} (${measureAbbreviation}) for ${
+                featuresByYear.displayFFYLanguage ? "FFY" : ""
+              } ${reportingYear} quality measure reporting.`,
               value: DC.NO,
             },
           ]}

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -100,4 +100,12 @@ export const featuresByYear = {
   get hasStreamlinedOms() {
     return getMeasureYear() >= 2023;
   },
+  /**
+   * Prior to 2025, we display FFY before the year name.
+   *
+   * In 2025 and beyond, we will not display the FFY language in front of the year.
+   */
+  get displayFFYLanguage() {
+    return getMeasureYear() < 2025;
+  },
 };

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -101,9 +101,10 @@ export const featuresByYear = {
     return getMeasureYear() >= 2023;
   },
   /**
-   * Prior to 2025, we display FFY before the year name.
+   * Prior to 2025, we displayed FFY before the year name. This was done in part
+   * to differentiate Federal Fiscal Year and HEDIS Medical Year.
    *
-   * In 2025 and beyond, we will not display the FFY language in front of the year.
+   * In 2025, stakeholders decided this explicit differentiation was unneeded.
    */
   get displayFFYLanguage() {
     return getMeasureYear() < 2025;

--- a/services/ui-src/src/views/AddAdultCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddAdultCoreSet/index.tsx
@@ -7,6 +7,7 @@ import * as Api from "hooks/api";
 import { useQueryClient } from "react-query";
 import { AnyObject, CoreSetAbbr, UserRoles } from "types";
 import { useUser } from "hooks/authHooks";
+import { featuresByYear } from "utils/featuresByYear";
 
 enum ReportType {
   SEPARATE = "separate",
@@ -72,7 +73,10 @@ export const AddAdultCoreSet = () => {
   return (
     <QMR.StateLayout
       breadcrumbItems={[
-        { path: `/${state}/${year}`, name: `FFY ${year}` },
+        {
+          path: `/${state}/${year}`,
+          name: `${featuresByYear.displayFFYLanguage ? "FFY" : ""} ${year}`,
+        },
         { path: `/${state}/${year}/add-adult`, name: "Add Adult Core Set" },
       ]}
     >

--- a/services/ui-src/src/views/AddChildCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddChildCoreSet/index.tsx
@@ -7,6 +7,7 @@ import * as Api from "hooks/api";
 import { useQueryClient } from "react-query";
 import { AnyObject, CoreSetAbbr, UserRoles } from "types";
 import { useUser } from "hooks/authHooks";
+import { featuresByYear } from "utils/featuresByYear";
 
 enum ReportType {
   SEPARATE = "separate",
@@ -72,7 +73,10 @@ export const AddChildCoreSet = () => {
   return (
     <QMR.StateLayout
       breadcrumbItems={[
-        { path: `/${state}/${year}`, name: `FFY ${year}` },
+        {
+          path: `/${state}/${year}`,
+          name: `${featuresByYear.displayFFYLanguage ? "FFY" : ""} ${year}`,
+        },
         { path: `/${state}/${year}/add-child`, name: "Add Child Core Set" },
       ]}
     >

--- a/services/ui-src/src/views/AddHHCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddHHCoreSet/index.tsx
@@ -8,6 +8,7 @@ import { useCustomRegister } from "hooks/useCustomRegister";
 import { useQueryClient } from "react-query";
 import { useUser } from "hooks/authHooks";
 import { CoreSetAbbr, UserRoles } from "types";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface HealthHome {
   "HealthHomeCoreSet-SPA": string;
@@ -81,7 +82,10 @@ export const AddHHCoreSet = () => {
   return (
     <QMR.StateLayout
       breadcrumbItems={[
-        { path: `/${state}/${year}`, name: `FFY ${year}` },
+        {
+          path: `/${state}/${year}`,
+          name: `${featuresByYear.displayFFYLanguage ? "FFY" : ""} ${year}`,
+        },
         { path: `/${state}/${year}/add-hh`, name: "Add Health Home Core Set" },
       ]}
     >

--- a/services/ui-src/src/views/AddStateSpecificMeasure/index.tsx
+++ b/services/ui-src/src/views/AddStateSpecificMeasure/index.tsx
@@ -6,6 +6,7 @@ import { CoreSetTableItem } from "components/Table/types";
 import { FormProvider, useForm } from "react-hook-form";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useUser } from "hooks/authHooks";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface NewMeasure {
   description: string;
@@ -128,7 +129,10 @@ export const AddStateSpecificMeasure = () => {
   return (
     <QMR.StateLayout
       breadcrumbItems={[
-        { path: `/${state}/${year}/${coreSetId}`, name: `FFY ${year}` },
+        {
+          path: `/${state}/${year}/${coreSetId}`,
+          name: `${featuresByYear.displayFFYLanguage ? "FFY" : ""} ${year}`,
+        },
         {
           path: `/${state}/${year}/${coreSetId}/add-ssm`,
           name: "Add State Specific Measures",

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -6,6 +6,7 @@ import { LoadingWrapper } from "components";
 import { DataSourceInformationBanner } from "shared/commonQuestions/DataSouceInformationBanner/DataSourceInformationBanner";
 import { CombinedRateNDR } from "shared/commonQuestions/CombinedRateNDR/CombinedRateNDR";
 import { AdditionalCombinedValues } from "shared/commonQuestions/AdditionalCombinedValues/AdditionalCombinedValues";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface Props {
   year: string;
@@ -54,7 +55,7 @@ export const CombinedRatesMeasure = ({
       breadcrumbItems={[
         {
           path: getPathToCombinedRatesTab(state!, year, combinedCoreSetAbbr),
-          name: `FFY ${year}`,
+          name: `${featuresByYear.displayFFYLanguage ? "FFY" : ""} ${year}`,
         },
         {
           path: `/${state}/${year}`,

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -8,6 +8,7 @@ import { Link, useParams, useSearchParams } from "react-router-dom";
 import { MeasureTableItem } from "components/Table/types";
 import { useFlags } from "launchdarkly-react-client-sdk";
 import { statesWithoutCombinedRates } from "utils";
+import { featuresByYear } from "utils/featuresByYear";
 
 const measuresWithoutPerformanceData = ["CSQ", "CPC-CH", "CPA-AD", "MSC-AD"];
 
@@ -114,7 +115,10 @@ export const CombinedRatesPage = () => {
   return (
     <QMR.StateLayout
       breadcrumbItems={[
-        { path: `/${state}/${year}`, name: `FFY ${year}` },
+        {
+          path: `/${state}/${year}`,
+          name: `${featuresByYear.displayFFYLanguage ? "FFY" : ""} ${year}`,
+        },
         {
           path: `/${state}/${year}`,
           name: "Combined Rates",

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -324,7 +324,10 @@ export const CoreSet = () => {
   return (
     <QMR.StateLayout
       breadcrumbItems={[
-        { path: `/${state}/${year}`, name: `FFY ${year}` },
+        {
+          path: `/${state}/${year}`,
+          name: `${featuresByYear.displayFFYLanguage ? "FFY" : ""} ${year}`,
+        },
         {
           path: `/${state}/${year}/${coreSetId}`,
           name: coreSetTitles(coreSet[0]) + spaName,

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -135,7 +135,9 @@ const Heading = () => {
     <CUI.Box display={{ base: "block", md: "flex" }}>
       <CUI.Box maxW="3xl" pb="6" pr={{ md: "4rem" }}>
         <CUI.Heading size="lg" data-cy="reporting-year-heading">
-          {`FFY ${year} Core Set Measures Reporting`}
+          {`${
+            featuresByYear.displayFFYLanguage ? "FFY" : ""
+          } ${year} Core Set Measures Reporting`}
         </CUI.Heading>
         <CUI.Text fontWeight="bold" pt="6">
           Complete each group of Core Set Measures below. Once a group is


### PR DESCRIPTION
### Description
Created one of those featureByYear flag things that will not display "FFY" string when the year is 2025 or beyond. 

### Related ticket(s)
CMDCT-4034

---
### How to test
https://djh52euni05mh.cloudfront.net/
1. Go around 2025 and make sure there is no mention of `FFY 2025` (you will see some instances of `FFY 2024` and that is ok and expected)
2. Make sure all other years do have FFY displayed
