### PR TITLE
CMDCT-4363 master and isDev behind VPN (QMR only)

### DIFF
--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -192,7 +192,8 @@ function setupWaf(
   });
 
   const wafRules: wafv2.CfnWebACL.RuleProperty[] = [];
-  if (isDev && vpnIpSetArn && vpnIpv6SetArn) {
+  const vpnOnly = (isDev || stage === "master") && vpnIpSetArn && vpnIpv6SetArn;
+  if (vpnOnly) {
     // Additional Rules for this WAF only because CMS asked to have the application made vpn only
     wafRules.push(
       {


### PR DESCRIPTION
Follow up to CMDCT-4363 main big PR (https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2590)
Just makes master like ephemeral environments, which is to say, behind the VPN.