### PR TITLE
[QMR] OEV-CH Update

### DIFF
--- a/services/ui-src/src/measures/2025/OEVCH/data.ts
+++ b/services/ui-src/src/measures/2025/OEVCH/data.ts
@@ -8,7 +8,7 @@ export const data: MeasureTemplateData = {
   coreset: "child",
   performanceMeasure: {
     questionText: [
-      "Percentage of enrolled children under age 21 who received a comprehensive or periodic oral evaluation within the measurement year. For 2025 Child Core Set reporting, the following rate is required: Total ages < 1 to 20.",
+      "Percentage of enrolled children under age 21 who received a comprehensive or periodic oral evaluation within the measurement year. For 2025 Child Core Set reporting, the following rate is required: Total (<Age 21).",
     ],
     categories,
     qualifiers,

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -1208,15 +1208,9 @@ export const data = {
     "OEV-CH": {
         "qualifiers": [
             {
-                "label": "Age <1",
-                "text": "Age <1",
+                "label": "Age < 3",
+                "text": "Age < 3",
                 "id": "cJpLzk",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Ages 1 to 2",
-                "text": "Ages 1 to 2",
-                "id": "lUpXnj",
                 "excludeFromOMS": true
             },
             {
@@ -1226,44 +1220,20 @@ export const data = {
                 "excludeFromOMS": true
             },
             {
-                "label": "Ages 6 to 7",
-                "text": "Ages 6 to 7",
+                "label": "Ages 6 to 14",
+                "text": "Ages 6 to 14",
                 "id": "HQtz8Q",
                 "excludeFromOMS": true
             },
             {
-                "label": "Ages 8 to 9",
-                "text": "Ages 8 to 9",
-                "id": "lw6tF8",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Ages 10 to 11",
-                "text": "Ages 10 to 11",
-                "id": "iS0hVY",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Ages 12 to 14",
-                "text": "Ages 12 to 14",
-                "id": "OAxju0",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Ages 15 to 18",
-                "text": "Ages 15 to 18",
+                "label": "Ages 15 to 20",
+                "text": "Ages 15 to 20",
                 "id": "0B13E5",
                 "excludeFromOMS": true
             },
             {
-                "label": "Ages 19 to 20",
-                "text": "Ages 19 to 20",
-                "id": "2v1LvP",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Total ages <1 to 20 (required rate)",
-                "text": "Total ages <1 to 20 (required rate)",
+                "label": "Total (< Age 21) (required rate)",
+                "text": "Total (< Age 21) (required rate)",
                 "id": "Total"
             }
         ],


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Performance Measure Question Text:
- Replace "ages < 1 to 20" --> "(<Age 21)"

Rate categories:
- Replace "Age <1" & "Ages 1 to 2" --> "Age < 3"
- Replace "Ages 6 to 7", "Ages 8 to 9", "Ages 10 to 11" & "Ages 12 to 14" --> "Ages 6 to 14" 
- Replace "Ages 15 to 18" & "Ages 19 to 20" --> "Ages 15 to 20" 
- Replace "Total ages <1 to 20 (required rate)" --> "Total (< Age 21) (required rate)"

Optional Measure Stratification rate label:
- Automatically updates from above change to rate ranges --> "Total (< Age 21) (required rate)"

### Related ticket(s)
CMDCT-4409

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
**Deploy Link:** https://do809kyukddsm.cloudfront.net/
1. Login with any state user
2. Select any Child Core Set for 2025
3. Select OEV-CH to confirm change
4. Scroll to "Measurement Specification" question and select "American Dental Association/Dental Quality Alliance (ADA/DQA)" for question 
5. Fill out Numerator, Denominator values so that Optional Measure Stratification section comes up
6. Confirm content changes match Jira ticket
    <img width="500" alt="Rate categories updated" src="https://github.com/user-attachments/assets/1b4c5b9b-e32c-435c-bb45-39f01387c74a">
     <img width="500" alt="Rate categories updated for Optional Measure Stratification section" src="https://github.com/user-attachments/assets/816435d7-0515-4e9a-85a7-3ef98b9db8b2">

---
### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary