### PR TITLE
All Hybrid-Possible Measures - "If you are reporting..."

### DIFF
--- a/services/ui-src/src/measures/2025/CBPAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CBPAD/index.tsx
@@ -28,6 +28,9 @@ export const CBPAD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,7 @@ export const CBPAD = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="adult" />
           <CMQ.DataSource data={PMD.dataSourceData} type="adult" />
           <CMQ.DateRange type="adult" />
-          <CMQ.DefinitionOfPopulation hybridMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure={isHybrid} />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/CBPAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CBPAD/index.tsx
@@ -28,7 +28,7 @@ export const CBPAD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2025/CBPHH/index.tsx
@@ -28,6 +28,9 @@ export const CBPHH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -44,7 +47,10 @@ export const CBPHH = ({
           <CMQ.MeasurementSpecification type="HEDIS" />
           <CMQ.DataSource data={PMD.dataSourceData} />
           <CMQ.DateRange type="health" />
-          <CMQ.DefinitionOfPopulation hybridMeasure coreset="health" />
+          <CMQ.DefinitionOfPopulation
+            hybridMeasure={isHybrid}
+            coreset="health"
+          />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure calcTotal />

--- a/services/ui-src/src/measures/2025/CBPHH/index.tsx
+++ b/services/ui-src/src/measures/2025/CBPHH/index.tsx
@@ -28,7 +28,7 @@ export const CBPHH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/CCSAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CCSAD/index.tsx
@@ -28,7 +28,7 @@ export const CCSAD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/CCSAD/index.tsx
+++ b/services/ui-src/src/measures/2025/CCSAD/index.tsx
@@ -28,6 +28,9 @@ export const CCSAD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,7 @@ export const CCSAD = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="adult" />
           <CMQ.DataSource data={PMD.dataSourceData} type="adult" />
           <CMQ.DateRange type="adult" />
-          <CMQ.DefinitionOfPopulation hybridMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure={isHybrid} />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CISCH/index.tsx
@@ -28,7 +28,7 @@ export const CISCH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/CISCH/index.tsx
+++ b/services/ui-src/src/measures/2025/CISCH/index.tsx
@@ -28,6 +28,9 @@ export const CISCH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,10 @@ export const CISCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
+          <CMQ.DefinitionOfPopulation
+            coreset="child"
+            hybridMeasure={isHybrid}
+          />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2025/DEVCH/index.tsx
@@ -28,6 +28,9 @@ export const DEVCH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,10 @@ export const DEVCH = ({
           <CMQ.MeasurementSpecification type="OHSU" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
+          <CMQ.DefinitionOfPopulation
+            coreset="child"
+            hybridMeasure={isHybrid}
+          />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />

--- a/services/ui-src/src/measures/2025/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2025/DEVCH/index.tsx
@@ -28,7 +28,7 @@ export const DEVCH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/HBDAD/index.tsx
+++ b/services/ui-src/src/measures/2025/HBDAD/index.tsx
@@ -28,6 +28,9 @@ export const HBDAD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,7 @@ export const HBDAD = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="adult" />
           <CMQ.DataSource data={PMD.dataSourceData} type="adult" />
           <CMQ.DateRange type="adult" />
-          <CMQ.DefinitionOfPopulation hybridMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure={isHybrid} />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/HBDAD/index.tsx
+++ b/services/ui-src/src/measures/2025/HBDAD/index.tsx
@@ -28,7 +28,7 @@ export const HBDAD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/HPCMIAD/index.tsx
+++ b/services/ui-src/src/measures/2025/HPCMIAD/index.tsx
@@ -28,6 +28,9 @@ export const HPCMIAD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,7 @@ export const HPCMIAD = ({
           <CMQ.MeasurementSpecification type="NCQA" coreset="adult" />
           <CMQ.DataSource data={PMD.dataSourceData} type="adult" />
           <CMQ.DateRange type="adult" />
-          <CMQ.DefinitionOfPopulation hybridMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure={isHybrid} />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/HPCMIAD/index.tsx
+++ b/services/ui-src/src/measures/2025/HPCMIAD/index.tsx
@@ -28,7 +28,7 @@ export const HPCMIAD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2025/IMACH/index.tsx
@@ -28,7 +28,7 @@ export const IMACH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/IMACH/index.tsx
+++ b/services/ui-src/src/measures/2025/IMACH/index.tsx
@@ -28,6 +28,9 @@ export const IMACH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,10 @@ export const IMACH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
+          <CMQ.DefinitionOfPopulation
+            coreset="child"
+            hybridMeasure={isHybrid}
+          />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/LSCCH/index.tsx
+++ b/services/ui-src/src/measures/2025/LSCCH/index.tsx
@@ -21,7 +21,7 @@ export const LSCCH = ({
   const { watch } = useFormContext<FormData>();
   const data = watch();
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/LSCCH/index.tsx
+++ b/services/ui-src/src/measures/2025/LSCCH/index.tsx
@@ -21,6 +21,9 @@ export const LSCCH = ({
   const { watch } = useFormContext<FormData>();
   const data = watch();
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   useEffect(() => {
     if (setValidationFunctions) {
@@ -42,7 +45,10 @@ export const LSCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
+          <CMQ.DefinitionOfPopulation
+            coreset="child"
+            hybridMeasure={isHybrid}
+          />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/PPC2AD/index.tsx
+++ b/services/ui-src/src/measures/2025/PPC2AD/index.tsx
@@ -28,6 +28,9 @@ export const PPC2AD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,7 @@ export const PPC2AD = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="adult" />
           <CMQ.DataSource data={PMD.dataSourceData} type="adult" />
           <CMQ.DateRange type="adult" />
-          <CMQ.DefinitionOfPopulation hybridMeasure />
+          <CMQ.DefinitionOfPopulation hybridMeasure={isHybrid} />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/PPC2AD/index.tsx
+++ b/services/ui-src/src/measures/2025/PPC2AD/index.tsx
@@ -28,7 +28,7 @@ export const PPC2AD = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/PPC2CH/index.tsx
+++ b/services/ui-src/src/measures/2025/PPC2CH/index.tsx
@@ -28,6 +28,9 @@ export const PPC2CH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,10 @@ export const PPC2CH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
+          <CMQ.DefinitionOfPopulation
+            coreset="child"
+            hybridMeasure={isHybrid}
+          />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} hybridMeasure />

--- a/services/ui-src/src/measures/2025/PPC2CH/index.tsx
+++ b/services/ui-src/src/measures/2025/PPC2CH/index.tsx
@@ -28,7 +28,7 @@ export const PPC2CH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2025/WCCCH/index.tsx
@@ -28,7 +28,7 @@ export const WCCCH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
-  const isHybrid = data?.DataSource.includes(
+  const isHybrid = data?.DataSource?.includes(
     "HybridAdministrativeandMedicalRecordsData"
   );
 

--- a/services/ui-src/src/measures/2025/WCCCH/index.tsx
+++ b/services/ui-src/src/measures/2025/WCCCH/index.tsx
@@ -28,6 +28,9 @@ export const WCCCH = ({
   }, [setValidationFunctions]);
 
   const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+  const isHybrid = data?.DataSource.includes(
+    "HybridAdministrativeandMedicalRecordsData"
+  );
 
   return (
     <>
@@ -43,7 +46,10 @@ export const WCCCH = ({
           <CMQ.MeasurementSpecification type="HEDIS" coreset="child" />
           <CMQ.DataSource data={PMD.dataSourceData} type="child" />
           <CMQ.DateRange type="child" />
-          <CMQ.DefinitionOfPopulation coreset="child" hybridMeasure />
+          <CMQ.DefinitionOfPopulation
+            coreset="child"
+            hybridMeasure={isHybrid}
+          />
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updates were made to these hybrid measures: CBP-AD, CBP-HH, CCS-AD, CIS-CH, DEV-CH, HBD-AD, HPCMI-AD, IMA-CH, LSC-CH, PPC2-AD, PPC2-CH, WCC-CH.

The question: 
_If you are reporting as a hybrid measure, provide the measure eligible population and sample size._ 
will only display now if the user selects **Hybrid (Administrative and Medical Records Data)** in the Data Source section.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4202

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any user
2) Go to reporting year 2025, select CBP-AD or any of the measures listed above

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
