### PR TITLE
CMDCT-4435: New 2025 measure PDS-AD

### DIFF
--- a/services/ui-src/src/measures/2025/PDSAD/data.ts
+++ b/services/ui-src/src/measures/2025/PDSAD/data.ts
@@ -1,0 +1,47 @@
+import { getCatQualLabels } from "../rateLabelText";
+import { MeasureTemplateData } from "shared/types/MeasureTemplate";
+import * as DC from "dataConstants";
+
+export const { categories, qualifiers } = getCatQualLabels("PDS-AD");
+
+export const data: MeasureTemplateData = {
+  type: "HEDIS",
+  coreset: "adult",
+  performanceMeasure: {
+    questionText: [
+      "The percentage of deliveries in which beneficiaries were screened for clinical depression during the postpartum period, and if screened positive, received follow-up care.",
+    ],
+    questionListTitles: [
+      "Depression Screening",
+      "Follow-Up on Positive Screen",
+    ],
+    questionListItems: [
+      "– The percentage of deliveries in which beneficiaries were screened for clinical depression using a standardized instrument during the postpartum period.",
+      "– The percentage of deliveries in which beneficiaries received follow-up care within 30 days of a positive depression screen finding.",
+    ],
+    categories,
+    qualifiers,
+  },
+  dataSource: {
+    optionsLabel:
+      "If reporting entities (e.g., health plans) used different data sources, please select all applicable data sources used below.",
+    options: [
+      {
+        value: DC.ELECTRONIC_CLINIC_DATA_SYSTEMS,
+        subOptions: [
+          {
+            options: [
+              { value: DC.ELECTRONIC_HEALTH_RECORDS_PERSONAL_HEALTH_REGISTRY },
+              { value: DC.HEALTH_INFORMATION_EXCHANGE_CLINICAL_REGISTRY },
+              { value: DC.CASE_MANAGEMENT_SYSTEM },
+              { value: DC.ADMINISTRATIVE_DATA },
+            ],
+          },
+        ],
+        description: true,
+      },
+      { value: DC.ELECTRONIC_HEALTH_RECORDS, description: true },
+      { value: DC.OTHER_DATA_SOURCE, description: true },
+    ],
+  },
+};

--- a/services/ui-src/src/measures/2025/PDSAD/data.ts
+++ b/services/ui-src/src/measures/2025/PDSAD/data.ts
@@ -40,8 +40,6 @@ export const data: MeasureTemplateData = {
         ],
         description: true,
       },
-      { value: DC.ELECTRONIC_HEALTH_RECORDS, description: true },
-      { value: DC.OTHER_DATA_SOURCE, description: true },
     ],
   },
 };

--- a/services/ui-src/src/measures/2025/PDSAD/validation.ts
+++ b/services/ui-src/src/measures/2025/PDSAD/validation.ts
@@ -21,39 +21,33 @@ const PDSValidation = (data: FormData) => {
     return errorArray;
   }
 
-  console.log("DATA IN VALIDATION", data);
-
   errorArray = [
+    ...errorArray,
+    ...GV.validateOneQualDenomHigherThanOtherDenomPM(data, PMD),
+    ...GV.validateAtLeastOneRateComplete(
+      performanceMeasureArray,
+      OPM,
+      PMD.qualifiers,
+      PMD.categories
+    ),
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateOPMRates(OPM),
-    ...GV.validateAtLeastOneDataSource(data),
-    ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateNumeratorsLessThanDenominatorsPM(
+      performanceMeasureArray,
+      OPM,
+      PMD.qualifiers
+    ),
     ...GV.validateDeviationTextFieldFilled(
       didCalculationsDeviate,
       deviationReason
     ),
+    ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDataSourceType(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
-
-    // Performance Measure Validations
-    ...GV.validateAtLeastOneRateComplete(
-      performanceMeasureArray,
-      OPM,
-      ageGroups,
-      PMD.categories
-    ),
-    ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
-    ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
-    ...GV.validateNumeratorsLessThanDenominatorsPM(
-      performanceMeasureArray,
-      OPM,
-      ageGroups
-    ),
-    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
-
-    // OMS Validations
     ...GV.omsValidations({
       data,
       qualifiers: PMD.qualifiers,
@@ -65,10 +59,13 @@ const PDSValidation = (data: FormData) => {
       ),
       validationCallbacks: [
         GV.validateNumeratorLessThanDenominatorOMS(),
-        GV.validateRateNotZeroOMS(),
+        GV.validateNumeratorLessThanDenominatorOMS(),
         GV.validateRateZeroOMS(),
+        GV.validateRateNotZeroOMS(),
       ],
     }),
+    ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
+    ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
   ];
 
   return errorArray;

--- a/services/ui-src/src/measures/2025/PDSAD/validation.ts
+++ b/services/ui-src/src/measures/2025/PDSAD/validation.ts
@@ -1,0 +1,77 @@
+import * as DC from "dataConstants";
+import * as GV from "shared/globalValidations";
+import * as PMD from "./data";
+import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
+//form type
+import { DefaultFormData as FormData } from "shared/types/FormData";
+
+const PDSValidation = (data: FormData) => {
+  const OPM = data[DC.OPM_RATES];
+  const ageGroups = PMD.qualifiers;
+  const performanceMeasureArray =
+    GV.getPerfMeasureRateArray(data, PMD.data.performanceMeasure) ?? [];
+  const dateRange = data[DC.DATE_RANGE];
+  const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
+  const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
+  const deviationReason = data[DC.DEVIATION_REASON];
+
+  let errorArray: any[] = [];
+  if (data[DC.DID_REPORT] === DC.NO) {
+    errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
+    return errorArray;
+  }
+
+  console.log("DATA IN VALIDATION", data);
+
+  errorArray = [
+    ...GV.validateDateRangeRadioButtonCompletion(data),
+    ...GV.validateBothDatesCompleted(dateRange),
+    ...GV.validateYearFormat(dateRange),
+    ...GV.validateOPMRates(OPM),
+    ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDataSourceType(data),
+    ...GV.validateDeviationTextFieldFilled(
+      didCalculationsDeviate,
+      deviationReason
+    ),
+    ...GV.validateAtLeastOneDeliverySystem(data),
+    ...GV.validateFfsRadioButtonCompletion(data),
+
+    // Performance Measure Validations
+    ...GV.validateAtLeastOneRateComplete(
+      performanceMeasureArray,
+      OPM,
+      ageGroups,
+      PMD.categories
+    ),
+    ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
+    ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),
+    ...GV.validateNumeratorsLessThanDenominatorsPM(
+      performanceMeasureArray,
+      OPM,
+      ageGroups
+    ),
+    ...GV.validateAtLeastOneDefinitionOfPopulation(data),
+
+    // OMS Validations
+    ...GV.omsValidations({
+      data,
+      qualifiers: PMD.qualifiers,
+      categories: PMD.categories,
+      locationDictionary: GV.omsLocationDictionary(
+        OMSData(2025),
+        PMD.qualifiers,
+        PMD.categories
+      ),
+      validationCallbacks: [
+        GV.validateNumeratorLessThanDenominatorOMS(),
+        GV.validateRateNotZeroOMS(),
+        GV.validateRateZeroOMS(),
+      ],
+    }),
+  ];
+
+  return errorArray;
+};
+
+export const validationFunctions = [PDSValidation];

--- a/services/ui-src/src/measures/2025/index.tsx
+++ b/services/ui-src/src/measures/2025/index.tsx
@@ -102,7 +102,7 @@ const twentyTwentyFiveMeasures = {
   "OUD-HH": measureTemplate,
   "PCR-AD": PCRAD,
   "PCR-HH": PCRHH,
-  // "PDS-AD": measureTemplate, //TO DO: replace with real measure
+  "PDS-AD": measureTemplate,
   // "PDS-CH": measureTemplate, //TO DO: replace with real measure
   "PPC2-AD": measureTemplate,
   "PPC2-CH": measureTemplate,

--- a/services/ui-src/src/measures/2025/measureTemplateData.tsx
+++ b/services/ui-src/src/measures/2025/measureTemplateData.tsx
@@ -157,6 +157,9 @@ import { validationFunctions as PPC2AD_Validations } from "./PPC2AD/validation";
 import { data as PPC2CH_Data } from "./PPC2CH/data";
 import { validationFunctions as PPC2CH_Validations } from "./PPC2CH/validation";
 
+import { data as PDSAD_Data } from "./PDSAD/data";
+import { validationFunctions as PDSAD_Validations } from "./PDSAD/validation";
+
 import { data as PQI01AD_Data } from "./PQI01AD/data";
 import { validationFunctions as PQI01AD_Validations } from "./PQI01AD/validation";
 
@@ -244,6 +247,7 @@ export const measureTemplateData: { [measure: string]: any } = {
   "OUD-HH": { data: OUDHH_Data, validationFunctions: OUDHH_Validations },
   "PPC2-AD": { data: PPC2AD_Data, validationFunctions: PPC2AD_Validations },
   "PPC2-CH": { data: PPC2CH_Data, validationFunctions: PPC2CH_Validations },
+  "PDS-AD": { data: PDSAD_Data, validationFunctions: OUDHH_Validations },
   "PQI01-AD": { data: PQI01AD_Data, validationFunctions: PQI01AD_Validations },
   "PQI05-AD": { data: PQI05AD_Data, validationFunctions: PQI05AD_Validations },
   "PQI08-AD": { data: PQI08AD_Data, validationFunctions: PQI08AD_Validations },

--- a/services/ui-src/src/measures/2025/measureTemplateData.tsx
+++ b/services/ui-src/src/measures/2025/measureTemplateData.tsx
@@ -247,7 +247,7 @@ export const measureTemplateData: { [measure: string]: any } = {
   "OUD-HH": { data: OUDHH_Data, validationFunctions: OUDHH_Validations },
   "PPC2-AD": { data: PPC2AD_Data, validationFunctions: PPC2AD_Validations },
   "PPC2-CH": { data: PPC2CH_Data, validationFunctions: PPC2CH_Validations },
-  "PDS-AD": { data: PDSAD_Data, validationFunctions: OUDHH_Validations },
+  "PDS-AD": { data: PDSAD_Data, validationFunctions: PDSAD_Validations },
   "PQI01-AD": { data: PQI01AD_Data, validationFunctions: PQI01AD_Validations },
   "PQI05-AD": { data: PQI05AD_Data, validationFunctions: PQI05AD_Validations },
   "PQI08-AD": { data: PQI08AD_Data, validationFunctions: PQI08AD_Validations },

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -1480,8 +1480,8 @@ export const data = {
                  "id": "39IwoL"
              },
              {
-                 "label": "Follow-Up Positive Screen: Age 21 and Older",
-                 "text": "Follow-Up Positive Screen: Age 21 and Older",
+                 "label": "Follow-Up on Positive Screen: Age 21 and Older",
+                 "text": "Follow-Up on Positive Screen: Age 21 and Older",
                  "id": "61YpqF"
              }
          ],

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -1488,6 +1488,21 @@ export const data = {
         ],
         "categories": [{"id":"YGJwmu", "label": "", "text":""}]
     },
+    "PDS-AD": {
+        "qualifiers": [
+             {
+                 "label": "Depression Screening: Age 21 and Older",
+                 "text": "Depression Screening: Age 21 and Older",
+                 "id": "39IwoL"
+             },
+             {
+                 "label": "Follow-Up Positive Screen: Age 21 and Older",
+                 "text": "Follow-Up Positive Screen: Age 21 and Older",
+                 "id": "61YpqF"
+             }
+         ],
+         "categories": [{"id":"U3Zb2j", "label": "", "text":""}]
+     },
     "PPC2-AD": {
         "qualifiers": [
             {

--- a/services/ui-src/src/shared/globalValidations/validateOneQualDenomHigherThanOtherDenomOMS/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateOneQualDenomHigherThanOtherDenomOMS/index.ts
@@ -32,7 +32,6 @@ const _validation = ({
   lowerIndex,
   errorMessageFunc = validateOneQualDenomHigherThanOtherDenomErrorMessage,
 }: ValProps) => {
-  console.log("WHAT THE FUCK!");
   const errorArray: FormError[] = [];
 
   for (const ratefields of rateData) {

--- a/services/ui-src/src/shared/globalValidations/validateOneQualDenomHigherThanOtherDenomOMS/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateOneQualDenomHigherThanOtherDenomOMS/index.ts
@@ -32,6 +32,7 @@ const _validation = ({
   lowerIndex,
   errorMessageFunc = validateOneQualDenomHigherThanOtherDenomErrorMessage,
 }: ValProps) => {
+  console.log("WHAT THE FUCK!");
   const errorArray: FormError[] = [];
 
   for (const ratefields of rateData) {


### PR DESCRIPTION
### Description
New measure:
<img width="899" alt="Screenshot 2025-05-08 at 11 37 42 AM" src="https://github.com/user-attachments/assets/81a734a4-c40c-4786-85ae-9fd565d289fb" />

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4435

---
### How to test
cloudwatch: https://d2ath12k8290wk.cloudfront.net/
1. Log in as any state user
2. Navigate to 2025 adult measures and find PDS-AD
3. Fill out the form, making sure it matches the content in the CMDCT-4435 ticket
4. For one special validation, try making the denominator of "Follow-up on Positive Screen" larger than "Depression Screening" denom. Click the validate measure button and you should see the following error:
<img width="902" alt="Screenshot 2025-05-08 at 11 37 30 AM" src="https://github.com/user-attachments/assets/d1eaedbe-2e0b-440e-b1a6-9ed2b8723304" />
