### PR TITLE
[QMR] LRCD-CH & CIS-CH 2025 Updates

### DIFF
--- a/services/ui-src/src/components/AutocompletedMeasureTemplate/index.tsx
+++ b/services/ui-src/src/components/AutocompletedMeasureTemplate/index.tsx
@@ -67,8 +67,7 @@ export const AutocompletedMeasureTemplate = ({
           <CUI.Text fontWeight="700">
             {`States are not asked to report data for this measure for ${
               featuresByYear.displayFFYLanguage ? "FFY" : ""
-            } ${year} Core Set reporting in the online
-            reporting system.`}
+            } ${year} Core Set reporting.`}
           </CUI.Text>
         </CUI.Stack>
 

--- a/services/ui-src/src/measures/2025/LRCDCH/index.tsx
+++ b/services/ui-src/src/measures/2025/LRCDCH/index.tsx
@@ -10,7 +10,7 @@ export const LRCDCH = ({ name, year }: Props) => {
     <QMR.AutocompletedMeasureTemplate
       year={year}
       measureTitle={`LRCD-CH - ${name}`}
-      performanceMeasureText="Percentage of nulliparous (first birth), term (37 or more completed weeks based on the obstetric estimate), singleton (one fetus), in a cephalic presentation (head-first) births delivered by cesarean during the measurement year."
+      performanceMeasureText="Percentage of nulliparous (first birth), term (37 or more completed weeks based on the obstetric estimate), singleton (one fetus), in a cephalic presentation (head-first) births to mothers under age 20 delivered by cesarean during the measurement year."
       performanceMeasureSubtext="To reduce state burden and streamline reporting, CMS will calculate
       this measure for states using state natality data obtained through
       the Centers for Disease Control and Prevention Wide-ranging Online

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -489,22 +489,6 @@ export const data = {
                 "id": "VxUjMm",
                 "excludeFromOMS": true
             },
-            {
-                "label": "Combo 3",
-                "text": "Combo 3",
-                "id": "aI8KQ7"
-            },
-            {
-                "label": "Combo 7",
-                "text": "Combo 7",
-                "id": "xOvucQ",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Combo 10",
-                "text": "Combo 10",
-                "id": "UwzvFc"
-            }
         ],
         "categories": [{"id":"u7wDB2", "label": "", "text":""}]
     },

--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -479,7 +479,7 @@ export const measureDescriptions: MeasureList = {
       "Follow-Up After Emergency Department Visit for Mental Illness: Ages 6 to 17",
     "IMA-CH": "Immunizations for Adolescents",
     "LBW-CH": "Live Births Weighing Less Than 2,500 Grams",
-    "LRCD-CH": "Low-Risk Cesarean Delivery",
+    "LRCD-CH": "Low-Risk Cesarean Delivery: Under Age 20",
     "LSC-CH": "Lead Screening in Children",
     "OEV-CH": "Oral Evaluation, Dental Services",
     "OEVP-CH": "Oral Evaluation During Pregnancy: Ages 15 to 20",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
**CIS-CH updates**
- Remove Combination 3, Combination 7 & Combination 10

**LRCD-CH updates**
- Update measure name
- Update measure description
- Note the text change is universally applied and Cam confirmed "It should be on all the non-reportable measures": 
   > States are not asked to report data for this measure for 2025 Core Set reporting in the online reporting system.
    <img width="400" alt="measure data for LRCD-CH" src="https://github.com/user-attachments/assets/c5d12615-c5d8-4bf9-a668-456586180fed">



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4407 (CIS-CH)
CMDCT-4408 (LRCD-CH)

---
### How to test
**Deploy Link:** https://d29h2z31uv9jni.cloudfront.net/

1. Sign into QMR, any state user
2. In FY 2025, go to the Child Core Set
3. Select CIS-CH
5. Fill out the measure
6. Make sure that the rate labels are removed and match the jira ticket
7. Go back and select LRCD-CH
8. Make sure measure name, and description and additional text at the bottom match Jira ticket

---

### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
