### PR TITLE
Change Prop Values to CoreSet

### DIFF
--- a/services/ui-src/src/measures/2021/ADDCH/index.tsx
+++ b/services/ui-src/src/measures/2021/ADDCH/index.tsx
@@ -43,7 +43,7 @@ export const ADDCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -59,7 +59,7 @@ export const ADDCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2021/AIFHH/index.tsx
@@ -36,7 +36,7 @@ export const AIFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2021/AIFHH/index.tsx
@@ -45,7 +45,7 @@ export const AIFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -65,7 +65,7 @@ export const AIFHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -74,7 +74,7 @@ export const AIFHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               AIFHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2021/AMBCH/index.tsx
+++ b/services/ui-src/src/measures/2021/AMBCH/index.tsx
@@ -45,7 +45,7 @@ export const AMBCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -70,7 +70,7 @@ export const AMBCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               customMask={mask}

--- a/services/ui-src/src/measures/2021/AMBHH/index.tsx
+++ b/services/ui-src/src/measures/2021/AMBHH/index.tsx
@@ -35,7 +35,7 @@ export const AMBHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/AMBHH/index.tsx
+++ b/services/ui-src/src/measures/2021/AMBHH/index.tsx
@@ -44,7 +44,7 @@ export const AMBHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -67,7 +67,7 @@ export const AMBHH = ({
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -75,7 +75,7 @@ export const AMBHH = ({
               rateMultiplicationValue={1000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
               allowNumeratorGreaterThanDenominator
             />

--- a/services/ui-src/src/measures/2021/AMMAD/index.tsx
+++ b/services/ui-src/src/measures/2021/AMMAD/index.tsx
@@ -60,7 +60,7 @@ export const AMMAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/AMRAD/index.tsx
+++ b/services/ui-src/src/measures/2021/AMRAD/index.tsx
@@ -108,7 +108,7 @@ export const AMRAD = ({
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal={true}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/AMRCH/index.tsx
+++ b/services/ui-src/src/measures/2021/AMRCH/index.tsx
@@ -43,7 +43,7 @@ export const AMRCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -59,7 +59,7 @@ export const AMRCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2021/APMCH/index.tsx
+++ b/services/ui-src/src/measures/2021/APMCH/index.tsx
@@ -43,7 +43,7 @@ export const APMCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -59,7 +59,7 @@ export const APMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2021/APPCH/index.tsx
+++ b/services/ui-src/src/measures/2021/APPCH/index.tsx
@@ -43,7 +43,7 @@ export const APPCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -59,7 +59,7 @@ export const APPCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2021/AUDCH/index.tsx
+++ b/services/ui-src/src/measures/2021/AUDCH/index.tsx
@@ -43,7 +43,7 @@ export const AUDCH = ({
           <CMQ.MeasurementSpecification type="CDC" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2021/AUDCH/index.tsx
+++ b/services/ui-src/src/measures/2021/AUDCH/index.tsx
@@ -59,7 +59,7 @@ export const AUDCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/BCSAD/index.tsx
+++ b/services/ui-src/src/measures/2021/BCSAD/index.tsx
@@ -59,8 +59,8 @@ export const BCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CBPAD/index.tsx
+++ b/services/ui-src/src/measures/2021/CBPAD/index.tsx
@@ -59,7 +59,7 @@ export const CBPAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2021/CBPHH/index.tsx
@@ -44,7 +44,7 @@ export const CBPHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation hybridMeasure healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure calcTotal />

--- a/services/ui-src/src/measures/2021/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2021/CBPHH/index.tsx
@@ -55,13 +55,13 @@ export const CBPHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2021/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2021/CBPHH/index.tsx
@@ -35,7 +35,7 @@ export const CBPHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/CCPAD/index.tsx
+++ b/services/ui-src/src/measures/2021/CCPAD/index.tsx
@@ -59,8 +59,8 @@ export const CCPAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CCPCH/index.tsx
+++ b/services/ui-src/src/measures/2021/CCPCH/index.tsx
@@ -44,7 +44,7 @@ export const CCPCH = ({
           <CMQ.MeasurementSpecification type="OPA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -57,9 +57,9 @@ export const CCPCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               categories={PMD.categories}
-              isSingleSex={true}
+              excludeOptions={["Sex"]}
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
             />

--- a/services/ui-src/src/measures/2021/CCSAD/index.tsx
+++ b/services/ui-src/src/measures/2021/CCSAD/index.tsx
@@ -59,8 +59,8 @@ export const CCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CCWAD/index.tsx
+++ b/services/ui-src/src/measures/2021/CCWAD/index.tsx
@@ -59,8 +59,8 @@ export const CCWAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CCWCH/index.tsx
+++ b/services/ui-src/src/measures/2021/CCWCH/index.tsx
@@ -43,7 +43,7 @@ export const CCWCH = ({
           <CMQ.MeasurementSpecification type="OPA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -59,8 +59,8 @@ export const CCWCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CDFAD/index.tsx
+++ b/services/ui-src/src/measures/2021/CDFAD/index.tsx
@@ -59,7 +59,7 @@ export const CDFAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2021/CDFCH/index.tsx
@@ -59,7 +59,7 @@ export const CDFCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2021/CDFCH/index.tsx
@@ -43,7 +43,7 @@ export const CDFCH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2021/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2021/CDFHH/index.tsx
@@ -34,7 +34,7 @@ export const CDFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2021/CDFHH/index.tsx
@@ -43,7 +43,7 @@ export const CDFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -60,14 +60,14 @@ export const CDFHH = ({
           {isOtherMeasureSpecSelected && (
             <CMQ.OtherPerformanceMeasure rateMultiplicationValue={100} />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               rateMultiplicationValue={100}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2021/CHLAD/index.tsx
+++ b/services/ui-src/src/measures/2021/CHLAD/index.tsx
@@ -59,8 +59,8 @@ export const CHLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2021/CHLCH/index.tsx
@@ -43,7 +43,7 @@ export const CHLCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2021/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2021/CHLCH/index.tsx
@@ -59,8 +59,8 @@ export const CHLCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2021/CISCH/index.tsx
@@ -59,7 +59,7 @@ export const CISCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2021/CISCH/index.tsx
@@ -43,7 +43,7 @@ export const CISCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2021/COBAD/index.tsx
+++ b/services/ui-src/src/measures/2021/COBAD/index.tsx
@@ -59,7 +59,7 @@ export const COBAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2021/DEVCH/index.tsx
@@ -43,7 +43,7 @@ export const DEVCH = ({
           <CMQ.MeasurementSpecification type="OHSU" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2021/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2021/DEVCH/index.tsx
@@ -60,7 +60,7 @@ export const DEVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2021/FUAAD/index.tsx
+++ b/services/ui-src/src/measures/2021/FUAAD/index.tsx
@@ -60,7 +60,7 @@ export const FUAAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2021/FUAHH/index.tsx
@@ -35,7 +35,7 @@ export const FUAHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2021/FUAHH/index.tsx
@@ -44,7 +44,7 @@ export const FUAHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -54,13 +54,13 @@ export const FUAHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2021/FUHAD/index.tsx
+++ b/services/ui-src/src/measures/2021/FUHAD/index.tsx
@@ -59,7 +59,7 @@ export const FUHAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={true}
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2021/FUHCH/index.tsx
@@ -43,7 +43,7 @@ export const FUHCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2021/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2021/FUHCH/index.tsx
@@ -59,7 +59,7 @@ export const FUHCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2021/FUHHH/index.tsx
@@ -35,7 +35,7 @@ export const FUHHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2021/FUHHH/index.tsx
@@ -44,7 +44,7 @@ export const FUHHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -55,13 +55,13 @@ export const FUHHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2021/FUMAD/index.tsx
+++ b/services/ui-src/src/measures/2021/FUMAD/index.tsx
@@ -58,7 +58,7 @@ export const FUMAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/FVAAD/index.tsx
+++ b/services/ui-src/src/measures/2021/FVAAD/index.tsx
@@ -60,7 +60,7 @@ export const FVAAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/HPCAD/index.tsx
+++ b/services/ui-src/src/measures/2021/HPCAD/index.tsx
@@ -59,7 +59,7 @@ export const HPCAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/HPCMIAD/index.tsx
+++ b/services/ui-src/src/measures/2021/HPCMIAD/index.tsx
@@ -59,7 +59,7 @@ export const HPCMIAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/HVLAD/index.tsx
+++ b/services/ui-src/src/measures/2021/HVLAD/index.tsx
@@ -59,7 +59,7 @@ export const HVLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/IETAD/index.tsx
+++ b/services/ui-src/src/measures/2021/IETAD/index.tsx
@@ -59,7 +59,7 @@ export const IETAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2021/IETHH/index.tsx
@@ -35,7 +35,7 @@ export const IETHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2021/IETHH/index.tsx
@@ -44,7 +44,7 @@ export const IETHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -54,14 +54,14 @@ export const IETHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2021/IMACH/index.tsx
@@ -43,7 +43,7 @@ export const IMACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2021/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2021/IMACH/index.tsx
@@ -59,7 +59,7 @@ export const IMACH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2021/IUHH/index.tsx
@@ -45,7 +45,7 @@ export const IUHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -65,7 +65,7 @@ export const IUHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -74,7 +74,7 @@ export const IUHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               IUHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2021/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2021/IUHH/index.tsx
@@ -36,7 +36,7 @@ export const IUHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/MSCAD/index.tsx
+++ b/services/ui-src/src/measures/2021/MSCAD/index.tsx
@@ -62,7 +62,7 @@ export const MSCAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               rateAlwaysEditable
             />
           )}

--- a/services/ui-src/src/measures/2021/OHDAD/index.tsx
+++ b/services/ui-src/src/measures/2021/OHDAD/index.tsx
@@ -59,7 +59,7 @@ export const OHDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/OUDAD/index.tsx
+++ b/services/ui-src/src/measures/2021/OUDAD/index.tsx
@@ -58,7 +58,7 @@ export const OUDAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/OUDHH/index.tsx
+++ b/services/ui-src/src/measures/2021/OUDHH/index.tsx
@@ -42,7 +42,7 @@ export const OUDHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -52,13 +52,13 @@ export const OUDHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/PC01AD/index.tsx
+++ b/services/ui-src/src/measures/2021/PC01AD/index.tsx
@@ -65,8 +65,8 @@ export const PC01AD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex={true}
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/PCRAD/index.tsx
+++ b/services/ui-src/src/measures/2021/PCRAD/index.tsx
@@ -63,7 +63,7 @@ export const PCRAD = ({
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               componentFlag={"PCR"}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2021/PCRHH/index.tsx
@@ -36,7 +36,7 @@ export const PCRHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
         removeLessThan30
       />
 

--- a/services/ui-src/src/measures/2021/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2021/PCRHH/index.tsx
@@ -46,7 +46,7 @@ export const PCRHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <PCRHHPerformanceMeasure data={PMD.data} />
@@ -57,13 +57,13 @@ export const PCRHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
               componentFlag={"PCR"}
             />
           )}

--- a/services/ui-src/src/measures/2021/PPCAD/index.tsx
+++ b/services/ui-src/src/measures/2021/PPCAD/index.tsx
@@ -59,8 +59,8 @@ export const PPCAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/PPCCH/index.tsx
+++ b/services/ui-src/src/measures/2021/PPCCH/index.tsx
@@ -59,8 +59,8 @@ export const PPCCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/PPCCH/index.tsx
+++ b/services/ui-src/src/measures/2021/PPCCH/index.tsx
@@ -43,7 +43,7 @@ export const PPCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2021/PQI01AD/index.tsx
+++ b/services/ui-src/src/measures/2021/PQI01AD/index.tsx
@@ -73,7 +73,7 @@ export const PQI01AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2021/PQI05AD/index.tsx
+++ b/services/ui-src/src/measures/2021/PQI05AD/index.tsx
@@ -73,7 +73,7 @@ export const PQI05AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2021/PQI08AD/index.tsx
+++ b/services/ui-src/src/measures/2021/PQI08AD/index.tsx
@@ -73,7 +73,7 @@ export const PQI08AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2021/PQI15AD/index.tsx
+++ b/services/ui-src/src/measures/2021/PQI15AD/index.tsx
@@ -72,7 +72,7 @@ export const PQI15AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2021/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2021/PQI92HH/index.tsx
@@ -35,7 +35,7 @@ export const PQI92HH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2021/PQI92HH/index.tsx
@@ -44,7 +44,7 @@ export const PQI92HH = ({
           <CMQ.MeasurementSpecification type="AHRQ" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -67,7 +67,7 @@ export const PQI92HH = ({
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -75,7 +75,7 @@ export const PQI92HH = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               allowNumeratorGreaterThanDenominator
               calcTotal
             />

--- a/services/ui-src/src/measures/2021/SAAAD/index.tsx
+++ b/services/ui-src/src/measures/2021/SAAAD/index.tsx
@@ -59,7 +59,7 @@ export const SAAAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/SFMCH/index.tsx
+++ b/services/ui-src/src/measures/2021/SFMCH/index.tsx
@@ -43,7 +43,7 @@ export const SFMCH = ({
           <CMQ.MeasurementSpecification type="ADA-DQA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={false} />
@@ -59,7 +59,7 @@ export const SFMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/SSDAD/index.tsx
+++ b/services/ui-src/src/measures/2021/SSDAD/index.tsx
@@ -59,7 +59,7 @@ export const SSDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/SSHH/index.tsx
+++ b/services/ui-src/src/measures/2021/SSHH/index.tsx
@@ -29,7 +29,7 @@ export const SSHH = ({
       <CMQ.StatusOfData />
       <CMQ.DataSource data={PMD.dataSourceData} />
       <CMQ.DateRange type="health" />
-      <CMQ.DefinitionOfPopulation healthHomeMeasure hybridMeasure />
+      <CMQ.DefinitionOfPopulation coreset="health" hybridMeasure />
       <PerformanceMeasure hybridMeasure />
       <CMQ.AdditionalNotes />
     </>

--- a/services/ui-src/src/measures/2021/W30CH/index.tsx
+++ b/services/ui-src/src/measures/2021/W30CH/index.tsx
@@ -43,7 +43,7 @@ export const W30CH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={false} />
@@ -59,7 +59,7 @@ export const W30CH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2021/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2021/WCCCH/index.tsx
@@ -59,7 +59,7 @@ export const WCCCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2021/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2021/WCCCH/index.tsx
@@ -43,7 +43,7 @@ export const WCCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="adult" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2021/WCVCH/index.tsx
+++ b/services/ui-src/src/measures/2021/WCVCH/index.tsx
@@ -43,7 +43,7 @@ export const WCVCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -59,7 +59,7 @@ export const WCVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2022/AABAD/index.tsx
+++ b/services/ui-src/src/measures/2022/AABAD/index.tsx
@@ -70,7 +70,7 @@ export const AABAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
               rateCalc={AABRateCalculation}
               customPrompt={PMD.data.customPrompt}
             />

--- a/services/ui-src/src/measures/2022/ADDCH/index.tsx
+++ b/services/ui-src/src/measures/2022/ADDCH/index.tsx
@@ -43,7 +43,7 @@ export const ADDCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -59,7 +59,7 @@ export const ADDCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2022/AIFHH/index.tsx
@@ -36,7 +36,7 @@ export const AIFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2022/AIFHH/index.tsx
@@ -45,7 +45,7 @@ export const AIFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -65,7 +65,7 @@ export const AIFHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -74,7 +74,7 @@ export const AIFHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               AIFHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2022/AMBCH/index.tsx
+++ b/services/ui-src/src/measures/2022/AMBCH/index.tsx
@@ -45,7 +45,7 @@ export const AMBCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -70,7 +70,7 @@ export const AMBCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               customMask={mask}

--- a/services/ui-src/src/measures/2022/AMBHH/index.tsx
+++ b/services/ui-src/src/measures/2022/AMBHH/index.tsx
@@ -35,7 +35,7 @@ export const AMBHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/AMBHH/index.tsx
+++ b/services/ui-src/src/measures/2022/AMBHH/index.tsx
@@ -44,7 +44,7 @@ export const AMBHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -67,7 +67,7 @@ export const AMBHH = ({
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -75,7 +75,7 @@ export const AMBHH = ({
               rateMultiplicationValue={1000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
               allowNumeratorGreaterThanDenominator
             />

--- a/services/ui-src/src/measures/2022/AMMAD/index.tsx
+++ b/services/ui-src/src/measures/2022/AMMAD/index.tsx
@@ -60,7 +60,7 @@ export const AMMAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/AMRAD/index.tsx
+++ b/services/ui-src/src/measures/2022/AMRAD/index.tsx
@@ -106,7 +106,7 @@ export const AMRAD = ({
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal={true}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/AMRCH/index.tsx
+++ b/services/ui-src/src/measures/2022/AMRCH/index.tsx
@@ -43,7 +43,7 @@ export const AMRCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -59,7 +59,7 @@ export const AMRCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2022/APMCH/index.tsx
+++ b/services/ui-src/src/measures/2022/APMCH/index.tsx
@@ -43,7 +43,7 @@ export const APMCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -59,7 +59,7 @@ export const APMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2022/APPCH/index.tsx
+++ b/services/ui-src/src/measures/2022/APPCH/index.tsx
@@ -43,7 +43,7 @@ export const APPCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -59,7 +59,7 @@ export const APPCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2022/BCSAD/index.tsx
+++ b/services/ui-src/src/measures/2022/BCSAD/index.tsx
@@ -59,8 +59,8 @@ export const BCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CBPAD/index.tsx
+++ b/services/ui-src/src/measures/2022/CBPAD/index.tsx
@@ -59,7 +59,7 @@ export const CBPAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2022/CBPHH/index.tsx
@@ -44,7 +44,7 @@ export const CBPHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation hybridMeasure healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure calcTotal />

--- a/services/ui-src/src/measures/2022/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2022/CBPHH/index.tsx
@@ -55,13 +55,13 @@ export const CBPHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2022/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2022/CBPHH/index.tsx
@@ -35,7 +35,7 @@ export const CBPHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/CCPAD/index.tsx
+++ b/services/ui-src/src/measures/2022/CCPAD/index.tsx
@@ -59,8 +59,8 @@ export const CCPAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CCPCH/index.tsx
+++ b/services/ui-src/src/measures/2022/CCPCH/index.tsx
@@ -44,7 +44,7 @@ export const CCPCH = ({
           <CMQ.MeasurementSpecification type="OPA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -57,9 +57,9 @@ export const CCPCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               categories={PMD.categories}
-              isSingleSex={true}
+              excludeOptions={["Sex"]}
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
             />

--- a/services/ui-src/src/measures/2022/CCSAD/index.tsx
+++ b/services/ui-src/src/measures/2022/CCSAD/index.tsx
@@ -59,8 +59,8 @@ export const CCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CCWAD/index.tsx
+++ b/services/ui-src/src/measures/2022/CCWAD/index.tsx
@@ -59,8 +59,8 @@ export const CCWAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CCWCH/index.tsx
+++ b/services/ui-src/src/measures/2022/CCWCH/index.tsx
@@ -43,7 +43,7 @@ export const CCWCH = ({
           <CMQ.MeasurementSpecification type="OPA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -59,8 +59,8 @@ export const CCWCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CDFAD/index.tsx
+++ b/services/ui-src/src/measures/2022/CDFAD/index.tsx
@@ -59,7 +59,7 @@ export const CDFAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2022/CDFCH/index.tsx
@@ -59,7 +59,7 @@ export const CDFCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2022/CDFCH/index.tsx
@@ -43,7 +43,7 @@ export const CDFCH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2022/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2022/CDFHH/index.tsx
@@ -34,7 +34,7 @@ export const CDFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2022/CDFHH/index.tsx
@@ -43,7 +43,7 @@ export const CDFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -60,14 +60,14 @@ export const CDFHH = ({
           {isOtherMeasureSpecSelected && (
             <CMQ.OtherPerformanceMeasure rateMultiplicationValue={100} />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               rateMultiplicationValue={100}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2022/CHLAD/index.tsx
+++ b/services/ui-src/src/measures/2022/CHLAD/index.tsx
@@ -59,8 +59,8 @@ export const CHLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2022/CHLCH/index.tsx
@@ -43,7 +43,7 @@ export const CHLCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2022/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2022/CHLCH/index.tsx
@@ -59,8 +59,8 @@ export const CHLCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2022/CISCH/index.tsx
@@ -59,7 +59,7 @@ export const CISCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2022/CISCH/index.tsx
@@ -43,7 +43,7 @@ export const CISCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2022/COBAD/index.tsx
+++ b/services/ui-src/src/measures/2022/COBAD/index.tsx
@@ -59,7 +59,7 @@ export const COBAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/COLAD/index.tsx
+++ b/services/ui-src/src/measures/2022/COLAD/index.tsx
@@ -59,7 +59,7 @@ export const COLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/COLHH/index.tsx
+++ b/services/ui-src/src/measures/2022/COLHH/index.tsx
@@ -44,7 +44,7 @@ export const COLHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -54,13 +54,13 @@ export const COLHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/COLHH/index.tsx
+++ b/services/ui-src/src/measures/2022/COLHH/index.tsx
@@ -35,7 +35,7 @@ export const COLHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2022/DEVCH/index.tsx
@@ -43,7 +43,7 @@ export const DEVCH = ({
           <CMQ.MeasurementSpecification type="OHSU" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2022/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2022/DEVCH/index.tsx
@@ -60,7 +60,7 @@ export const DEVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2022/FUAAD/index.tsx
+++ b/services/ui-src/src/measures/2022/FUAAD/index.tsx
@@ -59,7 +59,7 @@ export const FUAAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/FUACH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUACH/index.tsx
@@ -43,7 +43,7 @@ export const FUACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -59,7 +59,7 @@ export const FUACH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUAHH/index.tsx
@@ -35,7 +35,7 @@ export const FUAHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUAHH/index.tsx
@@ -44,7 +44,7 @@ export const FUAHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -54,13 +54,13 @@ export const FUAHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2022/FUHAD/index.tsx
+++ b/services/ui-src/src/measures/2022/FUHAD/index.tsx
@@ -59,7 +59,7 @@ export const FUHAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={true}
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUHCH/index.tsx
@@ -43,7 +43,7 @@ export const FUHCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2022/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUHCH/index.tsx
@@ -59,7 +59,7 @@ export const FUHCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUHHH/index.tsx
@@ -35,7 +35,7 @@ export const FUHHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUHHH/index.tsx
@@ -44,7 +44,7 @@ export const FUHHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -55,13 +55,13 @@ export const FUHHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2022/FUMAD/index.tsx
+++ b/services/ui-src/src/measures/2022/FUMAD/index.tsx
@@ -58,7 +58,7 @@ export const FUMAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUMCH/index.tsx
@@ -59,7 +59,7 @@ export const FUMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUMCH/index.tsx
@@ -43,7 +43,7 @@ export const FUMCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2022/FUMHH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUMHH/index.tsx
@@ -44,7 +44,7 @@ export const FUMHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure calcTotal data={PMD.data} />
@@ -56,10 +56,10 @@ export const FUMHH = ({
           {isOtherMeasureSpecSelected && (
             <CMQ.OtherPerformanceMeasure rateMultiplicationValue={100} />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="health"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2022/FUMHH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUMHH/index.tsx
@@ -35,7 +35,7 @@ export const FUMHH = ({
         measureAbbreviation={measureId}
         measureName={name}
         reportingYear={year}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/FVAAD/index.tsx
+++ b/services/ui-src/src/measures/2022/FVAAD/index.tsx
@@ -60,7 +60,7 @@ export const FVAAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/HPCAD/index.tsx
+++ b/services/ui-src/src/measures/2022/HPCAD/index.tsx
@@ -59,7 +59,7 @@ export const HPCAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/HPCMIAD/index.tsx
+++ b/services/ui-src/src/measures/2022/HPCMIAD/index.tsx
@@ -59,7 +59,7 @@ export const HPCMIAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/HVLAD/index.tsx
+++ b/services/ui-src/src/measures/2022/HVLAD/index.tsx
@@ -59,7 +59,7 @@ export const HVLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/IETAD/index.tsx
+++ b/services/ui-src/src/measures/2022/IETAD/index.tsx
@@ -59,7 +59,7 @@ export const IETAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2022/IETHH/index.tsx
@@ -35,7 +35,7 @@ export const IETHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2022/IETHH/index.tsx
@@ -44,7 +44,7 @@ export const IETHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -54,14 +54,14 @@ export const IETHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2022/IMACH/index.tsx
@@ -43,7 +43,7 @@ export const IMACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2022/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2022/IMACH/index.tsx
@@ -59,7 +59,7 @@ export const IMACH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2022/IUHH/index.tsx
@@ -45,7 +45,7 @@ export const IUHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -65,7 +65,7 @@ export const IUHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -74,7 +74,7 @@ export const IUHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               IUHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2022/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2022/IUHH/index.tsx
@@ -36,7 +36,7 @@ export const IUHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/MSCAD/index.tsx
+++ b/services/ui-src/src/measures/2022/MSCAD/index.tsx
@@ -62,7 +62,7 @@ export const MSCAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               rateAlwaysEditable
             />
           )}

--- a/services/ui-src/src/measures/2022/OEVCH/index.tsx
+++ b/services/ui-src/src/measures/2022/OEVCH/index.tsx
@@ -43,7 +43,7 @@ export const OEVCH = ({
           <CMQ.MeasurementSpecification type={DC.ADA_DQA} />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -57,7 +57,7 @@ export const OEVCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2022/OHDAD/index.tsx
+++ b/services/ui-src/src/measures/2022/OHDAD/index.tsx
@@ -59,7 +59,7 @@ export const OHDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/OUDAD/index.tsx
+++ b/services/ui-src/src/measures/2022/OUDAD/index.tsx
@@ -58,7 +58,7 @@ export const OUDAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/OUDHH/index.tsx
+++ b/services/ui-src/src/measures/2022/OUDHH/index.tsx
@@ -42,7 +42,7 @@ export const OUDHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -52,13 +52,13 @@ export const OUDHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/PCRAD/index.tsx
+++ b/services/ui-src/src/measures/2022/PCRAD/index.tsx
@@ -63,7 +63,7 @@ export const PCRAD = ({
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               componentFlag={"PCR"}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2022/PCRHH/index.tsx
@@ -36,7 +36,7 @@ export const PCRHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
         removeLessThan30
       />
 

--- a/services/ui-src/src/measures/2022/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2022/PCRHH/index.tsx
@@ -46,7 +46,7 @@ export const PCRHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <PCRHHPerformanceMeasure data={PMD.data} />
@@ -57,13 +57,13 @@ export const PCRHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
               componentFlag={"PCR"}
             />
           )}

--- a/services/ui-src/src/measures/2022/PPCAD/index.tsx
+++ b/services/ui-src/src/measures/2022/PPCAD/index.tsx
@@ -59,8 +59,8 @@ export const PPCAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/PPCCH/index.tsx
+++ b/services/ui-src/src/measures/2022/PPCCH/index.tsx
@@ -59,8 +59,8 @@ export const PPCCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["Sex"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/PPCCH/index.tsx
+++ b/services/ui-src/src/measures/2022/PPCCH/index.tsx
@@ -43,7 +43,7 @@ export const PPCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2022/PQI01AD/index.tsx
+++ b/services/ui-src/src/measures/2022/PQI01AD/index.tsx
@@ -73,7 +73,7 @@ export const PQI01AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2022/PQI05AD/index.tsx
+++ b/services/ui-src/src/measures/2022/PQI05AD/index.tsx
@@ -73,7 +73,7 @@ export const PQI05AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2022/PQI08AD/index.tsx
+++ b/services/ui-src/src/measures/2022/PQI08AD/index.tsx
@@ -73,7 +73,7 @@ export const PQI08AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2022/PQI15AD/index.tsx
+++ b/services/ui-src/src/measures/2022/PQI15AD/index.tsx
@@ -72,7 +72,7 @@ export const PQI15AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2022/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2022/PQI92HH/index.tsx
@@ -35,7 +35,7 @@ export const PQI92HH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2022/PQI92HH/index.tsx
@@ -44,7 +44,7 @@ export const PQI92HH = ({
           <CMQ.MeasurementSpecification type="AHRQ" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -67,7 +67,7 @@ export const PQI92HH = ({
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -75,7 +75,7 @@ export const PQI92HH = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               allowNumeratorGreaterThanDenominator
               calcTotal
             />

--- a/services/ui-src/src/measures/2022/SAAAD/index.tsx
+++ b/services/ui-src/src/measures/2022/SAAAD/index.tsx
@@ -59,7 +59,7 @@ export const SAAAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/SFMCH/index.tsx
+++ b/services/ui-src/src/measures/2022/SFMCH/index.tsx
@@ -43,7 +43,7 @@ export const SFMCH = ({
           <CMQ.MeasurementSpecification type="ADA-DQA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
@@ -59,7 +59,7 @@ export const SFMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/SSDAD/index.tsx
+++ b/services/ui-src/src/measures/2022/SSDAD/index.tsx
@@ -59,7 +59,7 @@ export const SSDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/SSHH/index.tsx
+++ b/services/ui-src/src/measures/2022/SSHH/index.tsx
@@ -29,7 +29,7 @@ export const SSHH = ({
       <CMQ.StatusOfData />
       <CMQ.DataSource data={PMD.dataSourceData} />
       <CMQ.DateRange type="health" />
-      <CMQ.DefinitionOfPopulation healthHomeMeasure hybridMeasure />
+      <CMQ.DefinitionOfPopulation coreset="health" hybridMeasure />
       <PerformanceMeasure hybridMeasure />
       <CMQ.AdditionalNotes />
     </>

--- a/services/ui-src/src/measures/2022/TFLCH/index.tsx
+++ b/services/ui-src/src/measures/2022/TFLCH/index.tsx
@@ -43,7 +43,7 @@ export const TFLCH = ({
           <CMQ.MeasurementSpecification type="ADA-DQA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -59,7 +59,7 @@ export const TFLCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2022/W30CH/index.tsx
+++ b/services/ui-src/src/measures/2022/W30CH/index.tsx
@@ -43,7 +43,7 @@ export const W30CH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
@@ -59,7 +59,7 @@ export const W30CH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2022/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2022/WCCCH/index.tsx
@@ -59,7 +59,7 @@ export const WCCCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2022/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2022/WCCCH/index.tsx
@@ -43,7 +43,7 @@ export const WCCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="adult" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2022/WCVCH/index.tsx
+++ b/services/ui-src/src/measures/2022/WCVCH/index.tsx
@@ -43,7 +43,7 @@ export const WCVCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -59,7 +59,7 @@ export const WCVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2023/AABAD/index.tsx
+++ b/services/ui-src/src/measures/2023/AABAD/index.tsx
@@ -68,7 +68,7 @@ export const AABAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
               rateCalc={AABRateCalculation}
               customPrompt={PMD.data.customPrompt}
             />

--- a/services/ui-src/src/measures/2023/AABCH/index.tsx
+++ b/services/ui-src/src/measures/2023/AABCH/index.tsx
@@ -46,7 +46,7 @@ export const AABCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -67,7 +67,7 @@ export const AABCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               customMask={mask}

--- a/services/ui-src/src/measures/2023/ADDCH/index.tsx
+++ b/services/ui-src/src/measures/2023/ADDCH/index.tsx
@@ -43,7 +43,7 @@ export const ADDCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -57,7 +57,7 @@ export const ADDCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2023/AIFHH/index.tsx
@@ -36,7 +36,7 @@ export const AIFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2023/AIFHH/index.tsx
@@ -45,7 +45,7 @@ export const AIFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -62,7 +62,7 @@ export const AIFHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -71,7 +71,7 @@ export const AIFHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               AIFHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2023/AMBCH/index.tsx
+++ b/services/ui-src/src/measures/2023/AMBCH/index.tsx
@@ -45,7 +45,7 @@ export const AMBCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -68,7 +68,7 @@ export const AMBCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               customMask={mask}

--- a/services/ui-src/src/measures/2023/AMBHH/index.tsx
+++ b/services/ui-src/src/measures/2023/AMBHH/index.tsx
@@ -35,7 +35,7 @@ export const AMBHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/AMBHH/index.tsx
+++ b/services/ui-src/src/measures/2023/AMBHH/index.tsx
@@ -44,7 +44,7 @@ export const AMBHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -64,7 +64,7 @@ export const AMBHH = ({
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -72,7 +72,7 @@ export const AMBHH = ({
               rateMultiplicationValue={1000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
               allowNumeratorGreaterThanDenominator
             />

--- a/services/ui-src/src/measures/2023/AMMAD/index.tsx
+++ b/services/ui-src/src/measures/2023/AMMAD/index.tsx
@@ -58,7 +58,7 @@ export const AMMAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/AMRAD/index.tsx
+++ b/services/ui-src/src/measures/2023/AMRAD/index.tsx
@@ -104,7 +104,7 @@ export const AMRAD = ({
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal={true}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/AMRCH/index.tsx
+++ b/services/ui-src/src/measures/2023/AMRCH/index.tsx
@@ -43,7 +43,7 @@ export const AMRCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -57,7 +57,7 @@ export const AMRCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2023/APMCH/index.tsx
+++ b/services/ui-src/src/measures/2023/APMCH/index.tsx
@@ -43,7 +43,7 @@ export const APMCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -57,7 +57,7 @@ export const APMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2023/APPCH/index.tsx
+++ b/services/ui-src/src/measures/2023/APPCH/index.tsx
@@ -43,7 +43,7 @@ export const APPCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -57,7 +57,7 @@ export const APPCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2023/BCSAD/index.tsx
+++ b/services/ui-src/src/measures/2023/BCSAD/index.tsx
@@ -57,8 +57,8 @@ export const BCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CBPAD/index.tsx
+++ b/services/ui-src/src/measures/2023/CBPAD/index.tsx
@@ -57,7 +57,7 @@ export const CBPAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2023/CBPHH/index.tsx
@@ -52,13 +52,13 @@ export const CBPHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2023/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2023/CBPHH/index.tsx
@@ -44,7 +44,7 @@ export const CBPHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation hybridMeasure healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure calcTotal />

--- a/services/ui-src/src/measures/2023/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2023/CBPHH/index.tsx
@@ -35,7 +35,7 @@ export const CBPHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/CCPAD/index.tsx
+++ b/services/ui-src/src/measures/2023/CCPAD/index.tsx
@@ -57,8 +57,8 @@ export const CCPAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CCPCH/index.tsx
+++ b/services/ui-src/src/measures/2023/CCPCH/index.tsx
@@ -44,7 +44,7 @@ export const CCPCH = ({
           <CMQ.MeasurementSpecification type="OPA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -55,9 +55,9 @@ export const CCPCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               categories={PMD.categories}
-              isSingleSex={true}
+              excludeOptions={["O8BrOa"]}
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
             />

--- a/services/ui-src/src/measures/2023/CCSAD/index.tsx
+++ b/services/ui-src/src/measures/2023/CCSAD/index.tsx
@@ -57,8 +57,8 @@ export const CCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CCWAD/index.tsx
+++ b/services/ui-src/src/measures/2023/CCWAD/index.tsx
@@ -57,8 +57,8 @@ export const CCWAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CCWCH/index.tsx
+++ b/services/ui-src/src/measures/2023/CCWCH/index.tsx
@@ -43,7 +43,7 @@ export const CCWCH = ({
           <CMQ.MeasurementSpecification type="OPA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -57,8 +57,8 @@ export const CCWCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CDFAD/index.tsx
+++ b/services/ui-src/src/measures/2023/CDFAD/index.tsx
@@ -57,7 +57,7 @@ export const CDFAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2023/CDFCH/index.tsx
@@ -57,7 +57,7 @@ export const CDFCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2023/CDFCH/index.tsx
@@ -43,7 +43,7 @@ export const CDFCH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2023/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2023/CDFHH/index.tsx
@@ -34,7 +34,7 @@ export const CDFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2023/CDFHH/index.tsx
@@ -43,7 +43,7 @@ export const CDFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -57,14 +57,14 @@ export const CDFHH = ({
           {isOtherMeasureSpecSelected && (
             <CMQ.OtherPerformanceMeasure rateMultiplicationValue={100} />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               rateMultiplicationValue={100}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2023/CHLAD/index.tsx
+++ b/services/ui-src/src/measures/2023/CHLAD/index.tsx
@@ -57,8 +57,8 @@ export const CHLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2023/CHLCH/index.tsx
@@ -43,7 +43,7 @@ export const CHLCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2023/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2023/CHLCH/index.tsx
@@ -57,8 +57,8 @@ export const CHLCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2023/CISCH/index.tsx
@@ -57,7 +57,7 @@ export const CISCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2023/CISCH/index.tsx
@@ -43,7 +43,7 @@ export const CISCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2023/COBAD/index.tsx
+++ b/services/ui-src/src/measures/2023/COBAD/index.tsx
@@ -57,7 +57,7 @@ export const COBAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/COLAD/index.tsx
+++ b/services/ui-src/src/measures/2023/COLAD/index.tsx
@@ -57,7 +57,7 @@ export const COLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/COLHH/index.tsx
+++ b/services/ui-src/src/measures/2023/COLHH/index.tsx
@@ -44,7 +44,7 @@ export const COLHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -52,13 +52,13 @@ export const COLHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/COLHH/index.tsx
+++ b/services/ui-src/src/measures/2023/COLHH/index.tsx
@@ -35,7 +35,7 @@ export const COLHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2023/DEVCH/index.tsx
@@ -57,7 +57,7 @@ export const DEVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2023/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2023/DEVCH/index.tsx
@@ -43,7 +43,7 @@ export const DEVCH = ({
           <CMQ.MeasurementSpecification type="OHSU" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2023/FUAAD/index.tsx
+++ b/services/ui-src/src/measures/2023/FUAAD/index.tsx
@@ -57,7 +57,7 @@ export const FUAAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/FUACH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUACH/index.tsx
@@ -43,7 +43,7 @@ export const FUACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -57,7 +57,7 @@ export const FUACH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUAHH/index.tsx
@@ -44,7 +44,7 @@ export const FUAHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -52,13 +52,13 @@ export const FUAHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2023/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUAHH/index.tsx
@@ -35,7 +35,7 @@ export const FUAHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/FUHAD/index.tsx
+++ b/services/ui-src/src/measures/2023/FUHAD/index.tsx
@@ -57,7 +57,7 @@ export const FUHAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={true}
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUHCH/index.tsx
@@ -43,7 +43,7 @@ export const FUHCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2023/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUHCH/index.tsx
@@ -57,7 +57,7 @@ export const FUHCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUHHH/index.tsx
@@ -35,7 +35,7 @@ export const FUHHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUHHH/index.tsx
@@ -44,7 +44,7 @@ export const FUHHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -52,13 +52,13 @@ export const FUHHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2023/FUMAD/index.tsx
+++ b/services/ui-src/src/measures/2023/FUMAD/index.tsx
@@ -56,7 +56,7 @@ export const FUMAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUMCH/index.tsx
@@ -43,7 +43,7 @@ export const FUMCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2023/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUMCH/index.tsx
@@ -57,7 +57,7 @@ export const FUMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/FUMHH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUMHH/index.tsx
@@ -44,7 +44,7 @@ export const FUMHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure calcTotal data={PMD.data} />
@@ -54,10 +54,10 @@ export const FUMHH = ({
           {isOtherMeasureSpecSelected && (
             <CMQ.OtherPerformanceMeasure rateMultiplicationValue={100} />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="health"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2023/FUMHH/index.tsx
+++ b/services/ui-src/src/measures/2023/FUMHH/index.tsx
@@ -35,7 +35,7 @@ export const FUMHH = ({
         measureAbbreviation={measureId}
         measureName={name}
         reportingYear={year}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/HBDAD/index.tsx
+++ b/services/ui-src/src/measures/2023/HBDAD/index.tsx
@@ -57,7 +57,7 @@ export const HBDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/HPCMIAD/index.tsx
+++ b/services/ui-src/src/measures/2023/HPCMIAD/index.tsx
@@ -57,7 +57,7 @@ export const HPCMIAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/HVLAD/index.tsx
+++ b/services/ui-src/src/measures/2023/HVLAD/index.tsx
@@ -57,7 +57,7 @@ export const HVLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/IETAD/index.tsx
+++ b/services/ui-src/src/measures/2023/IETAD/index.tsx
@@ -61,7 +61,7 @@ export const IETAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2023/IETHH/index.tsx
@@ -35,7 +35,7 @@ export const IETHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2023/IETHH/index.tsx
@@ -44,7 +44,7 @@ export const IETHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -56,14 +56,14 @@ export const IETHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2023/IMACH/index.tsx
@@ -43,7 +43,7 @@ export const IMACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2023/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2023/IMACH/index.tsx
@@ -57,7 +57,7 @@ export const IMACH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2023/IUHH/index.tsx
@@ -45,7 +45,7 @@ export const IUHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -62,7 +62,7 @@ export const IUHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -71,7 +71,7 @@ export const IUHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               IUHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2023/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2023/IUHH/index.tsx
@@ -36,7 +36,7 @@ export const IUHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/LSCCH/index.tsx
+++ b/services/ui-src/src/measures/2023/LSCCH/index.tsx
@@ -42,7 +42,7 @@ export const LSCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2023/LSCCH/index.tsx
+++ b/services/ui-src/src/measures/2023/LSCCH/index.tsx
@@ -53,7 +53,7 @@ export const LSCCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2023/OEVCH/index.tsx
+++ b/services/ui-src/src/measures/2023/OEVCH/index.tsx
@@ -43,7 +43,7 @@ export const OEVCH = ({
           <CMQ.MeasurementSpecification type={DC.ADA_DQA} />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -54,7 +54,7 @@ export const OEVCH = ({
           <CMQ.CombinedRates />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2023/OHDAD/index.tsx
+++ b/services/ui-src/src/measures/2023/OHDAD/index.tsx
@@ -57,7 +57,7 @@ export const OHDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/OUDAD/index.tsx
+++ b/services/ui-src/src/measures/2023/OUDAD/index.tsx
@@ -56,7 +56,7 @@ export const OUDAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/OUDHH/index.tsx
+++ b/services/ui-src/src/measures/2023/OUDHH/index.tsx
@@ -42,7 +42,7 @@ export const OUDHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -50,13 +50,13 @@ export const OUDHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2023/PCRHH/index.tsx
@@ -38,7 +38,7 @@ export const PCRHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <PCRHHPerformanceMeasure data={PMD.data} />
@@ -46,7 +46,7 @@ export const PCRHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && <NotCollectingOMS year={year} />}
         </>
       )}

--- a/services/ui-src/src/measures/2023/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2023/PCRHH/index.tsx
@@ -28,7 +28,7 @@ export const PCRHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
         removeLessThan30
       />
 

--- a/services/ui-src/src/measures/2023/PPCAD/index.tsx
+++ b/services/ui-src/src/measures/2023/PPCAD/index.tsx
@@ -57,8 +57,8 @@ export const PPCAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/PPCCH/index.tsx
+++ b/services/ui-src/src/measures/2023/PPCCH/index.tsx
@@ -57,8 +57,8 @@ export const PPCCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/PPCCH/index.tsx
+++ b/services/ui-src/src/measures/2023/PPCCH/index.tsx
@@ -43,7 +43,7 @@ export const PPCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2023/PQI01AD/index.tsx
+++ b/services/ui-src/src/measures/2023/PQI01AD/index.tsx
@@ -71,7 +71,7 @@ export const PQI01AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2023/PQI05AD/index.tsx
+++ b/services/ui-src/src/measures/2023/PQI05AD/index.tsx
@@ -71,7 +71,7 @@ export const PQI05AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2023/PQI08AD/index.tsx
+++ b/services/ui-src/src/measures/2023/PQI08AD/index.tsx
@@ -71,7 +71,7 @@ export const PQI08AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2023/PQI15AD/index.tsx
+++ b/services/ui-src/src/measures/2023/PQI15AD/index.tsx
@@ -70,7 +70,7 @@ export const PQI15AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2023/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2023/PQI92HH/index.tsx
@@ -44,7 +44,7 @@ export const PQI92HH = ({
           <CMQ.MeasurementSpecification type="AHRQ" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -64,7 +64,7 @@ export const PQI92HH = ({
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -72,7 +72,7 @@ export const PQI92HH = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               allowNumeratorGreaterThanDenominator
               calcTotal
             />

--- a/services/ui-src/src/measures/2023/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2023/PQI92HH/index.tsx
@@ -35,7 +35,7 @@ export const PQI92HH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2023/SAAAD/index.tsx
+++ b/services/ui-src/src/measures/2023/SAAAD/index.tsx
@@ -57,7 +57,7 @@ export const SAAAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/SFMCH/index.tsx
+++ b/services/ui-src/src/measures/2023/SFMCH/index.tsx
@@ -43,7 +43,7 @@ export const SFMCH = ({
           <CMQ.MeasurementSpecification type="ADA-DQA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
@@ -57,7 +57,7 @@ export const SFMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/SSDAD/index.tsx
+++ b/services/ui-src/src/measures/2023/SSDAD/index.tsx
@@ -57,7 +57,7 @@ export const SSDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/SSHH/index.tsx
+++ b/services/ui-src/src/measures/2023/SSHH/index.tsx
@@ -29,7 +29,7 @@ export const SSHH = ({
       <CMQ.StatusOfData />
       <CMQ.DataSource data={PMD.dataSourceData} />
       <CMQ.DateRange type="health" />
-      <CMQ.DefinitionOfPopulation healthHomeMeasure hybridMeasure />
+      <CMQ.DefinitionOfPopulation coreset="health" hybridMeasure />
       <PerformanceMeasure hybridMeasure />
       <CMQ.AdditionalNotes />
     </>

--- a/services/ui-src/src/measures/2023/TFLCH/index.tsx
+++ b/services/ui-src/src/measures/2023/TFLCH/index.tsx
@@ -43,7 +43,7 @@ export const TFLCH = ({
           <CMQ.MeasurementSpecification type="ADA-DQA" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -57,7 +57,7 @@ export const TFLCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2023/W30CH/index.tsx
+++ b/services/ui-src/src/measures/2023/W30CH/index.tsx
@@ -43,7 +43,7 @@ export const W30CH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
@@ -57,7 +57,7 @@ export const W30CH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2023/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2023/WCCCH/index.tsx
@@ -43,7 +43,7 @@ export const WCCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="adult" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2023/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2023/WCCCH/index.tsx
@@ -57,7 +57,7 @@ export const WCCCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2023/WCVCH/index.tsx
+++ b/services/ui-src/src/measures/2023/WCVCH/index.tsx
@@ -43,7 +43,7 @@ export const WCVCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -57,7 +57,7 @@ export const WCVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2024/AABAD/index.tsx
+++ b/services/ui-src/src/measures/2024/AABAD/index.tsx
@@ -67,7 +67,7 @@ export const AABAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
               rateCalc={AABRateCalculation}
               customPrompt={PMD.data.customPrompt}
             />

--- a/services/ui-src/src/measures/2024/AABCH/index.tsx
+++ b/services/ui-src/src/measures/2024/AABCH/index.tsx
@@ -46,7 +46,7 @@ export const AABCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -66,7 +66,7 @@ export const AABCH = ({
           )}
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               customMask={mask}

--- a/services/ui-src/src/measures/2024/ADDCH/index.tsx
+++ b/services/ui-src/src/measures/2024/ADDCH/index.tsx
@@ -43,7 +43,7 @@ export const ADDCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -56,7 +56,7 @@ export const ADDCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2024/AIFHH/index.tsx
@@ -36,7 +36,7 @@ export const AIFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2024/AIFHH/index.tsx
@@ -45,7 +45,7 @@ export const AIFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -62,7 +62,7 @@ export const AIFHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -71,7 +71,7 @@ export const AIFHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               AIFHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2024/AMBCH/index.tsx
+++ b/services/ui-src/src/measures/2024/AMBCH/index.tsx
@@ -45,7 +45,7 @@ export const AMBCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -67,7 +67,7 @@ export const AMBCH = ({
           )}
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               customMask={mask}

--- a/services/ui-src/src/measures/2024/AMBHH/index.tsx
+++ b/services/ui-src/src/measures/2024/AMBHH/index.tsx
@@ -35,7 +35,7 @@ export const AMBHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/AMBHH/index.tsx
+++ b/services/ui-src/src/measures/2024/AMBHH/index.tsx
@@ -44,7 +44,7 @@ export const AMBHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -64,7 +64,7 @@ export const AMBHH = ({
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -72,7 +72,7 @@ export const AMBHH = ({
               rateMultiplicationValue={1000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
               allowNumeratorGreaterThanDenominator
             />

--- a/services/ui-src/src/measures/2024/AMMAD/index.tsx
+++ b/services/ui-src/src/measures/2024/AMMAD/index.tsx
@@ -57,7 +57,7 @@ export const AMMAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/AMRAD/index.tsx
+++ b/services/ui-src/src/measures/2024/AMRAD/index.tsx
@@ -103,7 +103,7 @@ export const AMRAD = ({
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal={true}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/AMRCH/index.tsx
+++ b/services/ui-src/src/measures/2024/AMRCH/index.tsx
@@ -43,7 +43,7 @@ export const AMRCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const AMRCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2024/APMCH/index.tsx
+++ b/services/ui-src/src/measures/2024/APMCH/index.tsx
@@ -43,7 +43,7 @@ export const APMCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const APMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2024/APPCH/index.tsx
+++ b/services/ui-src/src/measures/2024/APPCH/index.tsx
@@ -43,7 +43,7 @@ export const APPCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const APPCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2024/BCSAD/index.tsx
+++ b/services/ui-src/src/measures/2024/BCSAD/index.tsx
@@ -56,8 +56,8 @@ export const BCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CBPAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CBPAD/index.tsx
@@ -56,7 +56,7 @@ export const CBPAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2024/CBPHH/index.tsx
@@ -52,13 +52,13 @@ export const CBPHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2024/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2024/CBPHH/index.tsx
@@ -44,7 +44,7 @@ export const CBPHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation hybridMeasure healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure calcTotal />

--- a/services/ui-src/src/measures/2024/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2024/CBPHH/index.tsx
@@ -35,7 +35,7 @@ export const CBPHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/CCPAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CCPAD/index.tsx
@@ -56,8 +56,8 @@ export const CCPAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CCPCH/index.tsx
+++ b/services/ui-src/src/measures/2024/CCPCH/index.tsx
@@ -44,7 +44,7 @@ export const CCPCH = ({
           <CMQ.MeasurementSpecification type="OPA" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -54,9 +54,9 @@ export const CCPCH = ({
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               categories={PMD.categories}
-              isSingleSex={true}
+              excludeOptions={["O8BrOa"]}
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
             />

--- a/services/ui-src/src/measures/2024/CCSAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CCSAD/index.tsx
@@ -56,8 +56,8 @@ export const CCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CCWAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CCWAD/index.tsx
@@ -56,8 +56,8 @@ export const CCWAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CCWCH/index.tsx
+++ b/services/ui-src/src/measures/2024/CCWCH/index.tsx
@@ -43,7 +43,7 @@ export const CCWCH = ({
           <CMQ.MeasurementSpecification type="OPA" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -56,8 +56,8 @@ export const CCWCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CDFAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CDFAD/index.tsx
@@ -56,7 +56,7 @@ export const CDFAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2024/CDFCH/index.tsx
@@ -56,7 +56,7 @@ export const CDFCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2024/CDFCH/index.tsx
@@ -43,7 +43,7 @@ export const CDFCH = ({
           <CMQ.MeasurementSpecification type="CMS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2024/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2024/CDFHH/index.tsx
@@ -34,7 +34,7 @@ export const CDFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2024/CDFHH/index.tsx
@@ -43,7 +43,7 @@ export const CDFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -57,14 +57,14 @@ export const CDFHH = ({
           {isOtherMeasureSpecSelected && (
             <CMQ.OtherPerformanceMeasure rateMultiplicationValue={100} />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               rateMultiplicationValue={100}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2024/CHLAD/index.tsx
+++ b/services/ui-src/src/measures/2024/CHLAD/index.tsx
@@ -56,8 +56,8 @@ export const CHLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2024/CHLCH/index.tsx
@@ -56,8 +56,8 @@ export const CHLCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2024/CHLCH/index.tsx
@@ -43,7 +43,7 @@ export const CHLCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2024/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2024/CISCH/index.tsx
@@ -56,7 +56,7 @@ export const CISCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2024/CISCH/index.tsx
@@ -43,7 +43,7 @@ export const CISCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2024/COBAD/index.tsx
+++ b/services/ui-src/src/measures/2024/COBAD/index.tsx
@@ -56,7 +56,7 @@ export const COBAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/COLAD/index.tsx
+++ b/services/ui-src/src/measures/2024/COLAD/index.tsx
@@ -56,7 +56,7 @@ export const COLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/COLHH/index.tsx
+++ b/services/ui-src/src/measures/2024/COLHH/index.tsx
@@ -44,7 +44,7 @@ export const COLHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -52,13 +52,13 @@ export const COLHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/COLHH/index.tsx
+++ b/services/ui-src/src/measures/2024/COLHH/index.tsx
@@ -35,7 +35,7 @@ export const COLHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2024/DEVCH/index.tsx
@@ -43,7 +43,7 @@ export const DEVCH = ({
           <CMQ.MeasurementSpecification type="OHSU" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2024/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2024/DEVCH/index.tsx
@@ -56,7 +56,7 @@ export const DEVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2024/FUAAD/index.tsx
+++ b/services/ui-src/src/measures/2024/FUAAD/index.tsx
@@ -56,7 +56,7 @@ export const FUAAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/FUACH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUACH/index.tsx
@@ -43,7 +43,7 @@ export const FUACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -56,7 +56,7 @@ export const FUACH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUAHH/index.tsx
@@ -44,7 +44,7 @@ export const FUAHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -52,13 +52,13 @@ export const FUAHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2024/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUAHH/index.tsx
@@ -35,7 +35,7 @@ export const FUAHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/FUHAD/index.tsx
+++ b/services/ui-src/src/measures/2024/FUHAD/index.tsx
@@ -56,7 +56,7 @@ export const FUHAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={true}
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUHCH/index.tsx
@@ -43,7 +43,7 @@ export const FUHCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2024/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUHCH/index.tsx
@@ -56,7 +56,7 @@ export const FUHCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUHHH/index.tsx
@@ -35,7 +35,7 @@ export const FUHHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUHHH/index.tsx
@@ -44,7 +44,7 @@ export const FUHHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -52,13 +52,13 @@ export const FUHHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2024/FUMAD/index.tsx
+++ b/services/ui-src/src/measures/2024/FUMAD/index.tsx
@@ -55,7 +55,7 @@ export const FUMAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUMCH/index.tsx
@@ -43,7 +43,7 @@ export const FUMCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2024/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUMCH/index.tsx
@@ -56,7 +56,7 @@ export const FUMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/FUMHH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUMHH/index.tsx
@@ -44,7 +44,7 @@ export const FUMHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure calcTotal data={PMD.data} />
@@ -54,10 +54,10 @@ export const FUMHH = ({
           {isOtherMeasureSpecSelected && (
             <CMQ.OtherPerformanceMeasure rateMultiplicationValue={100} />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="health"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2024/FUMHH/index.tsx
+++ b/services/ui-src/src/measures/2024/FUMHH/index.tsx
@@ -35,7 +35,7 @@ export const FUMHH = ({
         measureAbbreviation={measureId}
         measureName={name}
         reportingYear={year}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/HBDAD/index.tsx
+++ b/services/ui-src/src/measures/2024/HBDAD/index.tsx
@@ -56,7 +56,7 @@ export const HBDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/HPCMIAD/index.tsx
+++ b/services/ui-src/src/measures/2024/HPCMIAD/index.tsx
@@ -56,7 +56,7 @@ export const HPCMIAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/HVLAD/index.tsx
+++ b/services/ui-src/src/measures/2024/HVLAD/index.tsx
@@ -56,7 +56,7 @@ export const HVLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/IETAD/index.tsx
+++ b/services/ui-src/src/measures/2024/IETAD/index.tsx
@@ -60,7 +60,7 @@ export const IETAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2024/IETHH/index.tsx
@@ -35,7 +35,7 @@ export const IETHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2024/IETHH/index.tsx
@@ -44,7 +44,7 @@ export const IETHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -56,14 +56,14 @@ export const IETHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2024/IMACH/index.tsx
@@ -56,7 +56,7 @@ export const IMACH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2024/IMACH/index.tsx
@@ -43,7 +43,7 @@ export const IMACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2024/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2024/IUHH/index.tsx
@@ -45,7 +45,7 @@ export const IUHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -62,7 +62,7 @@ export const IUHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -71,7 +71,7 @@ export const IUHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               IUHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2024/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2024/IUHH/index.tsx
@@ -36,7 +36,7 @@ export const IUHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/LSCCH/index.tsx
+++ b/services/ui-src/src/measures/2024/LSCCH/index.tsx
@@ -52,7 +52,7 @@ export const LSCCH = ({
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2024/LSCCH/index.tsx
+++ b/services/ui-src/src/measures/2024/LSCCH/index.tsx
@@ -42,7 +42,7 @@ export const LSCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2024/OEVCH/index.tsx
+++ b/services/ui-src/src/measures/2024/OEVCH/index.tsx
@@ -43,7 +43,7 @@ export const OEVCH = ({
           <CMQ.MeasurementSpecification type={DC.ADA_DQA} coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -53,7 +53,7 @@ export const OEVCH = ({
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2024/OHDAD/index.tsx
+++ b/services/ui-src/src/measures/2024/OHDAD/index.tsx
@@ -56,7 +56,7 @@ export const OHDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/OUDAD/index.tsx
+++ b/services/ui-src/src/measures/2024/OUDAD/index.tsx
@@ -55,7 +55,7 @@ export const OUDAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/OUDHH/index.tsx
+++ b/services/ui-src/src/measures/2024/OUDHH/index.tsx
@@ -42,7 +42,7 @@ export const OUDHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -50,13 +50,13 @@ export const OUDHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2024/PCRHH/index.tsx
@@ -38,7 +38,7 @@ export const PCRHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <PCRHHPerformanceMeasure data={PMD.data} />
@@ -46,7 +46,7 @@ export const PCRHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && <NotCollectingOMS year={year} />}
         </>
       )}

--- a/services/ui-src/src/measures/2024/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2024/PCRHH/index.tsx
@@ -28,7 +28,7 @@ export const PCRHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
         removeLessThan30
       />
 

--- a/services/ui-src/src/measures/2024/PPC2AD/index.tsx
+++ b/services/ui-src/src/measures/2024/PPC2AD/index.tsx
@@ -56,8 +56,8 @@ export const PPC2AD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/PPC2CH/index.tsx
+++ b/services/ui-src/src/measures/2024/PPC2CH/index.tsx
@@ -56,8 +56,8 @@ export const PPC2CH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/PPC2CH/index.tsx
+++ b/services/ui-src/src/measures/2024/PPC2CH/index.tsx
@@ -43,7 +43,7 @@ export const PPC2CH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2024/PQI01AD/index.tsx
+++ b/services/ui-src/src/measures/2024/PQI01AD/index.tsx
@@ -70,7 +70,7 @@ export const PQI01AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2024/PQI05AD/index.tsx
+++ b/services/ui-src/src/measures/2024/PQI05AD/index.tsx
@@ -70,7 +70,7 @@ export const PQI05AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2024/PQI08AD/index.tsx
+++ b/services/ui-src/src/measures/2024/PQI08AD/index.tsx
@@ -70,7 +70,7 @@ export const PQI08AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2024/PQI15AD/index.tsx
+++ b/services/ui-src/src/measures/2024/PQI15AD/index.tsx
@@ -69,7 +69,7 @@ export const PQI15AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2024/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2024/PQI92HH/index.tsx
@@ -44,7 +44,7 @@ export const PQI92HH = ({
           <CMQ.MeasurementSpecification type="AHRQ" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -64,7 +64,7 @@ export const PQI92HH = ({
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -72,7 +72,7 @@ export const PQI92HH = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               allowNumeratorGreaterThanDenominator
               calcTotal
             />

--- a/services/ui-src/src/measures/2024/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2024/PQI92HH/index.tsx
@@ -35,7 +35,7 @@ export const PQI92HH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2024/SAAAD/index.tsx
+++ b/services/ui-src/src/measures/2024/SAAAD/index.tsx
@@ -56,7 +56,7 @@ export const SAAAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/SFMCH/index.tsx
+++ b/services/ui-src/src/measures/2024/SFMCH/index.tsx
@@ -43,7 +43,7 @@ export const SFMCH = ({
           <CMQ.MeasurementSpecification type="ADA-DQA" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
@@ -56,7 +56,7 @@ export const SFMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/SSDAD/index.tsx
+++ b/services/ui-src/src/measures/2024/SSDAD/index.tsx
@@ -56,7 +56,7 @@ export const SSDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/SSHH/index.tsx
+++ b/services/ui-src/src/measures/2024/SSHH/index.tsx
@@ -29,7 +29,7 @@ export const SSHH = ({
       <CMQ.StatusOfData />
       <CMQ.DataSource data={PMD.dataSourceData} />
       <CMQ.DateRange type="health" />
-      <CMQ.DefinitionOfPopulation healthHomeMeasure hybridMeasure />
+      <CMQ.DefinitionOfPopulation coreset="health" hybridMeasure />
       <PerformanceMeasure hybridMeasure />
       <CMQ.AdditionalNotes />
     </>

--- a/services/ui-src/src/measures/2024/TFLCH/index.tsx
+++ b/services/ui-src/src/measures/2024/TFLCH/index.tsx
@@ -43,7 +43,7 @@ export const TFLCH = ({
           <CMQ.MeasurementSpecification type="ADA-DQA" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const TFLCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2024/W30CH/index.tsx
+++ b/services/ui-src/src/measures/2024/W30CH/index.tsx
@@ -43,7 +43,7 @@ export const W30CH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
@@ -56,7 +56,7 @@ export const W30CH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2024/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2024/WCCCH/index.tsx
@@ -56,7 +56,7 @@ export const WCCCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2024/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2024/WCCCH/index.tsx
@@ -43,7 +43,7 @@ export const WCCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2024/WCVCH/index.tsx
+++ b/services/ui-src/src/measures/2024/WCVCH/index.tsx
@@ -43,7 +43,7 @@ export const WCVCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const WCVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2025/AABAD/index.tsx
+++ b/services/ui-src/src/measures/2025/AABAD/index.tsx
@@ -67,7 +67,7 @@ export const AABAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
               rateCalc={AABRateCalculation}
               customPrompt={PMD.data.customPrompt}
             />

--- a/services/ui-src/src/measures/2025/AABCH/index.tsx
+++ b/services/ui-src/src/measures/2025/AABCH/index.tsx
@@ -46,7 +46,7 @@ export const AABCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -66,7 +66,7 @@ export const AABCH = ({
           )}
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               customMask={mask}

--- a/services/ui-src/src/measures/2025/ADDCH/index.tsx
+++ b/services/ui-src/src/measures/2025/ADDCH/index.tsx
@@ -43,7 +43,7 @@ export const ADDCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -56,7 +56,7 @@ export const ADDCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2025/AIFHH/index.tsx
@@ -36,7 +36,7 @@ export const AIFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2025/AIFHH/index.tsx
+++ b/services/ui-src/src/measures/2025/AIFHH/index.tsx
@@ -45,7 +45,7 @@ export const AIFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -62,7 +62,7 @@ export const AIFHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -71,7 +71,7 @@ export const AIFHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               AIFHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2025/AMMAD/index.tsx
+++ b/services/ui-src/src/measures/2025/AMMAD/index.tsx
@@ -57,7 +57,7 @@ export const AMMAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/AMRAD/index.tsx
+++ b/services/ui-src/src/measures/2025/AMRAD/index.tsx
@@ -103,7 +103,7 @@ export const AMRAD = ({
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal={true}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/AMRCH/index.tsx
+++ b/services/ui-src/src/measures/2025/AMRCH/index.tsx
@@ -43,7 +43,7 @@ export const AMRCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const AMRCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2025/APMCH/index.tsx
+++ b/services/ui-src/src/measures/2025/APMCH/index.tsx
@@ -43,7 +43,7 @@ export const APMCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const APMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2025/APPCH/index.tsx
+++ b/services/ui-src/src/measures/2025/APPCH/index.tsx
@@ -43,7 +43,7 @@ export const APPCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const APPCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2025/BCSAD/index.tsx
+++ b/services/ui-src/src/measures/2025/BCSAD/index.tsx
@@ -56,8 +56,8 @@ export const BCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CBPAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CBPAD/index.tsx
@@ -56,7 +56,7 @@ export const CBPAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2025/CBPHH/index.tsx
@@ -52,13 +52,13 @@ export const CBPHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2025/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2025/CBPHH/index.tsx
@@ -44,7 +44,7 @@ export const CBPHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation hybridMeasure healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure calcTotal />

--- a/services/ui-src/src/measures/2025/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2025/CBPHH/index.tsx
@@ -35,7 +35,7 @@ export const CBPHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2025/CCPAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CCPAD/index.tsx
@@ -56,8 +56,8 @@ export const CCPAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CCPCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CCPCH/index.tsx
@@ -44,7 +44,7 @@ export const CCPCH = ({
           <CMQ.MeasurementSpecification type="OPA" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -54,9 +54,9 @@ export const CCPCH = ({
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               categories={PMD.categories}
-              isSingleSex={true}
+              excludeOptions={["O8BrOa"]}
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
             />

--- a/services/ui-src/src/measures/2025/CCSAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CCSAD/index.tsx
@@ -56,8 +56,8 @@ export const CCSAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CCWAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CCWAD/index.tsx
@@ -56,8 +56,8 @@ export const CCWAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CCWCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CCWCH/index.tsx
@@ -43,7 +43,7 @@ export const CCWCH = ({
           <CMQ.MeasurementSpecification type="OPA" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -56,8 +56,8 @@ export const CCWCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CDFAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CDFAD/index.tsx
@@ -56,7 +56,7 @@ export const CDFAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CDFCH/index.tsx
@@ -56,7 +56,7 @@ export const CDFCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CDFCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CDFCH/index.tsx
@@ -43,7 +43,7 @@ export const CDFCH = ({
           <CMQ.MeasurementSpecification type="CMS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2025/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2025/CDFHH/index.tsx
@@ -34,7 +34,7 @@ export const CDFHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2025/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2025/CDFHH/index.tsx
@@ -43,7 +43,7 @@ export const CDFHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -57,14 +57,14 @@ export const CDFHH = ({
           {isOtherMeasureSpecSelected && (
             <CMQ.OtherPerformanceMeasure rateMultiplicationValue={100} />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               rateMultiplicationValue={100}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2025/CHLAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CHLAD/index.tsx
@@ -56,8 +56,8 @@ export const CHLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CHLCH/index.tsx
@@ -56,8 +56,8 @@ export const CHLCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CHLCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CHLCH/index.tsx
@@ -43,7 +43,7 @@ export const CHLCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2025/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CISCH/index.tsx
@@ -56,7 +56,7 @@ export const CISCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CISCH/index.tsx
@@ -43,7 +43,7 @@ export const CISCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/COBAD/index.tsx
+++ b/services/ui-src/src/measures/2025/COBAD/index.tsx
@@ -56,7 +56,7 @@ export const COBAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/COLAD/index.tsx
+++ b/services/ui-src/src/measures/2025/COLAD/index.tsx
@@ -56,7 +56,7 @@ export const COLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/COLHH/index.tsx
+++ b/services/ui-src/src/measures/2025/COLHH/index.tsx
@@ -44,7 +44,7 @@ export const COLHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -52,13 +52,13 @@ export const COLHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/COLHH/index.tsx
+++ b/services/ui-src/src/measures/2025/COLHH/index.tsx
@@ -35,7 +35,7 @@ export const COLHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2025/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2025/DEVCH/index.tsx
@@ -43,7 +43,7 @@ export const DEVCH = ({
           <CMQ.MeasurementSpecification type="OHSU" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2025/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2025/DEVCH/index.tsx
@@ -56,7 +56,7 @@ export const DEVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2025/FUAAD/index.tsx
+++ b/services/ui-src/src/measures/2025/FUAAD/index.tsx
@@ -56,7 +56,7 @@ export const FUAAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/FUACH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUACH/index.tsx
@@ -43,7 +43,7 @@ export const FUACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -56,7 +56,7 @@ export const FUACH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUAHH/index.tsx
@@ -44,7 +44,7 @@ export const FUAHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -52,13 +52,13 @@ export const FUAHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2025/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUAHH/index.tsx
@@ -35,7 +35,7 @@ export const FUAHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2025/FUHAD/index.tsx
+++ b/services/ui-src/src/measures/2025/FUHAD/index.tsx
@@ -56,7 +56,7 @@ export const FUHAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={true}
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUHCH/index.tsx
@@ -43,7 +43,7 @@ export const FUHCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2025/FUHCH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUHCH/index.tsx
@@ -56,7 +56,7 @@ export const FUHCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUHHH/index.tsx
@@ -35,7 +35,7 @@ export const FUHHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2025/FUHHH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUHHH/index.tsx
@@ -44,7 +44,7 @@ export const FUHHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
@@ -52,13 +52,13 @@ export const FUHHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
             />
           )}

--- a/services/ui-src/src/measures/2025/FUMAD/index.tsx
+++ b/services/ui-src/src/measures/2025/FUMAD/index.tsx
@@ -55,7 +55,7 @@ export const FUMAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUMCH/index.tsx
@@ -43,7 +43,7 @@ export const FUMCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />

--- a/services/ui-src/src/measures/2025/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUMCH/index.tsx
@@ -56,7 +56,7 @@ export const FUMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/FUMHH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUMHH/index.tsx
@@ -44,7 +44,7 @@ export const FUMHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure calcTotal data={PMD.data} />
@@ -54,10 +54,10 @@ export const FUMHH = ({
           {isOtherMeasureSpecSelected && (
             <CMQ.OtherPerformanceMeasure rateMultiplicationValue={100} />
           )}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="health"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2025/FUMHH/index.tsx
+++ b/services/ui-src/src/measures/2025/FUMHH/index.tsx
@@ -35,7 +35,7 @@ export const FUMHH = ({
         measureAbbreviation={measureId}
         measureName={name}
         reportingYear={year}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2025/HBDAD/index.tsx
+++ b/services/ui-src/src/measures/2025/HBDAD/index.tsx
@@ -56,7 +56,7 @@ export const HBDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/HPCMIAD/index.tsx
+++ b/services/ui-src/src/measures/2025/HPCMIAD/index.tsx
@@ -56,7 +56,7 @@ export const HPCMIAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/HVLAD/index.tsx
+++ b/services/ui-src/src/measures/2025/HVLAD/index.tsx
@@ -56,7 +56,7 @@ export const HVLAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/IETAD/index.tsx
+++ b/services/ui-src/src/measures/2025/IETAD/index.tsx
@@ -60,7 +60,7 @@ export const IETAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2025/IETHH/index.tsx
@@ -35,7 +35,7 @@ export const IETHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2025/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2025/IETHH/index.tsx
@@ -44,7 +44,7 @@ export const IETHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -56,14 +56,14 @@ export const IETHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
               calcTotal
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2025/IMACH/index.tsx
@@ -56,7 +56,7 @@ export const IMACH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2025/IMACH/index.tsx
@@ -43,7 +43,7 @@ export const IMACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2025/IUHH/index.tsx
@@ -45,7 +45,7 @@ export const IUHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure={true} />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure
@@ -62,7 +62,7 @@ export const IUHH = ({
               customMask={xNumbersYDecimals(12, 1)}
             />
           )}
-          <CMQ.CombinedRates healthHomeMeasure={true} />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
@@ -71,7 +71,7 @@ export const IUHH = ({
               inputFieldNames={PMD.data.inputFieldNames}
               ndrFormulas={PMD.data.ndrFormulas}
               allowNumeratorGreaterThanDenominator
-              adultMeasure={false}
+              coreset="health"
               calcTotal={true}
               customMask={xNumbersYDecimals(12, 1)}
               IUHHPerformanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2025/IUHH/index.tsx
+++ b/services/ui-src/src/measures/2025/IUHH/index.tsx
@@ -36,7 +36,7 @@ export const IUHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2025/LSCCH/index.tsx
+++ b/services/ui-src/src/measures/2025/LSCCH/index.tsx
@@ -52,7 +52,7 @@ export const LSCCH = ({
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2025/LSCCH/index.tsx
+++ b/services/ui-src/src/measures/2025/LSCCH/index.tsx
@@ -42,7 +42,7 @@ export const LSCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/OEVCH/index.tsx
+++ b/services/ui-src/src/measures/2025/OEVCH/index.tsx
@@ -43,7 +43,7 @@ export const OEVCH = ({
           <CMQ.MeasurementSpecification type={DC.ADA_DQA} coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -53,7 +53,7 @@ export const OEVCH = ({
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
-              adultMeasure={false}
+              coreset="child"
               calcTotal
               categories={PMD.categories}
               performanceMeasureArray={performanceMeasureArray}

--- a/services/ui-src/src/measures/2025/OHDAD/index.tsx
+++ b/services/ui-src/src/measures/2025/OHDAD/index.tsx
@@ -56,7 +56,7 @@ export const OHDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/OUDAD/index.tsx
+++ b/services/ui-src/src/measures/2025/OUDAD/index.tsx
@@ -55,7 +55,7 @@ export const OUDAD = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/OUDHH/index.tsx
+++ b/services/ui-src/src/measures/2025/OUDHH/index.tsx
@@ -42,7 +42,7 @@ export const OUDHH = ({
           <CMQ.MeasurementSpecification type="CMS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} />
@@ -50,13 +50,13 @@ export const OUDHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && (
             <CMQ.OptionalMeasureStrat
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="health"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2025/PCRHH/index.tsx
@@ -38,7 +38,7 @@ export const PCRHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation healthHomeMeasure />
+          <CMQ.DefinitionOfPopulation coreset="health" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <PCRHHPerformanceMeasure data={PMD.data} />
@@ -46,7 +46,7 @@ export const PCRHH = ({
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
-          <CMQ.CombinedRates healthHomeMeasure />
+          <CMQ.CombinedRates coreset="health" />
           {showOptionalMeasureStrat && <NotCollectingOMS year={year} />}
         </>
       )}

--- a/services/ui-src/src/measures/2025/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2025/PCRHH/index.tsx
@@ -28,7 +28,7 @@ export const PCRHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
-        healthHomeMeasure
+        coreset="health"
         removeLessThan30
       />
 

--- a/services/ui-src/src/measures/2025/PPC2AD/index.tsx
+++ b/services/ui-src/src/measures/2025/PPC2AD/index.tsx
@@ -56,8 +56,8 @@ export const PPC2AD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
-              isSingleSex
+              coreset="adult"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/PPC2CH/index.tsx
+++ b/services/ui-src/src/measures/2025/PPC2CH/index.tsx
@@ -56,8 +56,8 @@ export const PPC2CH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
-              isSingleSex
+              coreset="child"
+              excludeOptions={["O8BrOa"]}
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/PPC2CH/index.tsx
+++ b/services/ui-src/src/measures/2025/PPC2CH/index.tsx
@@ -43,7 +43,7 @@ export const PPC2CH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure={true} hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/PQI01AD/index.tsx
+++ b/services/ui-src/src/measures/2025/PQI01AD/index.tsx
@@ -70,7 +70,7 @@ export const PQI01AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2025/PQI05AD/index.tsx
+++ b/services/ui-src/src/measures/2025/PQI05AD/index.tsx
@@ -70,7 +70,7 @@ export const PQI05AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2025/PQI08AD/index.tsx
+++ b/services/ui-src/src/measures/2025/PQI08AD/index.tsx
@@ -70,7 +70,7 @@ export const PQI08AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2025/PQI15AD/index.tsx
+++ b/services/ui-src/src/measures/2025/PQI15AD/index.tsx
@@ -69,7 +69,7 @@ export const PQI15AD = ({
               rateMultiplicationValue={100000}
               customMask={positiveNumbersWithMaxDecimalPlaces(1)}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure
+              coreset="adult"
               allowNumeratorGreaterThanDenominator
             />
           )}

--- a/services/ui-src/src/measures/2025/SAAAD/index.tsx
+++ b/services/ui-src/src/measures/2025/SAAAD/index.tsx
@@ -56,7 +56,7 @@ export const SAAAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/SFMCH/index.tsx
+++ b/services/ui-src/src/measures/2025/SFMCH/index.tsx
@@ -43,7 +43,7 @@ export const SFMCH = ({
           <CMQ.MeasurementSpecification type="ADA-DQA" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
@@ -56,7 +56,7 @@ export const SFMCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/SSDAD/index.tsx
+++ b/services/ui-src/src/measures/2025/SSDAD/index.tsx
@@ -56,7 +56,7 @@ export const SSDAD = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure
+              coreset="adult"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/SSHH/index.tsx
+++ b/services/ui-src/src/measures/2025/SSHH/index.tsx
@@ -29,7 +29,7 @@ export const SSHH = ({
       <CMQ.StatusOfData />
       <CMQ.DataSource data={PMD.dataSourceData} />
       <CMQ.DateRange type="health" />
-      <CMQ.DefinitionOfPopulation healthHomeMeasure hybridMeasure />
+      <CMQ.DefinitionOfPopulation coreset="health" hybridMeasure />
       <PerformanceMeasure />
       <CMQ.AdditionalNotes />
     </>

--- a/services/ui-src/src/measures/2025/TFLCH/index.tsx
+++ b/services/ui-src/src/measures/2025/TFLCH/index.tsx
@@ -43,7 +43,7 @@ export const TFLCH = ({
           <CMQ.MeasurementSpecification type="ADA-DQA" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const TFLCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2025/W30CH/index.tsx
+++ b/services/ui-src/src/measures/2025/W30CH/index.tsx
@@ -43,7 +43,7 @@ export const W30CH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
@@ -56,7 +56,7 @@ export const W30CH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
             />
           )}
         </>

--- a/services/ui-src/src/measures/2025/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2025/WCCCH/index.tsx
@@ -56,7 +56,7 @@ export const WCCCH = ({
               categories={PMD.categories}
               qualifiers={PMD.qualifiers}
               performanceMeasureArray={performanceMeasureArray}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/measures/2025/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2025/WCCCH/index.tsx
@@ -43,7 +43,7 @@ export const WCCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure hybridMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2025/WCVCH/index.tsx
+++ b/services/ui-src/src/measures/2025/WCVCH/index.tsx
@@ -43,7 +43,7 @@ export const WCVCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation childMeasure />
+          <CMQ.DefinitionOfPopulation coreset="child" />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
@@ -56,7 +56,7 @@ export const WCVCH = ({
               performanceMeasureArray={performanceMeasureArray}
               qualifiers={PMD.qualifiers}
               categories={PMD.categories}
-              adultMeasure={false}
+              coreset="child"
               calcTotal
             />
           )}

--- a/services/ui-src/src/shared/commonQuestions/CombinedRates.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRates.test.tsx
@@ -100,7 +100,7 @@ describe("Test CombinedRates component for Health Homes", () => {
   beforeEach(() => {
     renderWithHookForm(
       <SharedContext.Provider value={{ ...commonQuestionsLabel, year: 2023 }}>
-        <CombinedRates healthHomeMeasure />
+        <CombinedRates coreset="health" />
       </SharedContext.Provider>
     );
   });

--- a/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
+++ b/services/ui-src/src/shared/commonQuestions/CombinedRates.tsx
@@ -7,18 +7,19 @@ import { useContext } from "react";
 import SharedContext from "shared/SharedContext";
 
 interface Props {
-  healthHomeMeasure?: boolean;
+  coreset?: string;
 }
 
-export const CombinedRates = ({ healthHomeMeasure }: Props) => {
+export const CombinedRates = ({ coreset }: Props) => {
   const register = useCustomRegister<Types.CombinedRates>();
 
   //WIP: using form context to get the labels for this component temporarily.
   const labels: any = useContext(SharedContext);
 
-  const combinedLabel = healthHomeMeasure
-    ? labels.CombinedRates?.healthHome
-    : labels.CombinedRates?.notHealthHome;
+  const combinedLabel =
+    coreset === "health"
+      ? labels.CombinedRates?.healthHome
+      : labels.CombinedRates?.notHealthHome;
 
   return (
     <>

--- a/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
@@ -14,11 +14,10 @@ import { AnyObject } from "types";
 import { useParams } from "react-router-dom";
 
 interface Props {
-  childMeasure?: boolean;
   hybridMeasure?: boolean;
   populationSampleSize?: boolean;
-  healthHomeMeasure?: boolean;
   coreSetOptions?: CoreSetSpecificOptions;
+  coreset: string;
 }
 interface DefOfDenomOption {
   displayValue: string;
@@ -401,11 +400,10 @@ const HybridDefinitions = (register: any, header: boolean = true) => {
 };
 
 export const DefinitionOfPopulation = ({
-  childMeasure,
   populationSampleSize,
   hybridMeasure,
-  healthHomeMeasure,
   coreSetOptions,
+  coreset,
 }: Props) => {
   const register = useCustomRegister<Types.DefinitionOfPopulation>();
 
@@ -413,6 +411,8 @@ export const DefinitionOfPopulation = ({
   const labels: any = useContext(SharedContext);
 
   const params = useParams();
+  const childMeasure = coreset === "child";
+  const healthHomeMeasure = coreset === "health";
   const coreSetType = healthHomeMeasure ? "HHCS" : params.coreSetId;
 
   return (

--- a/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
@@ -17,7 +17,7 @@ interface Props {
   hybridMeasure?: boolean;
   populationSampleSize?: boolean;
   coreSetOptions?: CoreSetSpecificOptions;
-  coreset: string;
+  coreset?: string;
 }
 interface DefOfDenomOption {
   displayValue: string;

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
@@ -1,10 +1,10 @@
 import { OmsNode } from "shared/types";
 
-export const OMSData = (year: number, adultMeasure?: boolean): OmsNode[] => {
+export const OMSData = (year: number, coreset?: string): OmsNode[] => {
   switch (Number(year)) {
     case 2021:
     case 2022:
-      return dataLegacy(adultMeasure);
+      return dataLegacy(coreset === "adult");
     default:
       return data();
   }

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
@@ -1,10 +1,10 @@
 import { OmsNode } from "shared/types";
 
-export const OMSData = (year: number, coreset?: string): OmsNode[] => {
+export const OMSData = (year: number, adultMeasure?: boolean): OmsNode[] => {
   switch (Number(year)) {
     case 2021:
     case 2022:
-      return dataLegacy(coreset === "adult");
+      return dataLegacy(adultMeasure);
     default:
       return data();
   }

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/index.tsx
@@ -16,8 +16,8 @@ interface OmsCheckboxProps {
   name: string;
   /** data object for dynamic rendering */
   data: Types.OmsNode[];
-  isSingleSex: boolean;
   year: number;
+  excludeOptions: string[];
 }
 
 /**
@@ -27,11 +27,11 @@ interface OmsCheckboxProps {
 export const buildOmsCheckboxes = ({
   name,
   data,
-  isSingleSex,
+  excludeOptions,
   year,
 }: OmsCheckboxProps) => {
   return data
-    .filter((d) => !isSingleSex || (d.id !== "O8BrOa" && d.id !== "Sex")) // remove sex as a top level option if isSingleSex
+    .filter((d) => !excludeOptions.find((options) => options === d.id)) //remove any options the measure wants to exclude
     .map((lvlOneOption) => {
       const displayValue = lvlOneOption.label;
       const value = cleanString(lvlOneOption.id);
@@ -69,7 +69,7 @@ interface BaseProps extends Types.Qualifiers, Types.Categories {
   rateMultiplicationValue?: number;
   allowNumeratorGreaterThanDenominator?: boolean;
   customMask?: RegExp;
-  isSingleSex?: boolean;
+  excludeOptions?: string[];
   rateAlwaysEditable?: boolean;
   numberOfDecimals?: number;
   componentFlag?: ComponentFlagType;
@@ -85,13 +85,13 @@ interface DataDrivenProp {
   /** data array for dynamic rendering */
   data: Types.OmsNode[];
   /** cannot set adultMeasure if using custom data*/
-  adultMeasure?: never;
+  coreset?: never;
 }
 
 /** default data is being used for this component */
 interface DefaultDataProp {
   /** is this an adult measure? Should this contain the ACA portion? */
-  adultMeasure: boolean;
+  coreset: string;
   /** cannot set data if using default data */
   data?: never;
 }
@@ -132,11 +132,11 @@ export const OptionalMeasureStrat = ({
   ndrFormulas,
   data,
   calcTotal = false,
-  adultMeasure,
+  coreset,
   rateMultiplicationValue,
   allowNumeratorGreaterThanDenominator = false,
   customMask,
-  isSingleSex = false,
+  excludeOptions = [],
   rateAlwaysEditable,
   numberOfDecimals = 1,
   componentFlag = "DEFAULT",
@@ -150,7 +150,7 @@ export const OptionalMeasureStrat = ({
   const labels: any = useContext(SharedContext);
   const year = labels.year;
 
-  const omsData = data ?? OMSData(year, adultMeasure);
+  const omsData = data ?? OMSData(year, coreset);
   const { control, watch, getValues, setValue, unregister } =
     useFormContext<OMSType>();
   const values = getValues();
@@ -167,7 +167,7 @@ export const OptionalMeasureStrat = ({
   const checkBoxOptions = buildOmsCheckboxes({
     ...register("OptionalMeasureStratification"),
     data: omsData,
-    isSingleSex,
+    excludeOptions,
     year,
   });
 

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/index.tsx
@@ -150,7 +150,7 @@ export const OptionalMeasureStrat = ({
   const labels: any = useContext(SharedContext);
   const year = labels.year;
 
-  const omsData = data ?? OMSData(year, coreset);
+  const omsData = data ?? OMSData(year, coreset === "adult");
   const { control, watch, getValues, setValue, unregister } =
     useFormContext<OMSType>();
   const values = getValues();

--- a/services/ui-src/src/shared/commonQuestions/Reporting.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/Reporting.test.tsx
@@ -53,7 +53,7 @@ describe("Test Reporting component on a Health Home Measure", () => {
         measureName="My Test Measure"
         reportingYear="2021"
         measureAbbreviation="MTM"
-        healthHomeMeasure
+        coreset="health"
       />
     );
   });

--- a/services/ui-src/src/shared/commonQuestions/Reporting.tsx
+++ b/services/ui-src/src/shared/commonQuestions/Reporting.tsx
@@ -10,7 +10,7 @@ interface Props {
   measureName: string;
   measureAbbreviation: string;
   reportingYear: string;
-  healthHomeMeasure?: boolean;
+  coreset?: string;
   removeLessThan30?: boolean;
 }
 
@@ -18,7 +18,7 @@ export const Reporting = ({
   measureName,
   reportingYear,
   measureAbbreviation,
-  healthHomeMeasure,
+  coreset,
   removeLessThan30,
 }: Props) => {
   const register = useCustomRegister<Types.DidReport>();
@@ -51,7 +51,7 @@ export const Reporting = ({
       </QMR.CoreQuestionWrapper>
       {watchRadioStatus === DC.NO && (
         <WhyAreYouNotReporting
-          healthHomeMeasure={healthHomeMeasure}
+          coreset={coreset}
           removeLessThan30={removeLessThan30}
         />
       )}

--- a/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.test.tsx
@@ -180,7 +180,7 @@ describe(`Options`, () => {
 
 describe("WhyAreYouNotReporting component, Health Homes", () => {
   beforeEach(() => {
-    renderWithHookForm(<WhyAreYouNotReporting healthHomeMeasure />);
+    renderWithHookForm(<WhyAreYouNotReporting coreset="health" />);
   });
 
   it("renders the Health Homes version of the component", () => {

--- a/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.tsx
+++ b/services/ui-src/src/shared/commonQuestions/WhyAreYouNotReporting.tsx
@@ -7,18 +7,16 @@ import SharedContext from "shared/SharedContext";
 import { featuresByYear } from "utils/featuresByYear";
 
 interface Props {
-  healthHomeMeasure?: boolean;
+  coreset?: string;
   removeLessThan30?: boolean;
 }
 
-export const WhyAreYouNotReporting = ({
-  healthHomeMeasure,
-  removeLessThan30,
-}: Props) => {
+export const WhyAreYouNotReporting = ({ coreset, removeLessThan30 }: Props) => {
   //WIP: using form context to get the labels for this component temporarily.
   const labels: any = useContext(SharedContext);
 
   const register = useCustomRegister<Types.WhyAreYouNotReporting>();
+  const healthHomeMeasure = coreset === "health";
 
   return (
     <QMR.CoreQuestionWrapper


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The first stage of removing the index.tsx files in each measure. This isn't a necessary step but I wanted to centralizing some of the prop values to being more generic.

Mostly by removing any boolean props like these and changing it to be a coreset string prop
![Screenshot 2024-11-26 at 3 27 49 PM](https://github.com/user-attachments/assets/39de849e-d643-4fc0-ba36-cf11731ade2f)

All the index.tsx files that got updated just looks like this
![Screenshot 2024-11-26 at 3 32 43 PM](https://github.com/user-attachments/assets/c51f50a9-a13f-4d1a-b4a2-aecfbcea3972)

Note: I also made an update in the OMS section to let it exclude any options instead of just excluding the gender

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->


---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any user with healthhomes like [stateuserWA@test.com](mailto:stateuserDC@test.com)
2) In Reporting Year 2025, go to BCS-AD
3) Fill out BCS-AD and unlock the Optional Measure Stratification
4) BCS-AD does not break stratification down by sexes so the OMS should look like this
 
![Screenshot 2024-12-10 at 12 07 40 PM](https://github.com/user-attachments/assets/d6d20fbd-256a-47f2-b755-fead645a32c0)


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
