### PR TITLE
[CMDCT-4192] Core Set Delete Modal Render

### DIFF
--- a/services/ui-src/src/components/KebabMenu/index.tsx
+++ b/services/ui-src/src/components/KebabMenu/index.tsx
@@ -90,7 +90,9 @@ export const KebabMenu = ({
   menuLabel,
 }: KebabMenuProps) => {
   const [deleteDialogIsOpen, setDeleteDialogIsOpen] = useState(false);
-  const handleCloseDeleteDialog = () => setDeleteDialogIsOpen(false);
+  const handleCloseDeleteDialog = () => {
+    setDeleteDialogIsOpen(false);
+  };
   const cancelRef = useRef();
   const { isStateUser } = useUser();
 
@@ -190,6 +192,7 @@ const DeleteMenuItemAlertDialog = ({
             onSubmit={(e) => {
               e.preventDefault();
               handleDelete();
+              onClose();
             }}
           >
             <CUI.AlertDialogHeader fontSize="lg" fontWeight="bold">

--- a/services/ui-src/src/shared/types/MeasureTemplate.tsx
+++ b/services/ui-src/src/shared/types/MeasureTemplate.tsx
@@ -1,3 +1,4 @@
+import { ComponentFlagType } from "shared/commonQuestions/OptionalMeasureStrat/context";
 import { DataDrivenTypes } from "./TypeDataDriven";
 
 export interface customData {
@@ -29,6 +30,6 @@ export interface MeasureTemplateData {
   custom?: customData;
   opm?: {
     excludeOptions?: string[];
-    componentFlag?: string;
+    componentFlag?: ComponentFlagType;
   };
 }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Ignore the branch name, I forgot to rename it when I pushed it and that's on me.

This PR fixes the issues with the Delete Modal hanging after you press the delete button. The issue was caused by the fact that we deleted the flow from the process (hence the text is missing) but we never called the chakra command to close the modal so the render stayed while the text was removed.

The issue makes the modal look like this:
<img width="458" alt="Screenshot 2025-02-03 at 9 36 17 AM" src="https://github.com/user-attachments/assets/d021ff8a-deb5-4f77-8edd-839483b095af" />


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4192

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any state user
2) Select reporting year 2022
3) Add Child Core Set, you can choose either combined or multiple
4) In the Core Set Actions menu, select [Delete]
<img width="1220" alt="Screenshot 2025-02-03 at 9 34 54 AM" src="https://github.com/user-attachments/assets/fc2cc727-0a64-4ffa-aeb6-05fd30451c14" />

5) A modal will pop up. Follow the instructions to Delete Core Set
6) It should delete with no render issues.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
