### PR TITLE
Stratification - Hide "Add Another Sex" option behind a launch darkly flag

### DIFF
--- a/services/ui-src/src/measures/2025/OEVPAD/data.ts
+++ b/services/ui-src/src/measures/2025/OEVPAD/data.ts
@@ -13,7 +13,4 @@ export const data: MeasureTemplateData = {
     categories,
     qualifiers,
   },
-  custom: {
-    calcTotal: true,
-  },
 };

--- a/services/ui-src/src/measures/2025/OEVPAD/validation.ts
+++ b/services/ui-src/src/measures/2025/OEVPAD/validation.ts
@@ -51,7 +51,6 @@ const OEVPADValidation = (data: FormData) => {
       OPM,
       ageGroups
     ),
-    ...GV.validateTotalNDR(performanceMeasureArray, undefined, undefined),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
@@ -66,7 +65,6 @@ const OEVPADValidation = (data: FormData) => {
       ),
       validationCallbacks: [
         GV.validateNumeratorLessThanDenominatorOMS(),
-        GV.validateOMSTotalNDR(),
         GV.validateRateNotZeroOMS(),
         GV.validateRateZeroOMS(),
       ],

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -162,8 +162,9 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
     return <NDRSets name={`${props.name}.rateData`} />;
   }
 
+  //a flag added in 2025, if it's turned off, it'll hide add more for the sex (O8BrOa) category
   const sogiFlag =
-    !useFlags()?.["sogi-stratification-options"] &&
+    useFlags()?.["sogi-stratification-options"] &&
     props.id === "O8BrOa" &&
     props.year! >= 2025;
 
@@ -188,7 +189,7 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
           }),
         ]}
       />
-      {props.addMore && !sogiFlag && (
+      {props.addMore && (props.id !== "O8BrOa" || sogiFlag) && (
         <AddAnotherSection
           name={props.name}
           flagSubCat

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -1,5 +1,6 @@
 import * as QMR from "components";
 import * as CUI from "@chakra-ui/react";
+import { useFlags } from "launchdarkly-react-client-sdk";
 
 import { OmsNode } from "shared/types";
 
@@ -161,6 +162,11 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
     return <NDRSets name={`${props.name}.rateData`} />;
   }
 
+  const sogiFlag =
+    !useFlags()?.["sogi"] &&
+    props.parentDisplayName === "08Br0a" &&
+    props.year! >= parseInt("2025");
+
   return (
     <CUI.Box key={`${props.name}.topLevelCheckbox`}>
       <QMR.Checkbox
@@ -182,7 +188,7 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
           }),
         ]}
       />
-      {props.addMore && (
+      {props.addMore && !sogiFlag && (
         <AddAnotherSection
           name={props.name}
           flagSubCat

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -162,7 +162,7 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
     return <NDRSets name={`${props.name}.rateData`} />;
   }
 
-  //a flag added in 2025, if it's turned off, it'll hide add more for the sex (O8BrOa) category
+  //a flag added in 2025, if it's turned off, it'll hide [+Add Another Sex] button
   const sogiFlag =
     useFlags()?.["sogi-stratification-options"] &&
     props.id === "O8BrOa" &&

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -163,9 +163,7 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
   }
 
   const sogiFlag =
-    !useFlags()?.["sogi"] &&
-    props.parentDisplayName === "08Br0a" &&
-    props.year! >= parseInt("2025");
+    !useFlags()?.["sogi"] && props.id === "O8BrOa" && props.year! >= 2025;
 
   return (
     <CUI.Box key={`${props.name}.topLevelCheckbox`}>

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -163,7 +163,9 @@ export const TopLevelOmsChildren = (props: CheckboxChildrenProps) => {
   }
 
   const sogiFlag =
-    !useFlags()?.["sogi"] && props.id === "O8BrOa" && props.year! >= 2025;
+    !useFlags()?.["sogi-stratification-options"] &&
+    props.id === "O8BrOa" &&
+    props.year! >= 2025;
 
   return (
     <CUI.Box key={`${props.name}.topLevelCheckbox`}>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
New flag requested to hide the [+Add Another Sex] button.

![Screenshot 2025-05-06 at 12 27 20 PM](https://github.com/user-attachments/assets/012720cb-63c5-408c-92d6-e6f135f081fc)


Also added some changes to OEVP-AD measures, it doesn't capture totals so that shouldn't be there

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4496

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Deploy Link: https://d6snmp8xle1v2.cloudfront.net/

1) Sign into QMR, any state user
2) Go to any measure i.e. AAB-AB
3) Fill out **Measure Specification** Section to enable the performance measure
4) Scroll down to the **Performance Measure** Section and fill out an N/D/R set. This will enable the OMS section
5) Click the check box next to the option [ ] Sex and see that the  [+Add Another Sex] button is gone.

![Screenshot 2025-05-06 at 12 30 59 PM](https://github.com/user-attachments/assets/d11eebcb-1107-472f-945e-e8873dbe408e)

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
