### PR TITLE
CMDCT-4105 - adds raw output to jq for consistency and non-breaking when we add playwright

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -16,9 +16,6 @@ permissions:
   contents: read
   actions: read
 
-env:
-  SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY }}
-
 jobs:
   destroy:
     # Protected branches should be designated as such in the GitHub UI.

--- a/services/output.sh
+++ b/services/output.sh
@@ -19,5 +19,5 @@ if [ $output = "url" ]; then
 fi
 
 cd $service
-serverless info --stage $stage --json | jq --arg output $output '.outputs[] | select(.OutputKey == $output) | .OutputValue'
+serverless info --stage $stage --json | jq --raw-output --arg output $output '.outputs[] | select(.OutputKey == $output) | .OutputValue'
 cd ..

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -66,8 +66,9 @@ custom:
       package:initialize: |
         set -e
         curl -L --output lambda_layer.zip https://github.com/CMSgov/lambda-clamav-layer/releases/download/0.7/lambda_layer.zip
+        cp lambda_layer.zip services/uploads/lambda_layer.zip
       deploy:finalize: |
-        rm lambda_layer.zip
+        rm lambda_layer.zip services/uploads/lambda_layer.zip
         aws lambda invoke --region ${self:provider.region} --function-name ${self:service}-${self:custom.stage}-avDownloadDefinitions --invocation-type Event response.json
         cat response.json
         rm response.json


### PR DESCRIPTION
See this description:
https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2536#issue-2773307466

The only thing of note here is adding --raw-output to the jq call so that there is no quotes in the env variable which causes playwright problems. This came up while upgrading HCBS and so I'd like it fixed here so that we don't have it come back up when we add playwright to seds and it just keeps the files matching across repos which is a nice to have.

I also snuck in a removal of the env variable for serverless v4 since @JonHolman correctly pointed out does nothing.