### PR TITLE
CMDCT-4411, CMDCT-4413: 2025 updates for TFL-CH and OUD-HH

### DIFF
--- a/services/ui-src/src/measures/2025/OUDHH/data.ts
+++ b/services/ui-src/src/measures/2025/OUDHH/data.ts
@@ -4,11 +4,11 @@ import { MeasureTemplateData } from "shared/types/MeasureTemplate";
 export const { categories, qualifiers } = getCatQualLabels("OUD-HH");
 
 export const data: MeasureTemplateData = {
-  type: "CMS",
+  type: "SAMHSA",
   coreset: "health",
   performanceMeasure: {
     questionText: [
-      "Percentage of health home enrollees ages 18 to 64 with an opioid use disorder (OUD) who filled a prescription for or were administered or dispensed an FDA-approved medication for the disorder during the measurement year. Five rates are reported:",
+      "Percentage of health home enrollees age 18 and older with an opioid use disorder (OUD) who filled a prescription for or were administered or dispensed an FDA-approved medication for the disorder during the measurement year. Five rates are reported:",
       "A total (overall) rate capturing any medications used in medication assisted treatment of opioid dependence and addiction (Rate 1).",
       "Four separate rates representing the following types of FDA-approved drug products:",
     ],

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -1607,38 +1607,14 @@ export const data = {
                 "excludeFromOMS": true
             },
             {
-                "label": "Ages 6 to 7",
-                "text": "Ages 6 to 7",
+                "label": "Ages 6 to 14",
+                "text": "Ages 6 to 14",
                 "id": "zcbPe0",
                 "excludeFromOMS": true
             },
             {
-                "label": "Ages 8 to 9",
-                "text": "Ages 8 to 9",
-                "id": "OdDTxr",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Ages 10 to 11",
-                "text": "Ages 10 to 11",
-                "id": "Cjw7GS",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Ages 12 to 14",
-                "text": "Ages 12 to 14",
-                "id": "muOeEP",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Ages 15 to 18",
-                "text": "Ages 15 to 18",
-                "id": "fbpAPY",
-                "excludeFromOMS": true
-            },
-            {
-                "label": "Ages 19 to 20",
-                "text": "Ages 19 to 20",
+                "label": "Ages 15 to 20",
+                "text": "Ages 15 to 20",
                 "id": "a6okZM",
                 "excludeFromOMS": true
             },


### PR DESCRIPTION
### Description
CMDCT-4411: updating rate labels for TFL-CH
CMDCT-4413: updating wording and measure steward for OUD-HH


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4411, CMDCT-4413

---
### How to test

cloudfront link: https://d2utz4njmp68fo.cloudfront.net/

CMDCT-4411 test:
1. Log in as any QMR user
2. Navigate to 2025 child measures and go to TFL-CH
3. Observe that the measure rates under Performance measure section now have the groups: 1-2, 3-5, 6-14, 15-20 and 1-20 total

CMDCT-4413 test:
1. Log into state with HH measures such as DC
2. Navigate to 2025 child measures and go to OUD-HH
3. Observe that the measure steward (first option under Measurement Specifications) is now "Substance Abuse and Mental Health  Services Administration (SAMHSA)"
4. Also observe that the wording under Performance Measure is "Percentage of health home enrollees _age 18 and older_ ...."
