### PR TITLE
Global - Definition of Denominator Update

### DIFF
--- a/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
@@ -31,7 +31,8 @@ export const commonQuestionsLabel = {
       "If you report using Other Data Source, CMS will not be able to produce a combined Medicaid & CHIP rate for public reporting. If the information reported in the Data Source field is accurate, please continue reporting this measure.",
   },
   DefinitionsOfPopulation: {
-    defineDenomOther: "Define the other denominator population:",
+    defineDenomOther:
+      "Define the other denominator population (<em>text in this field is included in publicly-reported state-specific comments</em>):",
     measureEligiblePopDenom: {
       question: {
         default:

--- a/tests/cypress/cypress/e2e/userflow_admin.spec.ts
+++ b/tests/cypress/cypress/e2e/userflow_admin.spec.ts
@@ -11,8 +11,8 @@ describe(`Test banner`, () => {
     cy.get('[data-cy="New banner description"]').type(
       "test banner description"
     );
-    cy.get('[data-cy="New banner start date"]').type("01/01/2024");
-    cy.get('[data-cy="New banner end date"]').type("01/01/2025");
+    cy.get('[data-cy="New banner start date"]').type("01/01/2025");
+    cy.get('[data-cy="New banner end date"]').type("01/01/2026");
     cy.get('[data-cy="replace current banner button"]').click();
     cy.get('[data-cy="banner status"]').should("contain.text", "Active");
   });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR adds an extra line to **Definition of Population Included in the Measure** -> **Definition of denominator**. When you select Other, it will now have the added text _(text in this field is included in publicly-reported state-specific comments)_

![Screenshot 2025-01-06 at 10 54 20 AM](https://github.com/user-attachments/assets/f2e15211-e285-46d1-bf0d-7179cec953c5)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4204

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any user
2) In reporting year 2025, select any measure
3) Scroll down to **Definition of Population Included in the Measure** section.
4) Select the Other checkbox and see that the text exist.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
