### PR TITLE
 2025 Measure Steward Question Update 

### DIFF
--- a/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
@@ -82,20 +82,6 @@ export const commonQuestionsLabel = {
   MeasureSpecifications: {
     additionalContext:
       "If your state substantially varied from the measure specifications (including different methodology, timeframe, or reported age groups), please report your data using “Other” specifications.",
-    options: [
-      {
-        displayValue: "HEDIS MY 2024 (2025 Core Set Reporting)",
-        value: DC.HEDIS_MY_2023,
-      },
-      {
-        displayValue: "HEDIS MY 2023 (2024 Core Set Reporting)",
-        value: DC.HEDIS_MY_2022,
-      },
-      {
-        displayValue: "HEDIS MY 2022 (2023 Core Set Reporting)",
-        value: DC.HEDIS_MY_2021,
-      },
-    ],
     otherMeasurementSpecWarning:
       "If you report using Other specifications, CMS will not be able to publicly report the performance rate. In addition, the rate will not be used to calculate a combined Medicaid and CHIP rate. If the information reported in the Specifications field is accurate, please continue reporting this measure.",
   },

--- a/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
@@ -80,8 +80,7 @@ export const commonQuestionsLabel = {
       "Explain the variation(s) (<em>text in this field is included in publicly-reported state-specific comments</em>):",
   },
   MeasureSpecifications: {
-    additionalContext:
-      "If your state substantially varied from the measure specifications (including different methodology, timeframe, or reported age groups), please report your data using “Other” specifications.",
+    measureSpecYesNo: true,
     otherMeasurementSpecWarning:
       "If you report using Other specifications, CMS will not be able to publicly report the performance rate. In addition, the rate will not be used to calculate a combined Medicaid and CHIP rate. If the information reported in the Specifications field is accurate, please continue reporting this measure.",
   },

--- a/services/ui-src/src/shared/commonQuestions/DateRange.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DateRange.tsx
@@ -18,7 +18,7 @@ const measurementPeriodTableLinks = {
 };
 
 interface Props {
-  type: "adult" | "child" | "health";
+  type: Types.CoreSetKey;
 }
 
 const descriptionElement = (label: AnyObject) => {

--- a/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DefinitionsOfPopulation.tsx
@@ -17,7 +17,7 @@ interface Props {
   hybridMeasure?: boolean;
   populationSampleSize?: boolean;
   coreSetOptions?: CoreSetSpecificOptions;
-  coreset?: string;
+  coreset?: Types.CoreSetKey;
   deliverySystems?: boolean;
 }
 interface DefOfDenomOption {

--- a/services/ui-src/src/shared/commonQuestions/MeasurementSpecification.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasurementSpecification.tsx
@@ -6,12 +6,11 @@ import * as DC from "dataConstants";
 import { useContext } from "react";
 import SharedContext from "shared/SharedContext";
 import { Alert } from "@cmsgov/design-system";
+import { specifications, SpecificationType } from "shared/types";
 
 const HEDISChildren = () => {
   const register = useCustomRegister<Types.MeasurementSpecification>();
-
   const hedisLabels: any = useContext(SharedContext);
-
   const options = hedisLabels.MeasureSpecifications.options;
 
   return (
@@ -32,96 +31,39 @@ const HEDISChildren = () => {
 };
 
 interface Props {
-  type:
-    | "ADA-DQA"
-    | "AHRQ"
-    | "AHRQ-NCQA"
-    | "CDC"
-    | "CMS"
-    | "HEDIS"
-    | "HRSA"
-    | "JOINT"
-    | "NCQA"
-    | "OHSU"
-    | "OPA"
-    | "PQA"
-    | "SAMHSA";
+  type: SpecificationType;
   coreset?: string;
 }
 
-const specifications = {
-  "ADA-DQA": {
-    displayValue:
-      "American Dental Association/Dental Quality Alliance (ADA/DQA)",
-    value: DC.ADA_DQA,
-  },
-  AHRQ: {
-    displayValue: "Agency for Healthcare Research and Quality (AHRQ)",
-    value: DC.AHRQ,
-  },
-  "AHRQ-NCQA": {
-    displayValue:
-      "Agency for Healthcare Research and Quality (AHRQ) (survey instrument) and National Committee for Quality Assurance (survey administrative protocol)",
-    value: DC.AHRQ_NCQA,
-  },
-  CDC: {
-    displayValue: "Centers for Disease Contol and Prevention (CDC)",
-    value: DC.CDC,
-  },
-  CMS: {
-    displayValue: "Centers for Medicare & Medicaid Services (CMS)",
-    value: DC.CMS,
-  },
-  HEDIS: {
-    displayValue:
-      "National Committee for Quality Assurance (NCQA)/Healthcare Effectiveness Data and Information Set (HEDIS)",
-    value: DC.NCQA,
-    children: [<HEDISChildren key="HEDIS-Child" />],
-  },
-  HRSA: {
-    displayValue: "Health Resources and Services Administration (HRSA)",
-    value: DC.HRSA,
-  },
-  JOINT: {
-    displayValue: "The Joint Commission",
-    value: DC.JOINT_COMMISSION,
-  },
-  NCQA: {
-    displayValue: "National Committee for Quality Assurance (NCQA)",
-    value: DC.NCQA,
-  },
-  OHSU: {
-    displayValue: "Oregon Health and Science University (OHSU)",
-    value: DC.OHSU,
-  },
-  OPA: {
-    displayValue: "HHS Office of Population Affairs (OPA)",
-    value: DC.OPA,
-  },
-  PQA: {
-    displayValue: "Pharmacy Quality Alliance (PQA)",
-    value: DC.PQA,
-  },
-  SAMHSA: {
-    displayValue:
-      "Substance Abuse and Mental Health Services Administration (SAMHSA)",
-    value: DC.SAMHSA,
-  },
+export const Question = ({ type, coreset }: Props, year: number) => {
+  const coreSet = coreset;
+  const specification =
+    type === "HEDIS"
+      ? `${specifications[type].displayValue} Measurement Year ${year - 1}`
+      : specifications[type].displayValue;
+  return `Did your state use ${year} ${coreSet} Core Set measure specifications, which are based on ${specification} specifications to calculate this measure?`;
 };
 
 export const MeasurementSpecification = ({ type, coreset }: Props) => {
   const register = useCustomRegister<Types.MeasurementSpecification>();
+  const context: any = useContext(SharedContext);
+  const { MeasureSpecifications, year } = context;
 
-  const measureSpecLabels: any = useContext(SharedContext);
+  let measureSpecs = specifications;
+  measureSpecs.HEDIS.children = MeasureSpecifications.options && [
+    <HEDISChildren key="HEDIS-Child" />,
+  ];
+
+  Question({ type, coreset }, year);
 
   return (
     <QMR.CoreQuestionWrapper
       testid="measurement-specification"
       label="Measurement Specification"
     >
-      {measureSpecLabels?.MeasureSpecifications?.additionalContext && (
+      {MeasureSpecifications?.additionalContext && (
         <CUI.Text key="measureSpecAdditionalContext" size="sm" pb="3">
-          {measureSpecLabels?.MeasureSpecifications?.additionalContext}
+          {MeasureSpecifications?.additionalContext}
         </CUI.Text>
       )}
 
@@ -129,7 +71,7 @@ export const MeasurementSpecification = ({ type, coreset }: Props) => {
         <QMR.RadioButton
           {...register(DC.MEASUREMENT_SPECIFICATION)}
           options={[
-            specifications[type],
+            measureSpecs[type],
             {
               displayValue: "Other",
               value: DC.OTHER,
@@ -141,20 +83,16 @@ export const MeasurementSpecification = ({ type, coreset }: Props) => {
                   key={DC.MEASUREMENT_SPEC_OMS_DESCRIPTION}
                 />,
                 (coreset === "adult" || coreset === "child") &&
-                  measureSpecLabels.MeasureSpecifications
-                    .otherMeasurementSpecWarning && (
+                  MeasureSpecifications.otherMeasurementSpecWarning && (
                     <CUI.Box mb="8">
                       <Alert heading="Please Note" variation="warn">
                         <CUI.Text>
-                          {
-                            measureSpecLabels.MeasureSpecifications
-                              .otherMeasurementSpecWarning
-                          }
+                          {MeasureSpecifications.otherMeasurementSpecWarning}
                         </CUI.Text>
                       </Alert>
                     </CUI.Box>
                   ),
-                measureSpecLabels.MeasureSpecifications.upload && (
+                MeasureSpecifications.upload && (
                   <QMR.Upload
                     label="If you need additional space to describe your state's methodology, please attach further documentation below."
                     {...register(DC.MEASUREMENT_SPEC_OMS_DESCRIPTION_UPLOAD)}

--- a/services/ui-src/src/shared/commonQuestions/MeasurementSpecification.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasurementSpecification.tsx
@@ -10,7 +10,7 @@ import { Specifications, SpecificationType } from "shared/types";
 
 interface Props {
   type: SpecificationType;
-  coreset?: string;
+  coreset: Types.CoreSetKey;
 }
 
 const HEDISChildren = () => {
@@ -39,15 +39,21 @@ export const MeasurementSpecificationQuestionYesNo = (
   { type, coreset }: Props,
   year: number
 ) => {
-  const coreSet = coreset;
+  const label = {
+    adult: "Adult",
+    child: "Child",
+    health: "Health Home",
+  };
+
   const specification =
     type === "HEDIS"
       ? `${Specifications[type].displayValue} Measurement Year ${year - 1}`
       : Specifications[type].displayValue;
   return (
     <CUI.Text key="measureSpecAdditionalContext" size="sm" pb="3">
-      Did your state use {year} {coreSet} Core Set measure specifications, which
-      are based on {specification} specifications to calculate this measure?
+      Did your state use {year} {label[coreset]} Core Set measure
+      specifications, which are based on {specification} specifications to
+      calculate this measure?
     </CUI.Text>
   );
 };

--- a/services/ui-src/src/shared/commonQuestions/MeasurementSpecification.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasurementSpecification.tsx
@@ -10,7 +10,7 @@ import { Specifications, SpecificationType } from "shared/types";
 
 interface Props {
   type: SpecificationType;
-  coreset: Types.CoreSetKey;
+  coreset?: Types.CoreSetKey;
 }
 
 const HEDISChildren = () => {
@@ -51,7 +51,7 @@ export const MeasurementSpecificationQuestionYesNo = (
       : Specifications[type].displayValue;
   return (
     <CUI.Text key="measureSpecAdditionalContext" size="sm" pb="3">
-      Did your state use {year} {label[coreset]} Core Set measure
+      Did your state use {year} {label[coreset!]} Core Set measure
       specifications, which are based on {specification} specifications to
       calculate this measure?
     </CUI.Text>

--- a/services/ui-src/src/shared/types/GlobalTypes.tsx
+++ b/services/ui-src/src/shared/types/GlobalTypes.tsx
@@ -1,0 +1,1 @@
+export type CoreSetKey = "adult" | "child" | "health";

--- a/services/ui-src/src/shared/types/MeasureTemplate.tsx
+++ b/services/ui-src/src/shared/types/MeasureTemplate.tsx
@@ -1,5 +1,6 @@
 import { ComponentFlagType } from "shared/commonQuestions/OptionalMeasureStrat/context";
 import { DataDrivenTypes } from "./TypeDataDriven";
+import { CoreSetKey } from "./GlobalTypes";
 
 export interface customData {
   rateReadOnly?: boolean;
@@ -23,7 +24,7 @@ export interface customData {
 
 export interface MeasureTemplateData {
   type: string;
-  coreset: string;
+  coreset: CoreSetKey;
   hybridMeasure?: boolean;
   performanceMeasure: DataDrivenTypes.PerformanceMeasure;
   dataSource?: DataDrivenTypes.DataSource;

--- a/services/ui-src/src/shared/types/TypeMeasureSpecification.tsx
+++ b/services/ui-src/src/shared/types/TypeMeasureSpecification.tsx
@@ -15,7 +15,7 @@ export type SpecificationType =
   | "PQA"
   | "SAMHSA";
 
-type SpecifictionProps = {
+export type SpecifictionProps = {
   [type in SpecificationType]: {
     displayValue: string;
     value: string;
@@ -23,7 +23,7 @@ type SpecifictionProps = {
   };
 };
 
-export const specifications: SpecifictionProps = {
+export const Specifications: SpecifictionProps = {
   "ADA-DQA": {
     displayValue:
       "American Dental Association/Dental Quality Alliance (ADA/DQA)",

--- a/services/ui-src/src/shared/types/TypeMeasureSpecification.tsx
+++ b/services/ui-src/src/shared/types/TypeMeasureSpecification.tsx
@@ -1,5 +1,87 @@
 import * as DC from "dataConstants";
 
+export type SpecificationType =
+  | "ADA-DQA"
+  | "AHRQ"
+  | "AHRQ-NCQA"
+  | "CDC"
+  | "CMS"
+  | "HEDIS"
+  | "HRSA"
+  | "JOINT"
+  | "NCQA"
+  | "OHSU"
+  | "OPA"
+  | "PQA"
+  | "SAMHSA";
+
+type SpecifictionProps = {
+  [type in SpecificationType]: {
+    displayValue: string;
+    value: string;
+    children?: JSX.Element[];
+  };
+};
+
+export const specifications: SpecifictionProps = {
+  "ADA-DQA": {
+    displayValue:
+      "American Dental Association/Dental Quality Alliance (ADA/DQA)",
+    value: DC.ADA_DQA,
+  },
+  AHRQ: {
+    displayValue: "Agency for Healthcare Research and Quality (AHRQ)",
+    value: DC.AHRQ,
+  },
+  "AHRQ-NCQA": {
+    displayValue:
+      "Agency for Healthcare Research and Quality (AHRQ) (survey instrument) and National Committee for Quality Assurance (survey administrative protocol)",
+    value: DC.AHRQ_NCQA,
+  },
+  CDC: {
+    displayValue: "Centers for Disease Contol and Prevention (CDC)",
+    value: DC.CDC,
+  },
+  CMS: {
+    displayValue: "Centers for Medicare & Medicaid Services (CMS)",
+    value: DC.CMS,
+  },
+  HEDIS: {
+    displayValue:
+      "National Committee for Quality Assurance (NCQA)/Healthcare Effectiveness Data and Information Set (HEDIS)",
+    value: DC.NCQA,
+  },
+  HRSA: {
+    displayValue: "Health Resources and Services Administration (HRSA)",
+    value: DC.HRSA,
+  },
+  JOINT: {
+    displayValue: "The Joint Commission",
+    value: DC.JOINT_COMMISSION,
+  },
+  NCQA: {
+    displayValue: "National Committee for Quality Assurance (NCQA)",
+    value: DC.NCQA,
+  },
+  OHSU: {
+    displayValue: "Oregon Health and Science University (OHSU)",
+    value: DC.OHSU,
+  },
+  OPA: {
+    displayValue: "HHS Office of Population Affairs (OPA)",
+    value: DC.OPA,
+  },
+  PQA: {
+    displayValue: "Pharmacy Quality Alliance (PQA)",
+    value: DC.PQA,
+  },
+  SAMHSA: {
+    displayValue:
+      "Substance Abuse and Mental Health Services Administration (SAMHSA)",
+    value: DC.SAMHSA,
+  },
+};
+
 export interface MeasurementSpecification {
   [DC.MEASUREMENT_SPECIFICATION]: // Selected Measurement Specification
   | typeof DC.NCQA

--- a/services/ui-src/src/shared/types/index.tsx
+++ b/services/ui-src/src/shared/types/index.tsx
@@ -16,3 +16,4 @@ export * from "shared/types/TypeRateFields";
 export * from "shared/types/TypeReporting";
 export * from "shared/types/TypeStatusOfData";
 export * from "shared/types/TypeWhyAreYouNotReporting";
+export * from "shared/types/GlobalTypes";


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The **Measure Specification** section has some label changes needed. 

Pre-2025
<img width="1208" alt="Screenshot 2025-05-09 at 1 46 12 PM" src="https://github.com/user-attachments/assets/09e20a01-45f0-4d9a-abf2-81f50ad165e5" />

2025+
<img width="1206" alt="Screenshot 2025-05-09 at 1 45 25 PM" src="https://github.com/user-attachments/assets/1216e72d-80ad-4ca3-bd58-3106aecfb9b3" />

What makes this complicated is that the text is dynamic and based on the measure itself instead of a static the static text we utilize from the label text file. There's restructuring to the Measure Specification component but the data being saved is still the same.

I've also sorted each the pieces of the render into its own function to make it more readable.

---

`MeasurementSpecificationQuestionYesNo` function renders this text
![Screenshot 2025-05-09 at 1 54 22 PM](https://github.com/user-attachments/assets/a02bfec6-cc7e-4126-bb9a-b39f8354367b)

---

`MeasurementSpecificationOtherAlert` function renders this alert
![Screenshot 2025-05-09 at 1 55 47 PM](https://github.com/user-attachments/assets/fb3d1836-bcdc-4762-8234-4f0542096cb0)

---

`MeasurementSpecificationOtherTextbox` function renders this textbox
![Screenshot 2025-05-09 at 1 56 07 PM](https://github.com/user-attachments/assets/cdda16de-5c46-4cea-86c1-4fb1709bca9b)

---

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4481
CMDCT-4482
CMDCT-4483
CMDCT-4484
CMDCT-4485
CMDCT-4486
CMDCT-4487
CMDCT-4488
CMDCT-4489

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Deploy Link: https://d125ce9k18lnpn.cloudfront.net/

1) Sign into QMR, any state user
2) Go to AAB-AD, or any other measure with a Measure Specification
3) Scroll to the Measure Specification and check that the text matches the jira ticket.
    - AAB-AD is a HEDIS measure so it should match the text in CMDCT-4481
4) Check that measure validates

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
