### PR TITLE
CDMCT-4410, CMDCT-4412: updates for SFMCH and COLHH

### DIFF
--- a/services/ui-src/src/measures/2025/COLHH/data.ts
+++ b/services/ui-src/src/measures/2025/COLHH/data.ts
@@ -19,18 +19,6 @@ export const data: MeasureTemplateData = {
       "If reporting entities (e.g., health plans) used different data sources, please select all applicable data sources used below.",
     options: [
       {
-        value: DC.ADMINISTRATIVE_DATA,
-        subOptions: [
-          {
-            label: "What is the Administrative Data Source?",
-            options: [
-              { value: DC.MEDICAID_MANAGEMENT_INFO_SYSTEM },
-              { value: DC.ADMINISTRATIVE_DATA_OTHER, description: true },
-            ],
-          },
-        ],
-      },
-      {
         value: DC.ELECTRONIC_CLINIC_DATA_SYSTEMS,
         subOptions: [
           {

--- a/services/ui-src/src/measures/2025/SFMCH/data.ts
+++ b/services/ui-src/src/measures/2025/SFMCH/data.ts
@@ -8,7 +8,7 @@ export const data: MeasureTemplateData = {
   coreset: "child",
   performanceMeasure: {
     questionText: [
-      "Percentage of enrolled children who have ever received sealants on permanent first molar teeth: (1) at least one sealant and (2) all four molars sealed by the 10th birthdate.",
+      "Percentage of enrolled children who have ever received sealants on permanent first molar teeth by the 10th birthdate: (1) at least one sealant and (2) all four molars sealed.",
     ],
     questionListItems: [],
     categories,


### PR DESCRIPTION
### Description
1. CMDCT-4410: Reworded SFM-CH
2. CMDCT-4412: Removed the Administrative option for data sources. I assume I was supposed to remove the whole option and not just the word...

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4410, CMDCT-4412

---
### How to test

CMDCT-4410 test:
1. Log in as any QMR user
2. navigate to 2025 child measures and go to SFM-CH measure
3. Make sure it matches this "Percentage of enrolled children who have ever received sealants on permanent first molar teeth by the 10th birthdate: (1) at least one sealant and (2) all four molars sealed. "

CMDCT-4412 test:
1. navigate to 2025 health home measures and go to COL-HH measure
2. Make sure the "Administrative" option is no longer showing in data sources section
