### PR TITLE
Global Data Source Update

### DIFF
--- a/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
@@ -16,7 +16,7 @@ export const commonQuestionsLabel = {
       "Describe the data source (<em>text in this field is included in publicly-reported state-specific comments</em>):",
     srcExplanation: "Data Source Explanation",
     srcExplanationText:
-      "For each data source selected above, describe which reporting entities used each data source (e.g., health plans, FFS). If the data source differed across health plans or delivery systems, identify the number of plans or delivery systems that used each data source.",
+      "For each data source selected above, describe which reporting entities used each data source (e.g., health plans, FFS). If the data source differed across health plans or delivery systems, identify the number of plans or delivery systems that used each data source (<em>text in this field is included in publicly-reported state-specific comments</em>).",
     otherDataSourceWarning:
       "If you report using Other Data Source, CMS will not be able to produce a combined Medicaid & CHIP rate for public reporting. If the information reported in the Data Source field is accurate, please continue reporting this measure.",
     warning: {

--- a/services/ui-src/src/shared/commonQuestions/DataSource.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DataSource.tsx
@@ -199,7 +199,7 @@ export const DataSource = ({ data = defaultData, type }: DataSourceProps) => {
             fontWeight="bold"
             key="If the data source differed across"
           >
-            {labels.DataSource.srcExplanationText}
+            {parseLabelToHTML(labels.DataSource.srcExplanationText)}
           </CUI.Text>
           <QMR.TextArea
             label={labels.DataSource.srcDescription!}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR adds extra text to the Data Source textbox. It should now read: 

**For each data source selected above, describe which reporting entities used each data source (e.g., health plans, FFS). If the data source differed across health plans or delivery systems, identify the number of plans or delivery systems that used each data source _(text in this field is included in publicly-reported state-specific comments)._**

<img width="1359" alt="Screenshot 2024-12-23 at 3 13 50 PM" src="https://github.com/user-attachments/assets/dd1889f6-8b63-4e7f-af74-bd173a32d414" />


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4203

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any state user
2) Go to any measure with a **Data Source** section
3) Check any two textboxes, i.e. Administrative Data & Other Data Source. This should cause a textbox to display.
4) Look at the textbox and make sure it has the additional text shown in the image above.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
