### PR TITLE
CMDCT-4434: OEVP-AD 2025 updates

### DIFF
--- a/services/ui-src/src/measures/2025/OEVPAD/data.ts
+++ b/services/ui-src/src/measures/2025/OEVPAD/data.ts
@@ -7,7 +7,9 @@ export const data: MeasureTemplateData = {
   type: "ADA-DQA",
   coreset: "adult",
   performanceMeasure: {
-    questionText: ["."],
+    questionText: [
+      "Percentage of enrolled persons ages 21 to 44 with live-birth deliveries in the measurement year who received a comprehensive or periodic oral evaluation during pregnancy.",
+    ],
     categories,
     qualifiers,
   },

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -1272,8 +1272,8 @@ export const data = {
     "OEVP-AD": {
         "qualifiers": [
             {
-                "label": "",
-                "text": "",
+                "label": "Ages 21 to 44",
+                "text": "Ages 21 to 44",
                 "id": "wnh2qA",
             },
         ],


### PR DESCRIPTION
### Description
updating performance measure question and rate label text for OEVP-AD


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4434

---
### How to test

cloudfront link: https://dbt3tdm9w15ho.cloudfront.net/

1. Log in as any user
2. Navigate to 2025 adult measures and go to OEVP-AD
3. Make sure that under Performance Measure you see "Percentage of enrolled persons ages 21 to 44 with live-birth deliveries in the measurement year who received a comprehensive or periodic oral evaluation during pregnancy."
4. Also make sure you see "Ages 21 to 44" as the rate label