### PR TITLE
CMDCT-4363 - fixes broken destroy

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -58,7 +58,6 @@ jobs:
       - name: Destroy
         run: |
           ./run destroy --stage $branch_name --verify false
-          serverless reconcile
 
   # Notify the integrations channel when a destroy action fails
   notify_on_destroy_failure:


### PR DESCRIPTION
Follow on to:
https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2590
Basically destroy is broken because it is still using serverless. This removes that.