### PR TITLE
CMDCT-3979: adding underline to link so that accessibility warning goes away

### DIFF
--- a/services/ui-src/src/components/SupportInfo/index.tsx
+++ b/services/ui-src/src/components/SupportInfo/index.tsx
@@ -41,6 +41,7 @@ export const SupportInfo = () => (
       <CUI.Link
         href="https://www.medicaid.gov/sites/default/files/2023-12/sho23005_1.pdf"
         target={"_blank"}
+        textDecoration={"underline"}
         color="blue.600"
         aria-label="Initial Core Set Mandatory Reporting Guidance SHO"
       >
@@ -51,6 +52,7 @@ export const SupportInfo = () => (
       <CUI.Link
         href="https://www.medicaid.gov/sites/default/files/2024-03/smd24002.pdf"
         target={"_blank"}
+        textDecoration={"underline"}
         color="blue.600"
         aria-label="SMD 24-002: Initial Core Set Mandatory Reporting Guidance for the Health Home Core Quality Measure Sets and Federal Fiscal Year 2025 Updates to the Health Home Core Quality Measure Sets"
       >


### PR DESCRIPTION
### Description
There were only two links i could find using the axe DevTools extension that were problematic. I added underlines and now I am not getting accessibility warnings. 

The rest of the links referenced in [this](https://docs.google.com/document/d/1YeCDzSYFkoudim5f3YyjsDidkPsP_xicr6H6nU50sqg/edit?tab=t.0) accessibility write-up do not give me errors so not exactly sure what is expected there.


### Related ticket(s)
CMDCT-3979

---
### How to test
1. Install the axe DevTools chrome extension
2. Click around all the pages in all years and do a "Full Page Scan" on each page
3. Make sure on each page, there are no errors involving colors/contrasts of links