### PR TITLE
CMDCT-4084: removing covid language from 2025

### DIFF
--- a/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2023/commonQuestionsLabel.tsx
@@ -133,7 +133,6 @@ export const commonQuestionsLabel = {
     phe: "CMS recognizes that social distancing will make onsite medical chart reviews inadvisable during the COVID-19 pandemic. As such, hybrid measures that rely on such techniques will be particularly challenging during this time. While reporting of the Core Sets is voluntary, CMS encourages states that can collect information safely to continue reporting the measures they have reported in the past.",
   },
   WhyAreYouNotReporting: {
-    periodOfHealthEmergencyFlag: true,
     limitWithDataCollection:
       "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic",
     limitWithDataCollectionDesc:

--- a/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2024/commonQuestionsLabel.tsx
@@ -112,7 +112,6 @@ export const commonQuestionsLabel = {
     phe: "CMS recognizes that social distancing will make onsite medical chart reviews inadvisable during the COVID-19 pandemic. As such, hybrid measures that rely on such techniques will be particularly challenging during this time. CMS encourages states that can collect information safely to continue reporting the measures they have reported in the past.",
   },
   WhyAreYouNotReporting: {
-    periodOfHealthEmergencyFlag: true,
     limitWithDataCollection:
       "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic",
     limitWithDataCollectionDesc:

--- a/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
@@ -111,13 +111,6 @@ export const commonQuestionsLabel = {
   PerformanceMeasure: {
     phe: "CMS recognizes that social distancing will make onsite medical chart reviews inadvisable during the COVID-19 pandemic. As such, hybrid measures that rely on such techniques will be particularly challenging during this time. CMS encourages states that can collect information safely to continue reporting the measures they have reported in the past.",
   },
-  WhyAreYouNotReporting: {
-    periodOfHealthEmergencyFlag: true,
-    limitWithDataCollection:
-      "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic",
-    limitWithDataCollectionDesc:
-      "Describe your state's limitations with regard to collection, reporting, or accuracy of data for this measure:",
-  },
 };
 
 export default commonQuestionsLabel;

--- a/services/ui-src/src/measures/2021/SSHH/index.test.tsx
+++ b/services/ui-src/src/measures/2021/SSHH/index.test.tsx
@@ -9,12 +9,9 @@ import { Suspense } from "react";
 import { MeasuresLoading } from "views";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { axe, toHaveNoViolations } from "jest-axe";
-import { mockLDFlags } from "../../../../setupJest";
 import { clearMocks } from "shared/util/validationsMock";
 
 expect.extend(toHaveNoViolations);
-
-mockLDFlags.setDefault({ periodOfHealthEmergency2021: false });
 
 // Test Setup
 const measureAbbr = "SS-1-HH";

--- a/services/ui-src/src/measures/2022/SSHH/index.test.tsx
+++ b/services/ui-src/src/measures/2022/SSHH/index.test.tsx
@@ -9,12 +9,9 @@ import { Suspense } from "react";
 import { MeasuresLoading } from "views";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { axe, toHaveNoViolations } from "jest-axe";
-import { mockLDFlags } from "../../../../setupJest";
 import { clearMocks } from "shared/util/validationsMock";
 
 expect.extend(toHaveNoViolations);
-
-mockLDFlags.setDefault({ periodOfHealthEmergency2022: false });
 
 // Test Setup
 const measureAbbr = "SS-1-HH";

--- a/services/ui-src/src/measures/2023/CPAAD/questions/WhyDidYouNotCollect.tsx
+++ b/services/ui-src/src/measures/2023/CPAAD/questions/WhyDidYouNotCollect.tsx
@@ -1,10 +1,8 @@
 import * as QMR from "components";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { FormData } from "../types";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 export const WhyDidYouNotCollect = () => {
-  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2023"];
   const register = useCustomRegister<FormData>();
   return (
     <QMR.CoreQuestionWrapper
@@ -147,23 +145,17 @@ export const WhyDidYouNotCollect = () => {
               />,
             ],
           },
-          ...(pheIsCurrent
-            ? [
-                {
-                  displayValue:
-                    "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic",
-                  value: "LimitationWithDatCollecitonReportAccuracyCovid",
-                  children: [
-                    <QMR.TextArea
-                      label="Describe your state's limitations with regard to collection, reporting, or accuracy of data for this measure:"
-                      {...register(
-                        "LimitationWithDatCollecitonReportAccuracyCovid"
-                      )}
-                    />,
-                  ],
-                },
-              ]
-            : []),
+          {
+            displayValue:
+              "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic",
+            value: "LimitationWithDatCollecitonReportAccuracyCovid",
+            children: [
+              <QMR.TextArea
+                label="Describe your state's limitations with regard to collection, reporting, or accuracy of data for this measure:"
+                {...register("LimitationWithDatCollecitonReportAccuracyCovid")}
+              />,
+            ],
+          },
           {
             displayValue: "Small sample size (less than 30)",
             value: "SmallSampleSizeLessThan30",

--- a/services/ui-src/src/measures/2023/SSHH/index.test.tsx
+++ b/services/ui-src/src/measures/2023/SSHH/index.test.tsx
@@ -9,12 +9,9 @@ import { Suspense } from "react";
 import { MeasuresLoading } from "views";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { axe, toHaveNoViolations } from "jest-axe";
-import { mockLDFlags } from "../../../../setupJest";
 import { clearMocks } from "shared/util/validationsMock";
 
 expect.extend(toHaveNoViolations);
-
-mockLDFlags.setDefault({ periodOfHealthEmergency2023: false });
 
 // Test Setup
 const measureAbbr = "SS-1-HH";
@@ -103,19 +100,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(screen.queryByText("Performance Measure")).toBeInTheDocument();
   });
 
-  it("does not show covid text if periodOfHealthEmergency2023 flag is disabled", async () => {
-    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
-    useApiMock(apiData);
-    renderWithHookForm(component);
-    expect(
-      screen.queryByText(
-        "Describe any COVID-related difficulties encountered while collecting this data:"
-      )
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows covid text if periodOfHealthEmergency2023 flag is enabled", async () => {
-    mockLDFlags.setDefault({ periodOfHealthEmergency2023: true });
+  it("Always shows covid text for 2023", async () => {
     apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
     useApiMock(apiData);
     renderWithHookForm(component);

--- a/services/ui-src/src/measures/2023/SSHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2023/SSHH/questions/PerformanceMeasure.tsx
@@ -5,7 +5,6 @@ import * as DC from "dataConstants";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "shared/types";
 import { useEffect } from "react";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 interface Props {
   hybridMeasure?: boolean;
@@ -30,8 +29,6 @@ export const PerformanceMeasure = ({
   rateAlwaysEditable,
 }: Props) => {
   const { control, reset } = useFormContext();
-
-  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2023"];
 
   const { fields, remove, append } = useFieldArray({
     name: DC.OPM_RATES,
@@ -76,7 +73,7 @@ export const PerformanceMeasure = ({
         formLabelProps={{ fontWeight: 700 }}
         {...register(DC.OPM_EXPLAINATION)}
       />
-      {hybridMeasure && pheIsCurrent && (
+      {hybridMeasure && (
         <CUI.Box my="5">
           <CUI.Text>
             CMS recognizes that social distancing will make onsite medical chart

--- a/services/ui-src/src/measures/2024/CPAAD/questions/WhyDidYouNotCollect.tsx
+++ b/services/ui-src/src/measures/2024/CPAAD/questions/WhyDidYouNotCollect.tsx
@@ -1,10 +1,8 @@
 import * as QMR from "components";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { FormData } from "../types";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 export const WhyDidYouNotCollect = () => {
-  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2023"];
   const register = useCustomRegister<FormData>();
   return (
     <QMR.CoreQuestionWrapper
@@ -147,23 +145,17 @@ export const WhyDidYouNotCollect = () => {
               />,
             ],
           },
-          ...(pheIsCurrent
-            ? [
-                {
-                  displayValue:
-                    "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic",
-                  value: "LimitationWithDatCollecitonReportAccuracyCovid",
-                  children: [
-                    <QMR.TextArea
-                      label="Describe your state's limitations with regard to collection, reporting, or accuracy of data for this measure:"
-                      {...register(
-                        "LimitationWithDatCollecitonReportAccuracyCovid"
-                      )}
-                    />,
-                  ],
-                },
-              ]
-            : []),
+          {
+            displayValue:
+              "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic",
+            value: "LimitationWithDatCollecitonReportAccuracyCovid",
+            children: [
+              <QMR.TextArea
+                label="Describe your state's limitations with regard to collection, reporting, or accuracy of data for this measure:"
+                {...register("LimitationWithDatCollecitonReportAccuracyCovid")}
+              />,
+            ],
+          },
           {
             displayValue: "Small sample size (less than 30)",
             value: "SmallSampleSizeLessThan30",

--- a/services/ui-src/src/measures/2024/SSHH/index.test.tsx
+++ b/services/ui-src/src/measures/2024/SSHH/index.test.tsx
@@ -9,12 +9,9 @@ import { Suspense } from "react";
 import { MeasuresLoading } from "views";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { axe, toHaveNoViolations } from "jest-axe";
-import { mockLDFlags } from "../../../../setupJest";
 import { clearMocks } from "shared/util/validationsMock";
 
 expect.extend(toHaveNoViolations);
-
-mockLDFlags.setDefault({ periodOfHealthEmergency2024: false });
 
 // Test Setup
 const measureAbbr = "SS-1-HH";
@@ -111,19 +108,7 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
     expect(screen.queryByText("Performance Measure")).toBeInTheDocument();
   });
 
-  it("does not show covid text if periodOfHealthEmergency2024 flag is disabled", async () => {
-    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
-    useApiMock(apiData);
-    renderWithHookForm(component);
-    expect(
-      screen.queryByText(
-        "Describe any COVID-related difficulties encountered while collecting this data:"
-      )
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows covid text if periodOfHealthEmergency2024 flag is enabled", async () => {
-    mockLDFlags.setDefault({ periodOfHealthEmergency2024: true });
+  it("Always shows covid text for 2024", async () => {
     apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
     useApiMock(apiData);
     renderWithHookForm(component);

--- a/services/ui-src/src/measures/2024/SSHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2024/SSHH/questions/PerformanceMeasure.tsx
@@ -5,7 +5,6 @@ import * as DC from "dataConstants";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "shared/types";
 import { useEffect } from "react";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 interface Props {
   hybridMeasure?: boolean;
@@ -30,8 +29,6 @@ export const PerformanceMeasure = ({
   rateAlwaysEditable,
 }: Props) => {
   const { control, reset } = useFormContext();
-
-  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2024"];
 
   const { fields, remove, append } = useFieldArray({
     name: DC.OPM_RATES,
@@ -76,7 +73,7 @@ export const PerformanceMeasure = ({
         formLabelProps={{ fontWeight: 700 }}
         {...register(DC.OPM_EXPLAINATION)}
       />
-      {hybridMeasure && pheIsCurrent && (
+      {hybridMeasure && (
         <CUI.Box my="5">
           <CUI.Text>
             CMS recognizes that social distancing will make onsite medical chart

--- a/services/ui-src/src/measures/2025/CPAAD/questions/WhyDidYouNotCollect.tsx
+++ b/services/ui-src/src/measures/2025/CPAAD/questions/WhyDidYouNotCollect.tsx
@@ -1,10 +1,8 @@
 import * as QMR from "components";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { FormData } from "../types";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 export const WhyDidYouNotCollect = () => {
-  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2023"];
   const register = useCustomRegister<FormData>();
   return (
     <QMR.CoreQuestionWrapper
@@ -147,23 +145,6 @@ export const WhyDidYouNotCollect = () => {
               />,
             ],
           },
-          ...(pheIsCurrent
-            ? [
-                {
-                  displayValue:
-                    "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic",
-                  value: "LimitationWithDatCollecitonReportAccuracyCovid",
-                  children: [
-                    <QMR.TextArea
-                      label="Describe your state's limitations with regard to collection, reporting, or accuracy of data for this measure:"
-                      {...register(
-                        "LimitationWithDatCollecitonReportAccuracyCovid"
-                      )}
-                    />,
-                  ],
-                },
-              ]
-            : []),
           {
             displayValue: "Small sample size (less than 30)",
             value: "SmallSampleSizeLessThan30",

--- a/services/ui-src/src/measures/2025/CPCCH/questions/WhyDidYouNotCollect.tsx
+++ b/services/ui-src/src/measures/2025/CPCCH/questions/WhyDidYouNotCollect.tsx
@@ -146,17 +146,6 @@ export const WhyDidYouNotCollect = () => {
             ],
           },
           {
-            displayValue:
-              "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic",
-            value: "LimitationWithDatCollecitonReportAccuracyCovid",
-            children: [
-              <QMR.TextArea
-                label="Describe your state's limitations with regard to collection, reporting, or accuracy of data for this measure:"
-                {...register("LimitationWithDatCollecitonReportAccuracyCovid")}
-              />,
-            ],
-          },
-          {
             displayValue: "Small sample size (less than 30)",
             value: "SmallSampleSizeLessThan30",
             children: [

--- a/services/ui-src/src/measures/2025/SSHH/index.test.tsx
+++ b/services/ui-src/src/measures/2025/SSHH/index.test.tsx
@@ -9,12 +9,9 @@ import { Suspense } from "react";
 import { MeasuresLoading } from "views";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { axe, toHaveNoViolations } from "jest-axe";
-import { mockLDFlags } from "../../../../setupJest";
 import { clearMocks } from "shared/util/validationsMock";
 
 expect.extend(toHaveNoViolations);
-
-mockLDFlags.setDefault({ periodOfHealthEmergency2025: false });
 
 // Test Setup
 const measureAbbr = "SS-1-HH";
@@ -109,29 +106,6 @@ describe(`Test FFY ${year} ${measureAbbr}`, () => {
       screen.queryByText("Definition of Population Included in the Measure")
     ).toBeInTheDocument();
     expect(screen.queryByText("Performance Measure")).toBeInTheDocument();
-  });
-
-  it("does not show covid text if periodOfHealthEmergency2025 flag is disabled", async () => {
-    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
-    useApiMock(apiData);
-    renderWithHookForm(component);
-    expect(
-      screen.queryByText(
-        "Describe any COVID-related difficulties encountered while collecting this data:"
-      )
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows covid text if periodOfHealthEmergency2025 flag is enabled", async () => {
-    mockLDFlags.setDefault({ periodOfHealthEmergency2025: true });
-    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
-    useApiMock(apiData);
-    renderWithHookForm(component);
-    expect(
-      screen.queryByText(
-        "Describe any COVID-related difficulties encountered while collecting this data:"
-      )
-    ).toBeInTheDocument();
   });
 });
 

--- a/services/ui-src/src/measures/2025/SSHH/index.tsx
+++ b/services/ui-src/src/measures/2025/SSHH/index.tsx
@@ -30,7 +30,7 @@ export const SSHH = ({
       <CMQ.DataSource data={PMD.dataSourceData} />
       <CMQ.DateRange type="health" />
       <CMQ.DefinitionOfPopulation healthHomeMeasure hybridMeasure />
-      <PerformanceMeasure hybridMeasure />
+      <PerformanceMeasure />
       <CMQ.AdditionalNotes />
     </>
   );

--- a/services/ui-src/src/measures/2025/SSHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2025/SSHH/questions/PerformanceMeasure.tsx
@@ -5,7 +5,6 @@ import * as DC from "dataConstants";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "shared/types";
 import { useEffect } from "react";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 interface Props {
   hybridMeasure?: boolean;
@@ -25,13 +24,8 @@ const arrayIsReadOnly = (dataSource: string[]) => {
   );
 };
 
-export const PerformanceMeasure = ({
-  hybridMeasure,
-  rateAlwaysEditable,
-}: Props) => {
+export const PerformanceMeasure = ({ rateAlwaysEditable }: Props) => {
   const { control, reset } = useFormContext();
-
-  const pheIsCurrent = useFlags()?.["periodOfHealthEmergency2025"];
 
   const { fields, remove, append } = useFieldArray({
     name: DC.OPM_RATES,
@@ -76,24 +70,6 @@ export const PerformanceMeasure = ({
         formLabelProps={{ fontWeight: 700 }}
         {...register(DC.OPM_EXPLAINATION)}
       />
-      {hybridMeasure && pheIsCurrent && (
-        <CUI.Box my="5">
-          <CUI.Text>
-            CMS recognizes that social distancing will make onsite medical chart
-            reviews inadvisable during the COVID-19 pandemic. As such, hybrid
-            measures that rely on such techniques will be particularly
-            challenging during this time. While reporting of the Core Sets is
-            voluntary, CMS encourages states that can collect information safely
-            to continue reporting the measures they have reported in the past.
-          </CUI.Text>
-          <QMR.TextArea
-            formLabelProps={{ mt: 5 }}
-            {...register(DC.OPM_HYBRID_EXPLANATION)}
-            label="Describe any COVID-related difficulties encountered while collecting this data:"
-          />
-        </CUI.Box>
-      )}
-
       <CUI.Box marginTop={10}>
         {fields.map((_item, index) => {
           return (

--- a/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.test.tsx
@@ -9,10 +9,13 @@ import { PerformanceMeasure } from ".";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { screen } from "@testing-library/react";
 import { PCRRate } from "components";
-import { mockLDFlags } from "../../../../setupJest";
 import { LabelData } from "utils";
 import SharedContext from "shared/SharedContext";
 import commonQuestionsLabel2025 from "labels/2025/commonQuestionsLabel";
+import { getMeasureYear } from "utils/getMeasureYear";
+
+jest.mock("utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 jest.mock("hooks/api/usePathParams", () => ({
   ...jest.requireActual("hooks/api/usePathParams"),
@@ -31,8 +34,6 @@ interface Props {
   rateReadOnly: undefined | boolean;
   hybridMeasure: undefined | boolean;
 }
-
-mockLDFlags.setDefault({ periodOfHealthEmergency2025: false });
 
 const renderComponent = ({
   component,
@@ -159,7 +160,8 @@ describe("Test the PerformanceMeasure RateComponent prop", () => {
     expect(rateTextBox).toHaveDisplayValue("123");
   });
 
-  test("periodOfHealthEmergency2025 flag is set to false, covid text and textbox should not render", () => {
+  test("In 2025, covid text and textbox should not render", () => {
+    mockGetMeasureYear.mockReturnValue(2025);
     props.data = CBPdata;
     props.hybridMeasure = true;
     renderComponent(props);
@@ -169,8 +171,8 @@ describe("Test the PerformanceMeasure RateComponent prop", () => {
     expect(covidText).toBeNull();
   });
 
-  test("periodOfHealthEmergency2025 flag is set to true, covid text and textbox should render", () => {
-    mockLDFlags.set({ periodOfHealthEmergency2025: true });
+  test("In 2024 covid text and textbox should render", () => {
+    mockGetMeasureYear.mockReturnValue(2024);
     props.data = CBPdata;
     props.hybridMeasure = true;
     renderComponent(props);

--- a/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/PerformanceMeasure/index.tsx
@@ -7,8 +7,6 @@ import { PerformanceMeasureData } from "./data";
 import { useWatch } from "react-hook-form";
 import { getLabelText, isLegacyLabel, LabelData } from "utils";
 import { ndrFormula } from "types";
-import { useFlags } from "launchdarkly-react-client-sdk";
-import { usePathParams } from "hooks/api/usePathParams";
 import { useContext } from "react";
 import SharedContext from "shared/SharedContext";
 import { featuresByYear } from "utils/featuresByYear";
@@ -211,11 +209,6 @@ export const PerformanceMeasure = ({
   RateComponent = QMR.Rate, // Default to QMR.Rate
 }: Props) => {
   const register = useCustomRegister<Types.PerformanceMeasure>();
-  const { year } = usePathParams();
-  //for years after 2023, we use a flag to determine showing the covid message
-  const pheIsCurrent =
-    featuresByYear.periodOfHealthEmergency ||
-    useFlags()?.[`periodOfHealthEmergency${year}`];
 
   const dataSourceWatch = useWatch<Types.DataSource>({
     name: DC.DATA_SOURCE,
@@ -303,7 +296,7 @@ export const PerformanceMeasure = ({
           {...register(`${DC.PERFORMANCE_MEASURE}.${DC.EXPLAINATION}`)}
         />
       )}
-      {hybridMeasure && pheIsCurrent && (
+      {hybridMeasure && featuresByYear.displayCovidLanguage && (
         <CUI.Box my="5">
           <CUI.Text>{labels?.PerformanceMeasure?.phe}</CUI.Text>
           <QMR.TextArea

--- a/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.test.tsx
@@ -1,12 +1,13 @@
 import { screen } from "@testing-library/react";
 import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
 import { WhyAreYouNotReporting } from "./WhyAreYouNotReporting";
-import { mockLDFlags } from "../../../setupJest";
 import userEvent from "@testing-library/user-event";
 import SharedContext from "shared/SharedContext";
-import commonQuestionsLabel from "labels/2025/commonQuestionsLabel";
+import commonQuestionsLabel from "labels/2024/commonQuestionsLabel";
+import { getMeasureYear } from "utils/getMeasureYear";
 
-mockLDFlags.setDefault({ periodOfHealthEmergency2025: false });
+jest.mock("utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 describe("WhyAreYouNotReporting component initial appearance", () => {
   beforeEach(() => {
@@ -200,10 +201,13 @@ describe("WhyAreYouNotReporting component, Health Homes", () => {
 });
 
 describe("Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic (PHE active)", () => {
+  beforeEach(() => {
+    mockGetMeasureYear.mockReturnValue(2024);
+  });
+
   it("renders textBox correctly", () => {
-    mockLDFlags.set({ periodOfHealthEmergency2025: true });
     renderWithHookForm(
-      <SharedContext.Provider value={{ ...commonQuestionsLabel, year: "2025" }}>
+      <SharedContext.Provider value={{ ...commonQuestionsLabel, year: "2024" }}>
         <WhyAreYouNotReporting />
       </SharedContext.Provider>
     );

--- a/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.tsx
+++ b/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.tsx
@@ -2,9 +2,9 @@ import * as QMR from "components";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "../types";
 import * as DC from "dataConstants";
-import { useFlags } from "launchdarkly-react-client-sdk";
 import { useContext } from "react";
 import SharedContext from "shared/SharedContext";
+import { featuresByYear } from "utils/featuresByYear";
 
 interface Props {
   healthHomeMeasure?: boolean;
@@ -18,7 +18,6 @@ export const WhyAreYouNotReporting = ({
   //WIP: using form context to get the labels for this component temporarily.
   const labels: any = useContext(SharedContext);
 
-  const pheIsCurrent = useFlags()?.[`periodOfHealthEmergency${labels.year}`];
   const register = useCustomRegister<Types.WhyAreYouNotReporting>();
 
   return (
@@ -171,9 +170,8 @@ export const WhyAreYouNotReporting = ({
               />,
             ],
           },
-          //for years 2023 and over, check the flag to see if the label should be enabled
-          ...(!labels.WhyAreYouNotReporting?.periodOfHealthEmergencyFlag ||
-          pheIsCurrent
+          ...(labels.WhyAreYouNotReporting &&
+          featuresByYear.displayCovidLanguage
             ? [
                 {
                   displayValue:

--- a/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.tsx
+++ b/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.tsx
@@ -170,8 +170,7 @@ export const WhyAreYouNotReporting = ({
               />,
             ],
           },
-          ...(labels.WhyAreYouNotReporting &&
-          featuresByYear.displayCovidLanguage
+          ...(featuresByYear.displayCovidLanguage
             ? [
                 {
                   displayValue:

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -92,7 +92,7 @@ export const featuresByYear = {
   get hasStreamlinedOms() {
     return getMeasureYear() >= 2023;
   },
-  /*
+  /**
    * Prior to 2025, we displayed FFY before the year name. This was done in part
    * to differentiate Federal Fiscal Year and HEDIS Medical Year.
    *

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -37,14 +37,6 @@ export const featuresByYear = {
     return getMeasureYear() >= 2024;
   },
   /**
-   * Prior to 2023, we always displayed a message acknowledging
-   * the difficulty of data collection during the Covid pandemic.
-   * In 2023, we switched to controlling this message with a LaunchDarkly flag
-   */
-  get periodOfHealthEmergency() {
-    return getMeasureYear() < 2023;
-  },
-  /**
    * Prior to 2023, users were always required to fill out the measure dates,
    * even when they matched the Core Set's standard, specified range.
    * In 2023, we wrapped the dates in a "are your dates standard?" radio button,
@@ -99,5 +91,15 @@ export const featuresByYear = {
    */
   get hasStreamlinedOms() {
     return getMeasureYear() >= 2023;
+  },
+  /**
+   * Prior to 2025, we want to display questions that involve referencing
+   * the COVID-19 pandemic.
+   *
+   * In 2025 and beyond, we do not want to display this language.
+   *
+   */
+  get displayCovidLanguage() {
+    return getMeasureYear() < 2025;
   },
 };

--- a/services/ui-src/tsconfig.json
+++ b/services/ui-src/tsconfig.json
@@ -3,7 +3,8 @@
     "incremental": true,
     "target": "ESNext",
     "types": [
-      "vite/client"
+      "vite/client",
+      "@testing-library/jest-dom"
     ],
     "lib": [
       "es6",


### PR DESCRIPTION
### Description
2025 measures shouldn't have any reference to COVID related questions. This is a PR to remove them from 2025.

I also removed all instances of the periodOfEmergency feature flag as per request of the ticket

### Related ticket(s)
CMDCT-4084

---
### How to test
1. Log in as any user
2. Make sure that in the hybrid measures for 2025, there are no COVID related questions (see [ticket](https://jiraent.cms.gov/browse/CMDCT-4084) for list of measures that are hybrid)
3. Make sure there is no "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic" option for why did you not report
4. Make sure for all other years, the same covid questions and options are present



