### PR TITLE
2025 New Measure - EDV-AD Details

### DIFF
--- a/services/ui-src/src/measures/2025/EDVAD/data.ts
+++ b/services/ui-src/src/measures/2025/EDVAD/data.ts
@@ -7,11 +7,14 @@ export const data: MeasureTemplateData = {
   type: "ADA-DQA",
   coreset: "adult",
   performanceMeasure: {
-    questionText: [""],
+    questionText: [
+      "Number of emergency department (ED) visits for ambulatory care sensitive non-traumatic dental conditions per 100,000 beneficiary months for adults age 18 and older",
+    ],
     categories,
     qualifiers,
   },
   custom: {
-    calcTotal: true,
+    rateScale: 100000,
+    allowNumeratorGreaterThanDenominator: true,
   },
 };

--- a/services/ui-src/src/measures/2025/EDVAD/validation.ts
+++ b/services/ui-src/src/measures/2025/EDVAD/validation.ts
@@ -46,12 +46,6 @@ const EDVADValidation = (data: FormData) => {
     ),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
-    ...GV.validateNumeratorsLessThanDenominatorsPM(
-      performanceMeasureArray,
-      OPM,
-      ageGroups
-    ),
-    ...GV.validateTotalNDR(performanceMeasureArray, undefined, undefined),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
@@ -65,8 +59,6 @@ const EDVADValidation = (data: FormData) => {
         PMD.categories
       ),
       validationCallbacks: [
-        GV.validateNumeratorLessThanDenominatorOMS(),
-        GV.validateOMSTotalNDR(),
         GV.validateRateNotZeroOMS(),
         GV.validateRateZeroOMS(),
       ],

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -623,9 +623,14 @@ export const data = {
     "EDV-AD": {
         "qualifiers": [
             {
-                "label": "",
-                "text": "",
+                "label": "Ages 18 to 64",
+                "text": "Ages 18 to 64",
                 "id": "v8WDHi",
+            },
+            {
+                "label": "Age 65 and older",
+                "text": "Age 65 and older",
+                "id": "wfUxHA",
             },
         ],
         "categories": [{"id":"EXQjVl", "label": "", "text":""}]


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
New Measure EDV-AD.

In this measure numerator can be larger than the denominator, so those validations have been removed.

**Changes**
Performance measure:
_Number of emergency department (ED) visits for ambulatory care sensitive non-traumatic dental conditions per 100,000 beneficiary months for adults age 18 and older_

Rate Labels
![Screenshot 2025-05-05 at 4 04 47 PM](https://github.com/user-attachments/assets/bbeaee75-7d9c-4bd8-8873-426f6a56c756)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4451

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any state user
2) In FY 2025, go to the Adult Core Set
3) Select EDV-AD
4) Fill out the measure 
5) Make sure that the performance measure text is updated and the rate labels match the jira ticket

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
