### PR TITLE
New Measure Page: OEVP-AD & OEVP-CH

### DIFF
--- a/services/ui-src/src/measures/2025/OEVPAD/data.ts
+++ b/services/ui-src/src/measures/2025/OEVPAD/data.ts
@@ -4,9 +4,7 @@ import { getCatQualLabels } from "../rateLabelText";
 export const { categories, qualifiers } = getCatQualLabels("OEVP-AD");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
-  questionText: [
-    ".",
-  ],
+  questionText: ["."],
   categories,
   qualifiers,
 };

--- a/services/ui-src/src/measures/2025/OEVPAD/data.ts
+++ b/services/ui-src/src/measures/2025/OEVPAD/data.ts
@@ -1,0 +1,12 @@
+import { DataDrivenTypes } from "shared/types";
+import { getCatQualLabels } from "../rateLabelText";
+
+export const { categories, qualifiers } = getCatQualLabels("OEVP-AD");
+
+export const data: DataDrivenTypes.PerformanceMeasure = {
+  questionText: [
+    ".",
+  ],
+  categories,
+  qualifiers,
+};

--- a/services/ui-src/src/measures/2025/OEVPAD/index.test.tsx
+++ b/services/ui-src/src/measures/2025/OEVPAD/index.test.tsx
@@ -1,0 +1,242 @@
+import { screen, waitFor, act } from "@testing-library/react";
+import { createElement } from "react";
+import { RouterWrappedComp } from "utils/testing";
+import { MeasureWrapper } from "components/MeasureWrapper";
+import { useApiMock } from "utils/testUtils/useApiMock";
+import { useUser } from "hooks/authHooks";
+import Measures from "measures";
+import { Suspense } from "react";
+import { MeasuresLoading } from "views";
+import { measureDescriptions } from "measures/measureDescriptions";
+import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
+import { validationFunctions } from "./validation";
+import {
+  mockValidateAndSetErrors,
+  clearMocks,
+  validationsMockObj as V,
+} from "shared/util/validationsMock";
+import { axe, toHaveNoViolations } from "jest-axe";
+expect.extend(toHaveNoViolations);
+
+// Test Setup
+const measureAbbr = "OEVP-AD";
+const coreSet = "ACSC";
+const state = "AL";
+const year = 2025;
+const description = measureDescriptions[`${year}`][measureAbbr];
+const apiData: any = {};
+
+jest.mock("hooks/authHooks");
+const mockUseUser = useUser as jest.Mock;
+
+describe(`Test FFY ${year} ${measureAbbr}`, () => {
+  let component: JSX.Element;
+  beforeEach(() => {
+    clearMocks();
+    apiData.useGetMeasureValues = {
+      data: {
+        Item: {
+          compoundKey: `${state}${year}${coreSet}${measureAbbr}`,
+          coreSet,
+          createdAt: 1642517935305,
+          description,
+          lastAltered: 1642517935305,
+          lastAlteredBy: "undefined",
+          measure: measureAbbr,
+          state,
+          status: "incomplete",
+          year,
+          data: {},
+        },
+      },
+      isLoading: false,
+      refetch: jest.fn(),
+      isError: false,
+      error: undefined,
+    };
+
+    mockUseUser.mockImplementation(() => {
+      return { isStateUser: false };
+    });
+
+    const measure = createElement(Measures[year][measureAbbr]);
+    component = (
+      <Suspense fallback={MeasuresLoading()}>
+        <RouterWrappedComp>
+          <MeasureWrapper
+            measure={measure}
+            name={description}
+            year={`${year}`}
+            measureId={measureAbbr}
+          />
+        </RouterWrappedComp>
+      </Suspense>
+    );
+  });
+
+  it("should pass a11y tests", async () => {
+    useApiMock(apiData);
+    await act(async () => {
+      const { container } = renderWithHookForm(component);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  it("measure should render", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("measure-wrapper-form")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(measureAbbr + " - " + description));
+    });
+  });
+
+  /**
+   * Render the measure and confirm that all expected components exist.
+   * */
+  it("Always shows Are you reporting question", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("reporting"));
+  });
+
+  it("shows corresponding questions if yes to reporting then ", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("status-of-data")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("measurement-specification")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("data-source")).toBeInTheDocument();
+    expect(screen.queryByTestId("date-range")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("definition-of-population")
+    ).toBeInTheDocument();
+  });
+
+  it("does not show corresponding questions if no to reporting then ", async () => {
+    apiData.useGetMeasureValues.data.Item.data = notReportingData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("status-of-data")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("measurement-specification")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("data-source")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("date-range")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("definition-of-population")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows corresponding components and hides others when primary measure is selected", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("performance-measure")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("deviation-from-measure-specification")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("OPM")).not.toBeInTheDocument();
+  });
+
+  it("shows corresponding components and hides others when primary measure is NOT selected", async () => {
+    apiData.useGetMeasureValues.data.Item.data = OPMData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("OPM"));
+    expect(screen.queryByTestId("performance-measure")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("deviation-from-measure-specification")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows OMS when performance measure data has been entered", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("OMS"));
+  });
+  it("does not show OMS when performance measure data has been entered", async () => {
+    apiData.useGetMeasureValues.data.Item.data = notReportingData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("OMS")).not.toBeInTheDocument();
+  });
+
+  /** Validations Test
+   *
+   * Confirm that correct functions are called. Comprehensive testing of the validations is done in specific test files
+   * for each validation function. See globalValidations directory.
+   */
+  it("(Not Reporting) validationFunctions should call all expected validation functions", async () => {
+    mockValidateAndSetErrors(validationFunctions, notReportingData); // trigger validations
+    expect(V.validateReasonForNotReporting).toHaveBeenCalled();
+    expect(V.validateAtLeastOneRateComplete).not.toHaveBeenCalled();
+    expect(V.validateNumeratorsLessThanDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateRateNotZeroPM).not.toHaveBeenCalled();
+    expect(V.validateRateZeroPM).not.toHaveBeenCalled();
+    expect(V.validateBothDatesCompleted).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSource).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSourceType).not.toHaveBeenCalled();
+    expect(V.validateDeviationTextFieldFilled).not.toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatOMS).not.toHaveBeenCalled();
+    expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
+    expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
+  });
+
+  it("(Completed) validationFunctions should call all expected validation functions", async () => {
+    mockValidateAndSetErrors(validationFunctions, completedMeasureData); // trigger validations
+    expect(V.validateReasonForNotReporting).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneRateComplete).toHaveBeenCalled();
+    expect(V.validateNumeratorsLessThanDenominatorsPM).toHaveBeenCalled();
+    expect(V.validateRateNotZeroPM).toHaveBeenCalled();
+    expect(V.validateRateZeroPM).toHaveBeenCalled();
+    expect(V.validateBothDatesCompleted).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSourceType).toHaveBeenCalled();
+    expect(V.validateDeviationTextFieldFilled).toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatOMS).not.toHaveBeenCalled();
+    expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
+    expect(V.validateRateZeroOMS).toHaveBeenCalled();
+    expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateTotalNDR).toHaveBeenCalled();
+    expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
+  });
+});
+
+const notReportingData = {
+  DidReport: "no",
+};
+
+const OPMData = { MeasurementSpecification: "Other", DidReport: "yes" };
+
+const completedMeasureData = {
+  PerformanceMeasure: {
+    rates: {
+      singleCategory: [{}],
+    },
+  },
+  MeasurementSpecification: "ADA-DQA",
+  DidReport: "yes",
+};

--- a/services/ui-src/src/measures/2025/OEVPAD/index.tsx
+++ b/services/ui-src/src/measures/2025/OEVPAD/index.tsx
@@ -1,0 +1,68 @@
+import * as CMQ from "shared/commonQuestions";
+import * as DC from "dataConstants";
+import * as PMD from "./data";
+import * as QMR from "components";
+import { getPerfMeasureRateArray } from "shared/globalValidations";
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import { validationFunctions } from "./validation";
+//form type
+import { DefaultFormData as FormData } from "shared/types/FormData";
+
+export const OEVPAD = ({
+  name,
+  year,
+  measureId,
+  setValidationFunctions,
+  isNotReportingData,
+  isPrimaryMeasureSpecSelected,
+  showOptionalMeasureStrat,
+  isOtherMeasureSpecSelected,
+}: QMR.MeasureWrapperProps) => {
+  const { watch } = useFormContext<FormData>();
+  const data = watch();
+  const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+
+  useEffect(() => {
+    if (setValidationFunctions) {
+      setValidationFunctions(validationFunctions);
+    }
+  }, [setValidationFunctions]);
+
+  return (
+    <>
+      <CMQ.Reporting
+        reportingYear={year}
+        measureName={name}
+        measureAbbreviation={measureId}
+      />
+
+      {!isNotReportingData && (
+        <>
+          <CMQ.StatusOfData />
+          <CMQ.MeasurementSpecification type={DC.ADA_DQA} coreset="adult" />
+          <CMQ.DataSource type="adult" />
+          <CMQ.DateRange type="adult" />
+          <CMQ.DefinitionOfPopulation coreset="adult" />
+          {isPrimaryMeasureSpecSelected && (
+            <>
+              <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
+              <CMQ.DeviationFromMeasureSpec />
+            </>
+          )}
+          {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
+          {showOptionalMeasureStrat && (
+            <CMQ.OptionalMeasureStrat
+              coreset="adult"
+              calcTotal
+              categories={PMD.categories}
+              performanceMeasureArray={performanceMeasureArray}
+              qualifiers={PMD.qualifiers}
+            />
+          )}
+        </>
+      )}
+      <CMQ.AdditionalNotes />
+    </>
+  );
+};

--- a/services/ui-src/src/measures/2025/OEVPAD/validation.ts
+++ b/services/ui-src/src/measures/2025/OEVPAD/validation.ts
@@ -1,0 +1,76 @@
+import * as DC from "dataConstants";
+import * as GV from "shared/globalValidations";
+import * as PMD from "./data";
+import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
+//form type
+import { DefaultFormData as FormData } from "shared/types/FormData";
+
+const OEVPADValidation = (data: FormData) => {
+  const ageGroups = PMD.qualifiers;
+  const dateRange = data[DC.DATE_RANGE];
+  const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
+  const deviationReason = data[DC.DEVIATION_REASON];
+  const OPM = data[DC.OPM_RATES];
+  const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
+  const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
+
+  let errorArray: any[] = [];
+  if (data[DC.DID_REPORT] === DC.NO) {
+    errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
+    return errorArray;
+  }
+
+  errorArray = [
+    ...GV.validateDateRangeRadioButtonCompletion(data),
+    ...GV.validateBothDatesCompleted(dateRange),
+    ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateDeviationTextFieldFilled(
+      didCalculationsDeviate,
+      deviationReason
+    ),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
+
+    // Performance Measure Validations
+    ...GV.validateAtLeastOneRateComplete(
+      performanceMeasureArray,
+      OPM,
+      ageGroups,
+      PMD.categories
+    ),
+    ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
+    ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
+    ...GV.validateNumeratorsLessThanDenominatorsPM(
+      performanceMeasureArray,
+      OPM,
+      ageGroups
+    ),
+    ...GV.validateTotalNDR(performanceMeasureArray, undefined, undefined),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+
+    // OMS Validations
+    ...GV.omsValidations({
+      data,
+      qualifiers: PMD.qualifiers,
+      categories: PMD.categories,
+      locationDictionary: GV.omsLocationDictionary(
+        OMSData(2025),
+        PMD.qualifiers,
+        PMD.categories
+      ),
+      validationCallbacks: [
+        GV.validateNumeratorLessThanDenominatorOMS(),
+        GV.validateOMSTotalNDR(),
+        GV.validateRateNotZeroOMS(),
+        GV.validateRateZeroOMS(),
+      ],
+    }),
+  ];
+
+  return errorArray;
+};
+
+export const validationFunctions = [OEVPADValidation];

--- a/services/ui-src/src/measures/2025/OEVPCH/data.ts
+++ b/services/ui-src/src/measures/2025/OEVPCH/data.ts
@@ -1,0 +1,12 @@
+import { DataDrivenTypes } from "shared/types";
+import { getCatQualLabels } from "../rateLabelText";
+
+export const { categories, qualifiers } = getCatQualLabels("OEVP-CH");
+
+export const data: DataDrivenTypes.PerformanceMeasure = {
+  questionText: [
+    ".",
+  ],
+  categories,
+  qualifiers,
+};

--- a/services/ui-src/src/measures/2025/OEVPCH/data.ts
+++ b/services/ui-src/src/measures/2025/OEVPCH/data.ts
@@ -4,9 +4,7 @@ import { getCatQualLabels } from "../rateLabelText";
 export const { categories, qualifiers } = getCatQualLabels("OEVP-CH");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
-  questionText: [
-    ".",
-  ],
+  questionText: ["."],
   categories,
   qualifiers,
 };

--- a/services/ui-src/src/measures/2025/OEVPCH/index.test.tsx
+++ b/services/ui-src/src/measures/2025/OEVPCH/index.test.tsx
@@ -1,0 +1,242 @@
+import { screen, waitFor, act } from "@testing-library/react";
+import { createElement } from "react";
+import { RouterWrappedComp } from "utils/testing";
+import { MeasureWrapper } from "components/MeasureWrapper";
+import { useApiMock } from "utils/testUtils/useApiMock";
+import { useUser } from "hooks/authHooks";
+import Measures from "measures";
+import { Suspense } from "react";
+import { MeasuresLoading } from "views";
+import { measureDescriptions } from "measures/measureDescriptions";
+import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
+import { validationFunctions } from "./validation";
+import {
+  mockValidateAndSetErrors,
+  clearMocks,
+  validationsMockObj as V,
+} from "shared/util/validationsMock";
+import { axe, toHaveNoViolations } from "jest-axe";
+expect.extend(toHaveNoViolations);
+
+// Test Setup
+const measureAbbr = "OEVP-CH";
+const coreSet = "CCSC";
+const state = "AL";
+const year = 2025;
+const description = measureDescriptions[`${year}`][measureAbbr];
+const apiData: any = {};
+
+jest.mock("hooks/authHooks");
+const mockUseUser = useUser as jest.Mock;
+
+describe(`Test FFY ${year} ${measureAbbr}`, () => {
+  let component: JSX.Element;
+  beforeEach(() => {
+    clearMocks();
+    apiData.useGetMeasureValues = {
+      data: {
+        Item: {
+          compoundKey: `${state}${year}${coreSet}${measureAbbr}`,
+          coreSet,
+          createdAt: 1642517935305,
+          description,
+          lastAltered: 1642517935305,
+          lastAlteredBy: "undefined",
+          measure: measureAbbr,
+          state,
+          status: "incomplete",
+          year,
+          data: {},
+        },
+      },
+      isLoading: false,
+      refetch: jest.fn(),
+      isError: false,
+      error: undefined,
+    };
+
+    mockUseUser.mockImplementation(() => {
+      return { isStateUser: false };
+    });
+
+    const measure = createElement(Measures[year][measureAbbr]);
+    component = (
+      <Suspense fallback={MeasuresLoading()}>
+        <RouterWrappedComp>
+          <MeasureWrapper
+            measure={measure}
+            name={description}
+            year={`${year}`}
+            measureId={measureAbbr}
+          />
+        </RouterWrappedComp>
+      </Suspense>
+    );
+  });
+
+  it("should pass a11y tests", async () => {
+    useApiMock(apiData);
+    await act(async () => {
+      const { container } = renderWithHookForm(component);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  it("measure should render", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("measure-wrapper-form")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(measureAbbr + " - " + description));
+    });
+  });
+
+  /**
+   * Render the measure and confirm that all expected components exist.
+   * */
+  it("Always shows Are you reporting question", async () => {
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("reporting"));
+  });
+
+  it("shows corresponding questions if yes to reporting then ", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("status-of-data")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("measurement-specification")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("data-source")).toBeInTheDocument();
+    expect(screen.queryByTestId("date-range")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("definition-of-population")
+    ).toBeInTheDocument();
+  });
+
+  it("does not show corresponding questions if no to reporting then ", async () => {
+    apiData.useGetMeasureValues.data.Item.data = notReportingData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("status-of-data")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("measurement-specification")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("data-source")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("date-range")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("definition-of-population")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows corresponding components and hides others when primary measure is selected", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("performance-measure")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("deviation-from-measure-specification")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("OPM")).not.toBeInTheDocument();
+  });
+
+  it("shows corresponding components and hides others when primary measure is NOT selected", async () => {
+    apiData.useGetMeasureValues.data.Item.data = OPMData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("OPM"));
+    expect(screen.queryByTestId("performance-measure")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("deviation-from-measure-specification")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows OMS when performance measure data has been entered", async () => {
+    apiData.useGetMeasureValues.data.Item.data = completedMeasureData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("OMS"));
+  });
+  it("does not show OMS when performance measure data has been entered", async () => {
+    apiData.useGetMeasureValues.data.Item.data = notReportingData;
+    useApiMock(apiData);
+    renderWithHookForm(component);
+    expect(screen.queryByTestId("OMS")).not.toBeInTheDocument();
+  });
+
+  /** Validations Test
+   *
+   * Confirm that correct functions are called. Comprehensive testing of the validations is done in specific test files
+   * for each validation function. See globalValidations directory.
+   */
+  it("(Not Reporting) validationFunctions should call all expected validation functions", async () => {
+    mockValidateAndSetErrors(validationFunctions, notReportingData); // trigger validations
+    expect(V.validateReasonForNotReporting).toHaveBeenCalled();
+    expect(V.validateAtLeastOneRateComplete).not.toHaveBeenCalled();
+    expect(V.validateNumeratorsLessThanDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateRateNotZeroPM).not.toHaveBeenCalled();
+    expect(V.validateRateZeroPM).not.toHaveBeenCalled();
+    expect(V.validateBothDatesCompleted).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSource).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSourceType).not.toHaveBeenCalled();
+    expect(V.validateDeviationTextFieldFilled).not.toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatOMS).not.toHaveBeenCalled();
+    expect(V.validateNumeratorLessThanDenominatorOMS).not.toHaveBeenCalled();
+    expect(V.validateRateZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateRateNotZeroOMS).not.toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateOMSTotalNDR).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).not.toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).not.toHaveBeenCalled();
+  });
+
+  it("(Completed) validationFunctions should call all expected validation functions", async () => {
+    mockValidateAndSetErrors(validationFunctions, completedMeasureData); // trigger validations
+    expect(V.validateReasonForNotReporting).not.toHaveBeenCalled();
+    expect(V.validateAtLeastOneRateComplete).toHaveBeenCalled();
+    expect(V.validateNumeratorsLessThanDenominatorsPM).toHaveBeenCalled();
+    expect(V.validateRateNotZeroPM).toHaveBeenCalled();
+    expect(V.validateRateZeroPM).toHaveBeenCalled();
+    expect(V.validateBothDatesCompleted).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSource).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDataSourceType).toHaveBeenCalled();
+    expect(V.validateDeviationTextFieldFilled).toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatPM).not.toHaveBeenCalled();
+    expect(V.validateOneCatRateHigherThanOtherCatOMS).not.toHaveBeenCalled();
+    expect(V.validateNumeratorLessThanDenominatorOMS).toHaveBeenCalled();
+    expect(V.validateRateZeroOMS).toHaveBeenCalled();
+    expect(V.validateRateNotZeroOMS).toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualPM).not.toHaveBeenCalled();
+    expect(V.validateOneQualRateHigherThanOtherQualOMS).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsPM).not.toHaveBeenCalled();
+    expect(V.validateEqualCategoryDenominatorsOMS).not.toHaveBeenCalled();
+    expect(V.validateTotalNDR).toHaveBeenCalled();
+    expect(V.validateOMSTotalNDR).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDeliverySystem).toHaveBeenCalled();
+    expect(V.validateFfsRadioButtonCompletion).toHaveBeenCalled();
+    expect(V.validateAtLeastOneDefinitionOfPopulation).toHaveBeenCalled();
+  });
+});
+
+const notReportingData = {
+  DidReport: "no",
+};
+
+const OPMData = { MeasurementSpecification: "Other", DidReport: "yes" };
+
+const completedMeasureData = {
+  PerformanceMeasure: {
+    rates: {
+      singleCategory: [{}],
+    },
+  },
+  MeasurementSpecification: "ADA-DQA",
+  DidReport: "yes",
+};

--- a/services/ui-src/src/measures/2025/OEVPCH/index.tsx
+++ b/services/ui-src/src/measures/2025/OEVPCH/index.tsx
@@ -1,0 +1,68 @@
+import * as CMQ from "shared/commonQuestions";
+import * as DC from "dataConstants";
+import * as PMD from "./data";
+import * as QMR from "components";
+import { getPerfMeasureRateArray } from "shared/globalValidations";
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import { validationFunctions } from "./validation";
+//form type
+import { DefaultFormData as FormData } from "shared/types/FormData";
+
+export const OEVPCH = ({
+  name,
+  year,
+  measureId,
+  setValidationFunctions,
+  isNotReportingData,
+  isPrimaryMeasureSpecSelected,
+  showOptionalMeasureStrat,
+  isOtherMeasureSpecSelected,
+}: QMR.MeasureWrapperProps) => {
+  const { watch } = useFormContext<FormData>();
+  const data = watch();
+  const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+
+  useEffect(() => {
+    if (setValidationFunctions) {
+      setValidationFunctions(validationFunctions);
+    }
+  }, [setValidationFunctions]);
+
+  return (
+    <>
+      <CMQ.Reporting
+        reportingYear={year}
+        measureName={name}
+        measureAbbreviation={measureId}
+      />
+
+      {!isNotReportingData && (
+        <>
+          <CMQ.StatusOfData />
+          <CMQ.MeasurementSpecification type={DC.ADA_DQA} coreset="child" />
+          <CMQ.DataSource type="child" />
+          <CMQ.DateRange type="child" />
+          <CMQ.DefinitionOfPopulation coreset="child" />
+          {isPrimaryMeasureSpecSelected && (
+            <>
+              <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
+              <CMQ.DeviationFromMeasureSpec />
+            </>
+          )}
+          {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
+          {showOptionalMeasureStrat && (
+            <CMQ.OptionalMeasureStrat
+              coreset="child"
+              calcTotal
+              categories={PMD.categories}
+              performanceMeasureArray={performanceMeasureArray}
+              qualifiers={PMD.qualifiers}
+            />
+          )}
+        </>
+      )}
+      <CMQ.AdditionalNotes />
+    </>
+  );
+};

--- a/services/ui-src/src/measures/2025/OEVPCH/validation.ts
+++ b/services/ui-src/src/measures/2025/OEVPCH/validation.ts
@@ -1,0 +1,76 @@
+import * as DC from "dataConstants";
+import * as GV from "shared/globalValidations";
+import * as PMD from "./data";
+import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
+//form type
+import { DefaultFormData as FormData } from "shared/types/FormData";
+
+const OEVPCHValidation = (data: FormData) => {
+  const ageGroups = PMD.qualifiers;
+  const dateRange = data[DC.DATE_RANGE];
+  const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
+  const deviationReason = data[DC.DEVIATION_REASON];
+  const OPM = data[DC.OPM_RATES];
+  const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
+  const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
+
+  let errorArray: any[] = [];
+  if (data[DC.DID_REPORT] === DC.NO) {
+    errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
+    return errorArray;
+  }
+
+  errorArray = [
+    ...GV.validateDateRangeRadioButtonCompletion(data),
+    ...GV.validateBothDatesCompleted(dateRange),
+    ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateDeviationTextFieldFilled(
+      didCalculationsDeviate,
+      deviationReason
+    ),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
+
+    // Performance Measure Validations
+    ...GV.validateAtLeastOneRateComplete(
+      performanceMeasureArray,
+      OPM,
+      ageGroups,
+      PMD.categories
+    ),
+    ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
+    ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
+    ...GV.validateNumeratorsLessThanDenominatorsPM(
+      performanceMeasureArray,
+      OPM,
+      ageGroups
+    ),
+    ...GV.validateTotalNDR(performanceMeasureArray, undefined, undefined),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+
+    // OMS Validations
+    ...GV.omsValidations({
+      data,
+      qualifiers: PMD.qualifiers,
+      categories: PMD.categories,
+      locationDictionary: GV.omsLocationDictionary(
+        OMSData(2025),
+        PMD.qualifiers,
+        PMD.categories
+      ),
+      validationCallbacks: [
+        GV.validateNumeratorLessThanDenominatorOMS(),
+        GV.validateOMSTotalNDR(),
+        GV.validateRateNotZeroOMS(),
+        GV.validateRateZeroOMS(),
+      ],
+    }),
+  ];
+
+  return errorArray;
+};
+
+export const validationFunctions = [OEVPCHValidation];

--- a/services/ui-src/src/measures/2025/index.tsx
+++ b/services/ui-src/src/measures/2025/index.tsx
@@ -162,6 +162,12 @@ const NCIIDDAD = lazy(() =>
 const OEVCH = lazy(() =>
   import("./OEVCH").then((module) => ({ default: module.OEVCH }))
 );
+const OEVPAD = lazy(() =>
+  import("./OEVPAD").then((module) => ({ default: module.OEVPAD }))
+);
+const OEVPCH = lazy(() =>
+  import("./OEVPCH").then((module) => ({ default: module.OEVPCH }))
+);
 const OHDAD = lazy(() =>
   import("./OHDAD").then((module) => ({ default: module.OHDAD }))
 );
@@ -276,8 +282,8 @@ const twentyTwentyFiveMeasures = {
   "LSC-CH": LSCCH,
   "NCIIDD-AD": NCIIDDAD,
   "OEV-CH": OEVCH,
-  // "OEVP-AD": OEVPAD, //TO DO: replace with real measure
-  // "OEVP-CH": OEVPCH, //TO DO: replace with real measure
+  "OEVP-AD": OEVPAD,
+  "OEVP-CH": OEVPCH,
   "OHD-AD": OHDAD,
   "OUD-AD": OUDAD,
   "OUD-HH": OUDHH,

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -1259,6 +1259,26 @@ export const data = {
         ],
         "categories": [{"id":"oe5lKf", "label": "", "text":""}]
     },
+    "OEVP-AD": {
+        "qualifiers": [
+            {
+                "label": "",
+                "text": "",
+                "id": "wnh2qA",
+            },
+        ],
+        "categories": [{"id":"KNNGq6", "label": "", "text":""}]
+    },
+    "OEVP-CH": {
+        "qualifiers": [
+            {
+                "label": "",
+                "text": "",
+                "id": "Xq5NFt",
+            },
+        ],
+        "categories": [{"id":"oxB9C2", "label": "", "text":""}]
+    },
     "OHD-AD": {
         "qualifiers": [
             {

--- a/tests/cypress/support/constants.ts
+++ b/tests/cypress/support/constants.ts
@@ -27,7 +27,7 @@ export const measureAbbrList2025 = {
     // "LRCD-AD", //TO-DO: turn on when measure has been added
     "MSC-AD",
     "NCIIDD-AD", // complete on creation
-    // "OEVP-AD", //TO-DO: turn on when measure has been added
+    "OEVP-AD",
     "OHD-AD",
     "OUD-AD",
     "PCR-AD",
@@ -62,7 +62,7 @@ export const measureAbbrList2025 = {
     "LRCD-CH", // complete on creation
     "LSC-CH",
     "OEV-CH",
-    // "OEVP-CH", //TO-DO: turn on when measure has been added
+    "OEVP-CH",
     // "PDS-CH", //TO-DO: turn on when measure has been added
     // "PRS-CH", //TO-DO: turn on when measure has been added
     "PPC2-CH",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Since OEVP-AD & OEVP-CH is the same atm, I decided to do them both together, and also cut down on the merge conflicts. 

It is copied over from OEV-CH and I stripped out any information that was related to OEV-CH.

According to Cam, any performance measure and rateLabelText data will come at a later time.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4044
CMDCT-4049

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any state user
2) In reporting year 2025, select any Adult Core Set Measures
3) Go to OEVP-AD and fill out the form.
4) If the form page works as normal, we are good
5) Repeat for OEVP-CH

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
