### PR TITLE
[QMR] 2025 New Measure - OEVP-CH Details

### DIFF
--- a/services/ui-src/src/measures/2025/OEVPCH/data.ts
+++ b/services/ui-src/src/measures/2025/OEVPCH/data.ts
@@ -14,30 +14,4 @@ export const data: MeasureTemplateData = {
     categories,
     qualifiers,
   },
-  dataSource: {
-    optionsLabel:
-      "If reporting entities (e.g., health plans) used different data sources, please select all applicable data sources used below.",
-    options: [
-      {
-        value: DC.ADMINISTRATIVE_DATA,
-        subOptions: [
-          {
-            label: "What is the Administrative Data Source?",
-            options: [
-              {
-                value: DC.MEDICAID_MANAGEMENT_INFO_SYSTEM,
-              },
-              {
-                value: DC.ADMINISTRATIVE_DATA_OTHER,
-                description: true,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-  custom: {
-    calcTotal: true,
-  },
 };

--- a/services/ui-src/src/measures/2025/OEVPCH/data.ts
+++ b/services/ui-src/src/measures/2025/OEVPCH/data.ts
@@ -1,6 +1,5 @@
 import { getCatQualLabels } from "../rateLabelText";
 import { MeasureTemplateData } from "shared/types/MeasureTemplate";
-import * as DC from "dataConstants";
 
 export const { categories, qualifiers } = getCatQualLabels("OEVP-CH");
 

--- a/services/ui-src/src/measures/2025/OEVPCH/data.ts
+++ b/services/ui-src/src/measures/2025/OEVPCH/data.ts
@@ -1,5 +1,6 @@
 import { getCatQualLabels } from "../rateLabelText";
 import { MeasureTemplateData } from "shared/types/MeasureTemplate";
+import * as DC from "dataConstants";
 
 export const { categories, qualifiers } = getCatQualLabels("OEVP-CH");
 
@@ -7,9 +8,34 @@ export const data: MeasureTemplateData = {
   type: "ADA-DQA",
   coreset: "child",
   performanceMeasure: {
-    questionText: ["."],
+    questionText: [
+      "Percentage of enrolled persons ages 15 to 20 with live-birth deliveries in the measurement year who received a comprehensive or periodic oral evaluation during pregnancy. ",
+    ],
     categories,
     qualifiers,
+  },
+  dataSource: {
+    optionsLabel:
+      "If reporting entities (e.g., health plans) used different data sources, please select all applicable data sources used below.",
+    options: [
+      {
+        value: DC.ADMINISTRATIVE_DATA,
+        subOptions: [
+          {
+            label: "What is the Administrative Data Source?",
+            options: [
+              {
+                value: DC.MEDICAID_MANAGEMENT_INFO_SYSTEM,
+              },
+              {
+                value: DC.ADMINISTRATIVE_DATA_OTHER,
+                description: true,
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
   custom: {
     calcTotal: true,

--- a/services/ui-src/src/measures/2025/OEVPCH/validation.ts
+++ b/services/ui-src/src/measures/2025/OEVPCH/validation.ts
@@ -51,7 +51,6 @@ const OEVPCHValidation = (data: FormData) => {
       OPM,
       ageGroups
     ),
-    ...GV.validateTotalNDR(performanceMeasureArray, undefined, undefined),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
 
     // OMS Validations
@@ -66,7 +65,6 @@ const OEVPCHValidation = (data: FormData) => {
       ),
       validationCallbacks: [
         GV.validateNumeratorLessThanDenominatorOMS(),
-        GV.validateOMSTotalNDR(),
         GV.validateRateNotZeroOMS(),
         GV.validateRateZeroOMS(),
       ],

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -1282,8 +1282,8 @@ export const data = {
     "OEVP-CH": {
         "qualifiers": [
             {
-                "label": "",
-                "text": "",
+                "label": "Ages 15 to 20",
+                "text": "Ages 15 to 20",
                 "id": "Xq5NFt",
             },
         ],

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -1476,13 +1476,13 @@ export const data = {
         "qualifiers":[
             {
                 "label": "Depression Screening: Under Age 21", 
-                "text":"Depression Screening: Under Age 21",
-                "id":"Au9Fm5" 
+                "text": "Depression Screening: Under Age 21",
+                "id": "Au9Fm5" 
             },
             {
                 "label": "Follow-Up Positive Screen: Under Age 21", 
-                "text":"Follow-Up Positive Screen: Under Age 21",
-                "id":"np7XV9" 
+                "text": "Follow-Up Positive Screen: Under Age 21",
+                "id": "np7XV9" 
             },
         ],
         "categories": [{"id":"0YSQj5", "label": "", "text":""}]


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR covers adding measure details for measure "OEVP-CH" NOT to be confused with "OEV-CH"
- Performance Measure text update
- Data source: Administrative
- Rate Label: "Ages 15 to 20"

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4454

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
**Deploy Link:** https://jiraent.cms.gov/browse/CMDCT-4454

1. Sign into QMR, any state user
2. In FY 2025, go to either Child Core Set
3. Select OEVP-CH
4. Fill out the measure
5. Make sure that the performance measure text is updated and the rate labels match the jira ticket

Data Source
<img width="400" alt="Data source is administrative" src="https://github.com/user-attachments/assets/9e2df790-af88-4327-95c8-e84788abb9f3">
Performance Measure
<img width="400" alt="performance measure text updated" src="https://github.com/user-attachments/assets/a69b89a3-b0fa-49ff-a907-6f32528e8223">
Same for OMS section
<img width="400" alt="Optional Measure Stratification section shows rate labels" src="https://github.com/user-attachments/assets/ab3a78f7-215b-48a4-a749-d65ca0c4fc0e">

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary