### PR TITLE
New Measure Page: LRCD-AD

### DIFF
--- a/services/app-api/handlers/dynamoUtils/measureList.ts
+++ b/services/app-api/handlers/dynamoUtils/measureList.ts
@@ -1487,6 +1487,7 @@ export const measures: Measure = {
     {
       type: "A",
       measure: "LRCD-AD",
+      autocompleteOnCreation: true,
     },
     {
       type: "A",

--- a/services/ui-src/src/measures/2025/LRCDAD/index.test.tsx
+++ b/services/ui-src/src/measures/2025/LRCDAD/index.test.tsx
@@ -1,0 +1,88 @@
+import { screen, waitFor, act } from "@testing-library/react";
+import { createElement } from "react";
+import { RouterWrappedComp } from "utils/testing";
+import { MeasureWrapper } from "components/MeasureWrapper";
+import { useApiMock } from "utils/testUtils/useApiMock";
+import { useUser } from "hooks/authHooks";
+import Measures from "measures";
+import { Suspense } from "react";
+import { MeasuresLoading } from "views";
+import { measureDescriptions } from "measures/measureDescriptions";
+import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
+import { clearMocks } from "shared/util/validationsMock";
+import { axe, toHaveNoViolations } from "jest-axe";
+expect.extend(toHaveNoViolations);
+
+// Test Setup
+const measureAbbr = "LRCD-AD";
+const coreSet = "ACSC";
+const state = "AL";
+const year = 2025;
+const description = measureDescriptions[`${year}`][measureAbbr];
+const apiData: any = {};
+
+jest.mock("hooks/authHooks");
+const mockUseUser = useUser as jest.Mock;
+
+describe(`Test FFY ${year} ${measureAbbr}`, () => {
+  let component: JSX.Element;
+  beforeEach(() => {
+    clearMocks();
+    apiData.useGetMeasureValues = {
+      data: {
+        Item: {
+          compoundKey: `${state}${year}${coreSet}${measureAbbr}`,
+          coreSet,
+          createdAt: 1642517935305,
+          description,
+          lastAltered: 1642517935305,
+          lastAlteredBy: "undefined",
+          measure: measureAbbr,
+          state,
+          status: "incomplete",
+          year,
+          data: {},
+        },
+      },
+      isLoading: false,
+      refetch: jest.fn(),
+      isError: false,
+      error: undefined,
+    };
+
+    mockUseUser.mockImplementation(() => {
+      return { isStateUser: false };
+    });
+
+    const measure = createElement(Measures[year][measureAbbr]);
+    component = (
+      <Suspense fallback={MeasuresLoading()}>
+        <RouterWrappedComp>
+          <MeasureWrapper
+            measure={measure}
+            name={description}
+            year={`${year}`}
+            measureId={measureAbbr}
+          />
+        </RouterWrappedComp>
+      </Suspense>
+    );
+  });
+
+  it("measure should render", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.getByTestId("measure-wrapper-form")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText(measureAbbr + " - " + description));
+    });
+  });
+
+  it("should pass a11y tests", async () => {
+    useApiMock(apiData);
+    await act(async () => {
+      const { container } = renderWithHookForm(component);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/services/ui-src/src/measures/2025/LRCDAD/index.tsx
+++ b/services/ui-src/src/measures/2025/LRCDAD/index.tsx
@@ -1,0 +1,17 @@
+import * as QMR from "components";
+
+interface Props {
+  name: string;
+  year: string;
+}
+
+export const LRCDAD = ({ name, year }: Props) => {
+  return (
+    <QMR.AutocompletedMeasureTemplate
+      year={year}
+      measureTitle={`LRCD-AD - ${name}`}
+      performanceMeasureText=""
+      performanceMeasureSubtext=""
+    />
+  );
+};

--- a/services/ui-src/src/measures/2025/LRCDAD/index.tsx
+++ b/services/ui-src/src/measures/2025/LRCDAD/index.tsx
@@ -10,8 +10,11 @@ export const LRCDAD = ({ name, year }: Props) => {
     <QMR.AutocompletedMeasureTemplate
       year={year}
       measureTitle={`LRCD-AD - ${name}`}
-      performanceMeasureText=""
-      performanceMeasureSubtext=""
+      performanceMeasureText="Percentage of nulliparous (first birth), term (37 or more completed weeks based on the obstetric estimate), singleton (one fetus), in a cephalic presentation (head-first) births delivered by cesarean during the measurement year."
+      performanceMeasureSubtext="To reduce state burden and streamline reporting, CMS will calculate
+      this measure for states using state natality data obtained through
+      the Centers for Disease Control and Prevention Wide-ranging Online
+      Data for Epidemiologic Research (CDC WONDER)."
     />
   );
 };

--- a/services/ui-src/src/measures/2025/index.tsx
+++ b/services/ui-src/src/measures/2025/index.tsx
@@ -147,6 +147,9 @@ const IUHH = lazy(() =>
 const LBWCH = lazy(() =>
   import("./LBWCH").then((module) => ({ default: module.LBWCH }))
 );
+const LRCDAD = lazy(() =>
+  import("./LRCDAD").then((module) => ({ default: module.LRCDAD }))
+);
 const LRCDCH = lazy(() =>
   import("./LRCDCH").then((module) => ({ default: module.LRCDCH }))
 );
@@ -270,7 +273,7 @@ const twentyTwentyFiveMeasures = {
   "IMA-CH": IMACH,
   "IU-HH": IUHH,
   "LBW-CH": LBWCH,
-  // "LRCD-AD": LRCDAD, //TO DO: replace with real measure
+  "LRCD-AD": LRCDAD,
   "LRCD-CH": LRCDCH,
   "MSC-AD": MSCAD,
   "LSC-CH": LSCCH,

--- a/tests/cypress/cypress/e2e/userflow_adult.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_adult.spec.ts
@@ -70,7 +70,7 @@ describe("submit coreset", () => {
     // confirm reset
     cy.get('[data-cy="Status-AL2025"]').should(
       "contain.text",
-      "in progress1 of 39 complete"
+      "in progress2 of 39 complete"
     );
   });
 

--- a/tests/cypress/support/constants.ts
+++ b/tests/cypress/support/constants.ts
@@ -24,7 +24,7 @@ export const measureAbbrList2025 = {
     "HPCMI-AD",
     "HVL-AD",
     "IET-AD",
-    // "LRCD-AD", //TO-DO: turn on when measure has been added
+    "LRCD-AD",
     "MSC-AD",
     "NCIIDD-AD", // complete on creation
     // "OEVP-AD", //TO-DO: turn on when measure has been added


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR creates the page for LRCD-AD It is copied over from LRCD-CH and I stripped out any information that was related to OEV-CH.

According to Cam, any performance measure text and rateLabelText data will come at a later time.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4042

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any state user
2) In reporting year 2025, select any Adult Core Set Measures
3) Go to LRCD-AD  and see that it's an autocompleted measure
4) There should be no form fill on the page. It is missing text, that's suppose to come later

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
