### PR TITLE
CPA-AD Remove question

### DIFF
--- a/services/ui-src/src/measures/2025/CPAAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CPAAD/index.tsx
@@ -110,7 +110,10 @@ export const CPAAD = ({
         <>
           <Q.HowDidYouReport />
           <Q.DataSource type="adult" />
-          <CMQ.DefinitionOfPopulation coreSetOptions={defOfDenomOptions} />
+          <CMQ.DefinitionOfPopulation
+            coreSetOptions={defOfDenomOptions}
+            deliverySystems={false}
+          />
           <Q.PerformanceMeasure />
         </>
       )}

--- a/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
@@ -18,6 +18,7 @@ interface Props {
   populationSampleSize?: boolean;
   coreSetOptions?: CoreSetSpecificOptions;
   coreset?: string;
+  deliverySystems?: boolean;
 }
 interface DefOfDenomOption {
   displayValue: string;
@@ -404,6 +405,7 @@ export const DefinitionOfPopulation = ({
   hybridMeasure,
   coreSetOptions,
   coreset,
+  deliverySystems = true,
 }: Props) => {
   const register = useCustomRegister<Types.DefinitionOfPopulation>();
 
@@ -491,46 +493,47 @@ export const DefinitionOfPopulation = ({
       </CUI.Box>
       {(hybridMeasure || populationSampleSize) &&
         HybridDefinitions(register, !populationSampleSize)}
-      <CUI.Box mt="5">
-        <CUI.Heading size="sm" as="h2" my="2">
-          {"Which delivery systems are represented in the denominator?"}
-        </CUI.Heading>
-        <CUI.Text pb="2">
-          Select all delivery systems that apply in your state (must select at
-          least one); for each delivery system selected, enter the percentage of
-          the measure-eligible population represented by that service delivery
-          system.
-        </CUI.Text>
+      {deliverySystems && (
+        <CUI.Box mt="5">
+          <CUI.Heading size="sm" as="h2" my="2">
+            {"Which delivery systems are represented in the denominator?"}
+          </CUI.Heading>
+          <CUI.Text pb="2">
+            Select all delivery systems that apply in your state (must select at
+            least one); for each delivery system selected, enter the percentage
+            of the measure-eligible population represented by that service
+            delivery system.
+          </CUI.Text>
 
-        <QMR.Checkbox
-          formLabelProps={{ fontWeight: "400" }}
-          {...register(DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR)}
-          options={[
-            {
-              displayValue: "Fee-for-Service (FFS)",
-              value: DC.FFS,
-              children: [
-                <QMR.RadioButton
-                  {...register(DC.DELIVERY_SYS_FFS)}
-                  formLabelProps={{ fontWeight: "400" }}
-                  label="Is all of your measure-eligible Fee-for-Service (FFS) population included in this measure?"
-                  options={[
-                    {
-                      displayValue:
-                        "Yes, all of our measure-eligible Fee-for-Service (FFS) population are included in this measure.",
-                      value: DC.YES,
-                    },
-                    {
-                      displayValue:
-                        "No, not all of our measure-eligible Fee-for-Service (FFS) population are included in this measure.",
-                      value: DC.NO,
-                      children: [
-                        <QMR.NumberInput
-                          {...register(DC.DELIVERY_SYS_FFS_NO_PERCENT)}
-                          formLabelProps={{ fontWeight: "400" }}
-                          label="What percent of your measure-eligible Fee-for-Service (FFS) population are included in the measure?"
-                          renderHelperTextAbove
-                          helperText="The percentage provided here should represent the
+          <QMR.Checkbox
+            formLabelProps={{ fontWeight: "400" }}
+            {...register(DC.DELIVERY_SYS_REPRESENTATION_DENOMINATOR)}
+            options={[
+              {
+                displayValue: "Fee-for-Service (FFS)",
+                value: DC.FFS,
+                children: [
+                  <QMR.RadioButton
+                    {...register(DC.DELIVERY_SYS_FFS)}
+                    formLabelProps={{ fontWeight: "400" }}
+                    label="Is all of your measure-eligible Fee-for-Service (FFS) population included in this measure?"
+                    options={[
+                      {
+                        displayValue:
+                          "Yes, all of our measure-eligible Fee-for-Service (FFS) population are included in this measure.",
+                        value: DC.YES,
+                      },
+                      {
+                        displayValue:
+                          "No, not all of our measure-eligible Fee-for-Service (FFS) population are included in this measure.",
+                        value: DC.NO,
+                        children: [
+                          <QMR.NumberInput
+                            {...register(DC.DELIVERY_SYS_FFS_NO_PERCENT)}
+                            formLabelProps={{ fontWeight: "400" }}
+                            label="What percent of your measure-eligible Fee-for-Service (FFS) population are included in the measure?"
+                            renderHelperTextAbove
+                            helperText="The percentage provided here should represent the
                           percentage of the denominator population(s) included
                           in the measure (i.e., Medicaid, CHIP, etc.) that
                           receives items/services through the selected delivery
@@ -539,39 +542,39 @@ export const DefinitionOfPopulation = ({
                           and half of your state’s fee-for-service enrollees,
                           select managed care, and select fee-for-service and
                           enter 50."
-                          displayPercent
-                          mask={percentageAllowOneDecimalMax}
-                        />,
-                      ],
-                    },
-                  ]}
-                />,
-              ],
-            },
-            {
-              displayValue: "Primary Care Case Management (PCCM)",
-              value: DC.PCCM,
-              children: [
-                <QMR.RadioButton
-                  {...register(DC.DELIVERY_SYS_PCCM)}
-                  formLabelProps={{ fontWeight: "400" }}
-                  label="Is all of your measure-eligible Primary Care Case Management (PCCM) population included in this measure?"
-                  options={[
-                    {
-                      displayValue:
-                        "Yes, all of our measure-eligible Primary Care Case Management (PCCM) population are included in this measure.",
-                      value: DC.YES,
-                    },
-                    {
-                      displayValue:
-                        "No, not all of our measure-eligible Primary Care Case Management (PCCM) population are included in this measure.",
-                      value: DC.NO,
-                      children: [
-                        <QMR.NumberInput
-                          {...register(DC.DELIVERY_SYS_PCCM_NO_PERCENT)}
-                          displayPercent
-                          renderHelperTextAbove
-                          helperText="The percentage provided here should represent the
+                            displayPercent
+                            mask={percentageAllowOneDecimalMax}
+                          />,
+                        ],
+                      },
+                    ]}
+                  />,
+                ],
+              },
+              {
+                displayValue: "Primary Care Case Management (PCCM)",
+                value: DC.PCCM,
+                children: [
+                  <QMR.RadioButton
+                    {...register(DC.DELIVERY_SYS_PCCM)}
+                    formLabelProps={{ fontWeight: "400" }}
+                    label="Is all of your measure-eligible Primary Care Case Management (PCCM) population included in this measure?"
+                    options={[
+                      {
+                        displayValue:
+                          "Yes, all of our measure-eligible Primary Care Case Management (PCCM) population are included in this measure.",
+                        value: DC.YES,
+                      },
+                      {
+                        displayValue:
+                          "No, not all of our measure-eligible Primary Care Case Management (PCCM) population are included in this measure.",
+                        value: DC.NO,
+                        children: [
+                          <QMR.NumberInput
+                            {...register(DC.DELIVERY_SYS_PCCM_NO_PERCENT)}
+                            displayPercent
+                            renderHelperTextAbove
+                            helperText="The percentage provided here should represent the
                           percentage of the denominator population(s) included
                           in the measure (i.e., Medicaid, CHIP, etc.) that
                           receives items/services through the selected
@@ -580,48 +583,106 @@ export const DefinitionOfPopulation = ({
                           care enrollees and half of your state’s
                           fee-for-service enrollees, select managed care, and
                           select fee-for-service and enter 50."
-                          mask={percentageAllowOneDecimalMax}
-                          formLabelProps={{ fontWeight: "400" }}
-                          label="What percent of your measure-eligible Primary Care Case Management (PCCM) population are included in the measure?"
-                        />,
-                      ],
-                    },
-                  ]}
-                />,
-              ],
-            },
-            {
-              displayValue:
-                "Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP)",
-              value: DC.MCO_PIHP,
-              children: [
-                <CUI.Box py="5" key="DeliverySys-MCO_PIHP-NumberOfPlans">
-                  <QMR.NumberInput
-                    formLabelProps={{ fontWeight: "400" }}
-                    mask={allPositiveIntegers}
-                    label="What is the number of Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) plans that are included in the reported data?"
-                    {...register(DC.DELIVERY_SYS_MCO_PIHP_NUM_PLANS)}
-                  />
-                </CUI.Box>,
-                <CUI.Box pt="5" key="DeliverySys-MCO_PIHP">
+                            mask={percentageAllowOneDecimalMax}
+                            formLabelProps={{ fontWeight: "400" }}
+                            label="What percent of your measure-eligible Primary Care Case Management (PCCM) population are included in the measure?"
+                          />,
+                        ],
+                      },
+                    ]}
+                  />,
+                ],
+              },
+              {
+                displayValue:
+                  "Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP)",
+                value: DC.MCO_PIHP,
+                children: [
+                  <CUI.Box py="5" key="DeliverySys-MCO_PIHP-NumberOfPlans">
+                    <QMR.NumberInput
+                      formLabelProps={{ fontWeight: "400" }}
+                      mask={allPositiveIntegers}
+                      label="What is the number of Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) plans that are included in the reported data?"
+                      {...register(DC.DELIVERY_SYS_MCO_PIHP_NUM_PLANS)}
+                    />
+                  </CUI.Box>,
+                  <CUI.Box pt="5" key="DeliverySys-MCO_PIHP">
+                    <QMR.RadioButton
+                      {...register(DC.DELIVERY_SYS_MCO_PIHP)}
+                      formLabelProps={{ fontWeight: "400" }}
+                      label="Is all of your measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) population included in this measure?"
+                      options={[
+                        {
+                          displayValue:
+                            "Yes, all of our measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) population are included in this measure.",
+                          value: DC.YES,
+                        },
+                        {
+                          displayValue:
+                            "No, not all of our measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) population are included in this measure.",
+                          value: DC.NO,
+                          children: [
+                            <CUI.Text mb="5" key="AdditionalMCOIncludedText">
+                              {
+                                "What percent of your measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) population are"
+                              }
+                              <CUI.Text as="i" fontWeight="600">
+                                {" included "}
+                              </CUI.Text>
+                              {"in the measure?"}
+                            </CUI.Text>,
+                            <QMR.NumberInput
+                              displayPercent
+                              mask={percentageAllowOneDecimalMax}
+                              renderHelperTextAbove
+                              helperText="The percentage provided here should represent the percentage of the denominator population(s) included in the measure (i.e., Medicaid, CHIP, etc.) that receives items/services through the selected delivery system. For example, if the population included in the reported data represents all managed care enrollees and half of your state’s fee-for-service enrollees, select managed care, and select fee-for-service and enter 50."
+                              {...register(DC.DELIVERY_SYS_MCO_PIHP_NO_INC)}
+                            />,
+                            <CUI.Text my="5" key="AdditionalMCOExcludedText">
+                              {" "}
+                              {
+                                "How many of your measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) plans are"
+                              }
+                              <CUI.Text as="i" fontWeight="600">
+                                {" excluded "}
+                              </CUI.Text>
+                              {
+                                "from the measure? If none are excluded, please enter zero."
+                              }
+                            </CUI.Text>,
+                            <QMR.NumberInput
+                              mask={allPositiveIntegers}
+                              {...register(DC.DELIVERY_SYS_MCO_PIHP_NO_EXCL)}
+                            />,
+                          ],
+                        },
+                      ]}
+                    />
+                  </CUI.Box>,
+                ],
+              },
+              {
+                displayValue: "Integrated Care Models (ICM)",
+                value: DC.ICM,
+                children: [
                   <QMR.RadioButton
-                    {...register(DC.DELIVERY_SYS_MCO_PIHP)}
                     formLabelProps={{ fontWeight: "400" }}
-                    label="Is all of your measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) population included in this measure?"
+                    label="Is all of your measure-eligible Integrated Care Models (ICM) population included in this measure?"
+                    {...register(DC.DELIVERY_SYS_ICM)}
                     options={[
                       {
                         displayValue:
-                          "Yes, all of our measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) population are included in this measure.",
+                          "Yes, all of our measure-eligible Integrated Care Models (ICM) population are included in this measure.",
                         value: DC.YES,
                       },
                       {
                         displayValue:
-                          "No, not all of our measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) population are included in this measure.",
+                          "No, not all of our measure-eligible Integrated Care Models (ICM) population are included in this measure.",
                         value: DC.NO,
                         children: [
-                          <CUI.Text mb="5" key="AdditionalMCOIncludedText">
+                          <CUI.Text mb="5" key="AdditionalICMIncludedText">
                             {
-                              "What percent of your measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) population are"
+                              "What percent of your measure-eligible Integrated Care Models (ICM) population are"
                             }
                             <CUI.Text as="i" fontWeight="600">
                               {" included "}
@@ -630,66 +691,8 @@ export const DefinitionOfPopulation = ({
                           </CUI.Text>,
                           <QMR.NumberInput
                             displayPercent
-                            mask={percentageAllowOneDecimalMax}
                             renderHelperTextAbove
-                            helperText="The percentage provided here should represent the percentage of the denominator population(s) included in the measure (i.e., Medicaid, CHIP, etc.) that receives items/services through the selected delivery system. For example, if the population included in the reported data represents all managed care enrollees and half of your state’s fee-for-service enrollees, select managed care, and select fee-for-service and enter 50."
-                            {...register(DC.DELIVERY_SYS_MCO_PIHP_NO_INC)}
-                          />,
-                          <CUI.Text my="5" key="AdditionalMCOExcludedText">
-                            {" "}
-                            {
-                              "How many of your measure-eligible Managed Care Organization/Pre-paid Inpatient Health Plan (MCO/PIHP) plans are"
-                            }
-                            <CUI.Text as="i" fontWeight="600">
-                              {" excluded "}
-                            </CUI.Text>
-                            {
-                              "from the measure? If none are excluded, please enter zero."
-                            }
-                          </CUI.Text>,
-                          <QMR.NumberInput
-                            mask={allPositiveIntegers}
-                            {...register(DC.DELIVERY_SYS_MCO_PIHP_NO_EXCL)}
-                          />,
-                        ],
-                      },
-                    ]}
-                  />
-                </CUI.Box>,
-              ],
-            },
-            {
-              displayValue: "Integrated Care Models (ICM)",
-              value: DC.ICM,
-              children: [
-                <QMR.RadioButton
-                  formLabelProps={{ fontWeight: "400" }}
-                  label="Is all of your measure-eligible Integrated Care Models (ICM) population included in this measure?"
-                  {...register(DC.DELIVERY_SYS_ICM)}
-                  options={[
-                    {
-                      displayValue:
-                        "Yes, all of our measure-eligible Integrated Care Models (ICM) population are included in this measure.",
-                      value: DC.YES,
-                    },
-                    {
-                      displayValue:
-                        "No, not all of our measure-eligible Integrated Care Models (ICM) population are included in this measure.",
-                      value: DC.NO,
-                      children: [
-                        <CUI.Text mb="5" key="AdditionalICMIncludedText">
-                          {
-                            "What percent of your measure-eligible Integrated Care Models (ICM) population are"
-                          }
-                          <CUI.Text as="i" fontWeight="600">
-                            {" included "}
-                          </CUI.Text>
-                          {"in the measure?"}
-                        </CUI.Text>,
-                        <QMR.NumberInput
-                          displayPercent
-                          renderHelperTextAbove
-                          helperText="The percentage provided here should represent the
+                            helperText="The percentage provided here should represent the
                           percentage of the denominator population(s) included
                           in the measure (i.e., Medicaid, CHIP, etc.) that
                           receives items/services through the selected
@@ -698,53 +701,53 @@ export const DefinitionOfPopulation = ({
                           care enrollees and half of your state’s
                           fee-for-service enrollees, select managed care, and
                           select fee-for-service and enter 50."
-                          mask={percentageAllowOneDecimalMax}
-                          formLabelProps={{ fontWeight: "400" }}
-                          {...register(DC.DELIVERY_SYS_ICM_NO_PERCENT)}
-                        />,
-                        <CUI.Box py="5" key="AdditionalICMText">
-                          <CUI.Text my="5" key="AdditionalMCOExcludedText">
-                            {" "}
-                            {
-                              "How many of your measure-eligible Integrated Care Models (ICM) plans are"
-                            }
-                            <CUI.Text as="i" fontWeight="600">
-                              {" excluded "}
-                            </CUI.Text>
-                            {
-                              "from the measure? If none are excluded, please enter zero."
-                            }
-                          </CUI.Text>
-                          <QMR.NumberInput
-                            mask={allPositiveIntegers}
+                            mask={percentageAllowOneDecimalMax}
                             formLabelProps={{ fontWeight: "400" }}
-                            {...register(DC.DELIVERY_SYS_ICM_NO_POP)}
-                          />
-                        </CUI.Box>,
-                      ],
-                    },
-                  ]}
-                />,
-              ],
-            },
-            {
-              displayValue: "Other",
-              value: DC.OTHER,
-              children: [
-                <CUI.Box pb="5" key="DeliverySys-Other">
-                  <QMR.TextArea
-                    formLabelProps={{ fontWeight: "400" }}
-                    label={parseLabelToHTML(
-                      labels.DefinitionsOfPopulation.deliverySysOther
-                    )}
-                    {...register(DC.DELIVERY_SYS_OTHER)}
-                  />
-                </CUI.Box>,
-                <CUI.Box py="5" key="DeliverySys-Other-Percent">
-                  <QMR.NumberInput
-                    displayPercent
-                    renderHelperTextAbove
-                    helperText="The percentage provided here should represent the percentage
+                            {...register(DC.DELIVERY_SYS_ICM_NO_PERCENT)}
+                          />,
+                          <CUI.Box py="5" key="AdditionalICMText">
+                            <CUI.Text my="5" key="AdditionalMCOExcludedText">
+                              {" "}
+                              {
+                                "How many of your measure-eligible Integrated Care Models (ICM) plans are"
+                              }
+                              <CUI.Text as="i" fontWeight="600">
+                                {" excluded "}
+                              </CUI.Text>
+                              {
+                                "from the measure? If none are excluded, please enter zero."
+                              }
+                            </CUI.Text>
+                            <QMR.NumberInput
+                              mask={allPositiveIntegers}
+                              formLabelProps={{ fontWeight: "400" }}
+                              {...register(DC.DELIVERY_SYS_ICM_NO_POP)}
+                            />
+                          </CUI.Box>,
+                        ],
+                      },
+                    ]}
+                  />,
+                ],
+              },
+              {
+                displayValue: "Other",
+                value: DC.OTHER,
+                children: [
+                  <CUI.Box pb="5" key="DeliverySys-Other">
+                    <QMR.TextArea
+                      formLabelProps={{ fontWeight: "400" }}
+                      label={parseLabelToHTML(
+                        labels.DefinitionsOfPopulation.deliverySysOther
+                      )}
+                      {...register(DC.DELIVERY_SYS_OTHER)}
+                    />
+                  </CUI.Box>,
+                  <CUI.Box py="5" key="DeliverySys-Other-Percent">
+                    <QMR.NumberInput
+                      displayPercent
+                      renderHelperTextAbove
+                      helperText="The percentage provided here should represent the percentage
                     of the denominator population(s) included in the measure
                     (i.e., Medicaid, CHIP, etc.) that receives items/services
                     through the selected delivery system. For example, if the
@@ -752,25 +755,26 @@ export const DefinitionOfPopulation = ({
                     managed care enrollees and half of your state’s
                     fee-for-service enrollees, select managed care, and select
                     fee-for-service and enter 50."
-                    mask={percentageAllowOneDecimalMax}
-                    formLabelProps={{ fontWeight: "400" }}
-                    label="Percentage of total other population represented in data reported:"
-                    {...register(DC.DELIVERY_SYS_OTHER_PERCENT)}
-                  />
-                </CUI.Box>,
-                <CUI.Box py="5" key="DeliverySys-Other-NumberOfHealthPlans">
-                  <QMR.NumberInput
-                    mask={allPositiveIntegers}
-                    formLabelProps={{ fontWeight: "400" }}
-                    label="If applicable, list the number of Health Plans represented:"
-                    {...register(DC.DELIVERY_SYS_OTHER_NUM_HEALTH_PLANS)}
-                  />
-                </CUI.Box>,
-              ],
-            },
-          ]}
-        />
-      </CUI.Box>
+                      mask={percentageAllowOneDecimalMax}
+                      formLabelProps={{ fontWeight: "400" }}
+                      label="Percentage of total other population represented in data reported:"
+                      {...register(DC.DELIVERY_SYS_OTHER_PERCENT)}
+                    />
+                  </CUI.Box>,
+                  <CUI.Box py="5" key="DeliverySys-Other-NumberOfHealthPlans">
+                    <QMR.NumberInput
+                      mask={allPositiveIntegers}
+                      formLabelProps={{ fontWeight: "400" }}
+                      label="If applicable, list the number of Health Plans represented:"
+                      {...register(DC.DELIVERY_SYS_OTHER_NUM_HEALTH_PLANS)}
+                    />
+                  </CUI.Box>,
+                ],
+              },
+            ]}
+          />
+        </CUI.Box>
+      )}
       {healthHomeMeasure && HealthHomeDefinitions(register)}
     </QMR.CoreQuestionWrapper>
   );


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
For CPA-AD, the BOs want the **deliver systems** question in the **Definition of Population Included in the Measure** section removed. This PR will add a boolean prop to control the showing/hiding of that question.

![Screenshot 2024-12-24 at 12 33 55 PM](https://github.com/user-attachments/assets/31a0b5c4-c5d0-488f-ba83-56ca4a17a2d0)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4201

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any state user
2) In Reporting year 2025, go to CPA-AD
3) Scroll down to the **Definition of Population Included in The Measure** section and check that the question "Which delivery systems are represented in the denominator?" is not being rendered.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
