### PR TITLE
limit branch name to 20 characters

### DIFF
--- a/.github/branchNameValidation.sh
+++ b/.github/branchNameValidation.sh
@@ -3,6 +3,7 @@
 set -e
 
 local_branch=${1}
+[ -z "${1}" ] && local_branch=$(git rev-parse --abbrev-ref HEAD)
 
 valid_branch='^[a-z][a-z0-9-]*$'
 
@@ -15,7 +16,7 @@ join_by() { local IFS='|'; echo "$*"; }
 #creates glob match to check for reserved words used in branch names which would trigger failures
 glob=$(join_by $(for i in ${reserved_words[@]}; do echo "^$i-|-$i$|-$i-|^$i$"; done;))
 
-if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ ${#local_branch} -gt 64 ]]; then
+if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ ${#local_branch} -gt 20 ]]; then
     echo """
      ------------------------------------------------------------------------------------------------------------------------------
      ERROR:  Please read below
@@ -28,7 +29,7 @@ if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ 
     Therefore, the branch name must be a valid service name. Branch name must be all lower case with no spaces and no underscores.
 
     From Serverless:
-        A service name should only contain alphanumeric (case sensitive) and hyphens. It should start with an alphabetic character and shouldnt exceed 128 characters.
+        A service name should only contain alphanumeric (case sensitive) and hyphens. It should start with an alphabetic character and shouldnt exceed 20 characters.
         For Github Actions support, please push your code to a new branch with a name that meets Serverless' service name requirements.
         So, make a new branch with a name that begins with a letter and is made up of only letters, numbers, and hyphens... then delete this branch.
         ------------------------------------------------------------------------------------------------------------------------------

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,13 @@ permissions:
   pull-requests: write
 
 jobs:
+prchecks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure pre-commit to skip branch name validation
+        run: |
+          echo "SKIP=branch-name-validation" >> $GITHUB_ENV
   assignAuthor:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,10 @@ repos:
     rev: v8.12.0
     hooks:
       - id: gitleaks
+  - repo: local
+    hooks:
+      - id: branch-name-validation
+        name: branch-name-validation
+        entry: .github/branchNameValidation.sh
+        language: script
+        pass_filenames: false


### PR DESCRIPTION
### Description
Serverless automates naming of resources based on the branch name, and long names can often overrun the automatically generated limit. We've shortened this limit before, but we're still seeing errors pop up. Shorten the length limit to 20 for all repos.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3700

---
### How to test
checkout this branch, create a new branch that is longer than 20 characters, and make a change on your branch (e.g. change the text on a button)
run pre-commit run and you should see the error message Bad branch name detected in your terminal. A branch name under 20 characters that starts with a letter should pass this pre-commit check.



### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
