### PR TITLE
PQI Combined Rates fix

### DIFF
--- a/services/app-api/handlers/rate/migratePqiMiscalculations.ts
+++ b/services/app-api/handlers/rate/migratePqiMiscalculations.ts
@@ -27,8 +27,6 @@ export const main = async () => {
     );
     logger.info(`Found ${allExistingRates.length} existing rates`);
 
-    // The new shape for combined rates has an "AdditionalValues" property.
-    // If a rate doesn't have that property, it's the old shape.
     const ratesNeedingMigration = allExistingRates.filter((rate) =>
       rate.measure.startsWith("PQI")
     );

--- a/services/app-api/handlers/rate/migratePqiMiscalculations.ts
+++ b/services/app-api/handlers/rate/migratePqiMiscalculations.ts
@@ -1,0 +1,55 @@
+import { logger } from "../../libs/debug-lib";
+import dynamodbLib from "../../libs/dynamodb-lib";
+import { CombinedRatesTableEntry } from "../../types";
+import { calculateAndPutRate } from "./rateCalculations";
+
+/**
+ * This is a data migration function for the rates table.
+ * During development of the feature, we changed the shape of its data.
+ * This script will look at every entry in the table and,
+ * if it is the old shape, recompute it from scratch and overwrite it.
+ *
+ * We should only need to run this twice: once in DEV, and once in VAL.
+ * The API version that produced the old data shape was never active in PROD.
+ *
+ * Once this script has been run, delete it! It should be idempotent but
+ * there is no need to keep it around. Be sure to delete the function from
+ * app-api/serverless.yml as well.
+ */
+export const main = async () => {
+  try {
+    logger.info("Scanning for existing combined rates");
+
+    const allExistingRates = await dynamodbLib.scanAll<CombinedRatesTableEntry>(
+      {
+        TableName: process.env.rateTable,
+      }
+    );
+    logger.info(`Found ${allExistingRates.length} existing rates`);
+
+    // The new shape for combined rates has an "AdditionalValues" property.
+    // If a rate doesn't have that property, it's the old shape.
+    const ratesNeedingMigration = allExistingRates.filter((rate) =>
+      rate.measure.startsWith("PQI")
+    );
+    logger.info(`Of those, ${ratesNeedingMigration.length} are PQI`);
+
+    for (let rate of ratesNeedingMigration) {
+      const { state, year, coreSet, measure } = rate;
+      const parameters = { state, year, coreSet, measure };
+      logger.info(`Processing rate ${JSON.stringify(parameters)}`);
+
+      // The combined core set is either ACS or CCS.
+      // We can build a separated core set abbr by adding "M" or "C",
+      // and it doesn't matter which. An update for either will combine both.
+      await calculateAndPutRate({ ...parameters, coreSet: coreSet + "M" });
+      logger.info("Calculation complete.");
+    }
+
+    logger.info("Migration complete!");
+    return { status: 200 };
+  } catch (err) {
+    logger.error("Error!", err);
+    return { status: 500 };
+  }
+};

--- a/services/app-api/handlers/rate/migratePqiMiscalculations.ts
+++ b/services/app-api/handlers/rate/migratePqiMiscalculations.ts
@@ -4,17 +4,17 @@ import { CombinedRatesTableEntry } from "../../types";
 import { calculateAndPutRate } from "./rateCalculations";
 
 /**
- * This is a data migration function for the rates table.
- * During development of the feature, we changed the shape of its data.
- * This script will look at every entry in the table and,
- * if it is the old shape, recompute it from scratch and overwrite it.
+ * This is a data migration function for the combined rates table.
+ * During development of the feature, we broke the calculation for PQI measures.
+ * The broken calculation was deployed all the way to production,
+ * and states submitted data against it.
  *
- * We should only need to run this twice: once in DEV, and once in VAL.
- * The API version that produced the old data shape was never active in PROD.
+ * The measure data itself is not affected,
+ * but the Combined Rates page for any PQI measure will display
+ * a rate that is 1000x smaller than it should be.
  *
- * Once this script has been run, delete it! It should be idempotent but
- * there is no need to keep it around. Be sure to delete the function from
- * app-api/serverless.yml as well.
+ * Now that the calculation is fixed,
+ * this migration will correct all existing combined rate entries.
  */
 export const main = async () => {
   try {

--- a/services/app-api/handlers/rate/rateNDRCalculations.test.ts
+++ b/services/app-api/handlers/rate/rateNDRCalculations.test.ts
@@ -177,7 +177,12 @@ describe("NDR calculations for Combined Rates", () => {
     expect(result[0].Combined.rate).toBe(333.3);
 
     // PQI-AD: per hundred thousand
-    result = combineRates("PQI-AD", dataSources, medicaidMeasure, chipMeasure);
+    result = combineRates(
+      "PQI01-AD",
+      dataSources,
+      medicaidMeasure,
+      chipMeasure
+    );
     expect(result[0].Combined.rate).toBe(33333.3);
   });
 

--- a/services/app-api/handlers/rate/rateNDRCalculations.ts
+++ b/services/app-api/handlers/rate/rateNDRCalculations.ts
@@ -245,7 +245,10 @@ const transformQuotient = (
       return (1 - quotient) * 100;
     case "AMB-CH":
       return quotient * 1000;
-    case "PQI-AD":
+    case "PQI01-AD":
+    case "PQI05-AD":
+    case "PQI08-AD":
+    case "PQI15-AD":
       return quotient * 100000;
     default:
       return quotient * 100;

--- a/services/app-api/libs/dynamodb-lib.ts
+++ b/services/app-api/libs/dynamodb-lib.ts
@@ -14,10 +14,14 @@ import {
   paginateScan,
   paginateQuery,
 } from "@aws-sdk/lib-dynamodb";
-import { CoreSet, Measure, Banner } from "../types";
+import { CoreSet, Measure, Banner, CombinedRatesTableEntry } from "../types";
 import { logger } from "./debug-lib";
 
-export type QmrDynamoTableType = CoreSet | Measure | Banner;
+export type QmrDynamoTableType =
+  | CoreSet
+  | Measure
+  | Banner
+  | CombinedRatesTableEntry;
 
 const localConfig = {
   endpoint: process.env.DYNAMODB_URL,

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -260,6 +260,13 @@ export type EventParameters = Record<string, string | undefined>;
 /**
  * This is the shape of data saved to the Rates table.
  */
+export type CombinedRatesTableEntry = RateParameters & {
+  /** This will be `${stateAbbr}${year}${coreSetAbbr}`. Example: `MI2024ACS` */
+  compoundKey: string;
+  lastAltered: number;
+  data: CombinedRatesPayload;
+};
+
 export type CombinedRatesPayload = {
   /**
    * Lists the data sources the user entered when completing the rate.


### PR DESCRIPTION
### Description
This PR addresses an issue introduced by PR #2386.

Context: PQI rates differ from most. Rather than a percentage, the rate is displayed as per hundred thousand. Prior to the refactor in 2386, our combined rate code would use the 100k multiplier if the first three letters of the measure abbreviation were PQI. After my refactor, we only use that multiplier if the measure abbreviation is `PQI-AD` exactly. Unfortunately, there is no such measure. There are actually _four_ PQI measures: `PQI01-AD`, `PQI05-AD`, `PQI08-AD`, and `PQI15-AD`. This is now reflected in the code.

Since that refactor was done after UAT testing had begun, but before the feature went live, all existing combined rates for PQI measures in production are incorrect. Thus, this PR also contains a migration to recalculate all of those values. This can be done pretty neatly, because the calculation is entirely server-side: Read the separate values from the measures table, perform the calculation, and write the result to the rates table.

### Related ticket(s)
CMDCT-

---
### How to test
1. Log in to QMR as a state user, for a state that uses combined rates
2. Enter some values for PQI01-AD in the CHIP core set. Note the calculated rate value.
3. Enter some values for PQI01-AD in the Medicaid core set. Note the calculated rate value.
4. Go to the combined rates page for PQI01-AD. The calculated combined rate should be about the same as the individual values. Notably, it should _not_ be 1000 times smaller.
5. I guess poke around some of the other PQI measures? If you like.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
