### PR TITLE
(FY2025) Remove Hedis Validation

### DIFF
--- a/services/ui-src/src/measures/2025/AABAD/validation.ts
+++ b/services/ui-src/src/measures/2025/AABAD/validation.ts
@@ -48,7 +48,6 @@ const AABADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
     ...GV.validateAtLeastOneDeliverySystem(data),

--- a/services/ui-src/src/measures/2025/AABCH/validation.ts
+++ b/services/ui-src/src/measures/2025/AABCH/validation.ts
@@ -30,7 +30,6 @@ const AABCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     // Performance Measure Validations
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2025/ADDCH/validation.ts
+++ b/services/ui-src/src/measures/2025/ADDCH/validation.ts
@@ -45,7 +45,6 @@ const ADDCHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
     ...GV.validateDeviationTextFieldFilled(

--- a/services/ui-src/src/measures/2025/AISAD/validation.ts
+++ b/services/ui-src/src/measures/2025/AISAD/validation.ts
@@ -91,7 +91,6 @@ const AISADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
   ];
 

--- a/services/ui-src/src/measures/2025/AMMAD/validation.ts
+++ b/services/ui-src/src/measures/2025/AMMAD/validation.ts
@@ -72,7 +72,6 @@ const AMMADValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateOPMRates(OPM),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
     ...GV.validateAtLeastOneDeliverySystem(data),

--- a/services/ui-src/src/measures/2025/AMRAD/validation.ts
+++ b/services/ui-src/src/measures/2025/AMRAD/validation.ts
@@ -29,7 +29,6 @@ const AMRADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateDeviationTextFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2025/AMRCH/validation.ts
+++ b/services/ui-src/src/measures/2025/AMRCH/validation.ts
@@ -33,7 +33,6 @@ const AMRCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateDeviationTextFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2025/APMCH/validation.ts
+++ b/services/ui-src/src/measures/2025/APMCH/validation.ts
@@ -65,7 +65,6 @@ const APMCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateDeviationTextFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2025/APPCH/validation.ts
+++ b/services/ui-src/src/measures/2025/APPCH/validation.ts
@@ -47,7 +47,6 @@ const APPCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),

--- a/services/ui-src/src/measures/2025/BCSAD/validation.ts
+++ b/services/ui-src/src/measures/2025/BCSAD/validation.ts
@@ -70,7 +70,6 @@ const BCSValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateDeviationTextFieldFilled(
       didCalculationsDeviate,

--- a/services/ui-src/src/measures/2025/CBPAD/validation.ts
+++ b/services/ui-src/src/measures/2025/CBPAD/validation.ts
@@ -52,7 +52,6 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOPMRates(OPM),

--- a/services/ui-src/src/measures/2025/CBPHH/validation.ts
+++ b/services/ui-src/src/measures/2025/CBPHH/validation.ts
@@ -53,7 +53,6 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),

--- a/services/ui-src/src/measures/2025/CCSAD/validation.ts
+++ b/services/ui-src/src/measures/2025/CCSAD/validation.ts
@@ -62,7 +62,6 @@ const CCSADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),

--- a/services/ui-src/src/measures/2025/CHLAD/validation.ts
+++ b/services/ui-src/src/measures/2025/CHLAD/validation.ts
@@ -43,7 +43,6 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOPMRates(OPM),

--- a/services/ui-src/src/measures/2025/CHLCH/validation.ts
+++ b/services/ui-src/src/measures/2025/CHLCH/validation.ts
@@ -43,7 +43,6 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),

--- a/services/ui-src/src/measures/2025/CISCH/validation.ts
+++ b/services/ui-src/src/measures/2025/CISCH/validation.ts
@@ -66,7 +66,6 @@ const CISCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
   ];
 

--- a/services/ui-src/src/measures/2025/COLAD/validation.ts
+++ b/services/ui-src/src/measures/2025/COLAD/validation.ts
@@ -55,7 +55,6 @@ const COLADValidation = (data: FormData) => {
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2025/COLHH/validation.ts
+++ b/services/ui-src/src/measures/2025/COLHH/validation.ts
@@ -55,7 +55,6 @@ const COLHHValidation = (data: FormData) => {
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOPMRates(OPM),

--- a/services/ui-src/src/measures/2025/CPUAD/validation.ts
+++ b/services/ui-src/src/measures/2025/CPUAD/validation.ts
@@ -43,7 +43,6 @@ const CPUADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),

--- a/services/ui-src/src/measures/2025/FUAAD/validation.ts
+++ b/services/ui-src/src/measures/2025/FUAAD/validation.ts
@@ -61,7 +61,6 @@ const FUAADValidation = (data: FormData) => {
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateOPMRates(OPM),
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2025/FUACH/validation.ts
+++ b/services/ui-src/src/measures/2025/FUACH/validation.ts
@@ -43,7 +43,6 @@ const FUACHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),

--- a/services/ui-src/src/measures/2025/FUAHH/validation.ts
+++ b/services/ui-src/src/measures/2025/FUAHH/validation.ts
@@ -37,7 +37,6 @@ const FUAHHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateOPMRates(OPM),

--- a/services/ui-src/src/measures/2025/FUHAD/validation.ts
+++ b/services/ui-src/src/measures/2025/FUHAD/validation.ts
@@ -70,7 +70,6 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateFfsRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),

--- a/services/ui-src/src/measures/2025/FUHCH/validation.ts
+++ b/services/ui-src/src/measures/2025/FUHCH/validation.ts
@@ -61,7 +61,6 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2025/FUHHH/validation.ts
+++ b/services/ui-src/src/measures/2025/FUHHH/validation.ts
@@ -37,7 +37,6 @@ const FUHHHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2025/FUMAD/validation.ts
+++ b/services/ui-src/src/measures/2025/FUMAD/validation.ts
@@ -63,7 +63,6 @@ const FUMADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(

--- a/services/ui-src/src/measures/2025/FUMCH/validation.ts
+++ b/services/ui-src/src/measures/2025/FUMCH/validation.ts
@@ -60,7 +60,6 @@ const FUMCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2025/FUMHH/validation.ts
+++ b/services/ui-src/src/measures/2025/FUMHH/validation.ts
@@ -40,7 +40,6 @@ const FUMHHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),

--- a/services/ui-src/src/measures/2025/GSDAD/validation.ts
+++ b/services/ui-src/src/measures/2025/GSDAD/validation.ts
@@ -73,7 +73,6 @@ const GSDADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateEqualQualifierDenominatorsPM(

--- a/services/ui-src/src/measures/2025/IETAD/validation.ts
+++ b/services/ui-src/src/measures/2025/IETAD/validation.ts
@@ -107,7 +107,6 @@ const IETValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),

--- a/services/ui-src/src/measures/2025/IETHH/validation.ts
+++ b/services/ui-src/src/measures/2025/IETHH/validation.ts
@@ -108,7 +108,6 @@ const IETValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),

--- a/services/ui-src/src/measures/2025/IMACH/validation.ts
+++ b/services/ui-src/src/measures/2025/IMACH/validation.ts
@@ -52,7 +52,6 @@ const DEVCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),

--- a/services/ui-src/src/measures/2025/LSCCH/validation.ts
+++ b/services/ui-src/src/measures/2025/LSCCH/validation.ts
@@ -27,7 +27,6 @@ const LSCCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDataSourceType(data),
     ...GV.validateHybridMeasurePopulation(data),

--- a/services/ui-src/src/measures/2025/MSCAD/validation.ts
+++ b/services/ui-src/src/measures/2025/MSCAD/validation.ts
@@ -56,7 +56,6 @@ const MSCADValidation = (data: DefaultFormData) => {
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateRateNotZeroPM(performanceMeasureArray, OPM, ageGroups),
     ...GV.validateRateZeroPM(performanceMeasureArray, OPM, ageGroups, data),

--- a/services/ui-src/src/measures/2025/PCRAD/validation.ts
+++ b/services/ui-src/src/measures/2025/PCRAD/validation.ts
@@ -49,7 +49,6 @@ const PCRADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),

--- a/services/ui-src/src/measures/2025/PCRHH/validation.ts
+++ b/services/ui-src/src/measures/2025/PCRHH/validation.ts
@@ -52,7 +52,6 @@ const PCRHHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),

--- a/services/ui-src/src/measures/2025/PPC2AD/validation.ts
+++ b/services/ui-src/src/measures/2025/PPC2AD/validation.ts
@@ -65,7 +65,6 @@ const PPC2ADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
   ];

--- a/services/ui-src/src/measures/2025/PPC2CH/validation.ts
+++ b/services/ui-src/src/measures/2025/PPC2CH/validation.ts
@@ -63,7 +63,6 @@ const PPC2CHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDeliverySystem(data),
     ...GV.validateFfsRadioButtonCompletion(data),

--- a/services/ui-src/src/measures/2025/SAAAD/validation.ts
+++ b/services/ui-src/src/measures/2025/SAAAD/validation.ts
@@ -61,7 +61,6 @@ const SAAADValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),

--- a/services/ui-src/src/measures/2025/SSDAD/validation.ts
+++ b/services/ui-src/src/measures/2025/SSDAD/validation.ts
@@ -60,7 +60,6 @@ const SSDValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),

--- a/services/ui-src/src/measures/2025/W30CH/validation.ts
+++ b/services/ui-src/src/measures/2025/W30CH/validation.ts
@@ -56,7 +56,6 @@ const W30CHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),

--- a/services/ui-src/src/measures/2025/WCCCH/validation.ts
+++ b/services/ui-src/src/measures/2025/WCCCH/validation.ts
@@ -47,7 +47,6 @@ const WCCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateAtLeastOneDefinitionOfPopulation(data),
     ...GV.validateAtLeastOneRateComplete(

--- a/services/ui-src/src/measures/2025/WCVCH/validation.ts
+++ b/services/ui-src/src/measures/2025/WCVCH/validation.ts
@@ -64,7 +64,6 @@ const WCVCHValidation = (data: FormData) => {
     ...GV.validateDateRangeRadioButtonCompletion(data),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateYearFormat(dateRange),
-    ...GV.validateHedisYear(data),
     ...GV.validateOPMRates(OPM),
     ...GV.validateTotalNDR(performanceMeasureArray),
   ];


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We've updated the Measure Specification in this PR, so HEDIS measures went from looking like this:
<img width="1316" alt="Screenshot 2025-05-16 at 10 04 41 AM" src="https://github.com/user-attachments/assets/85248064-0829-420f-9bc2-b9e58356fc5f" />

to looking like this
<img width="1301" alt="Screenshot 2025-05-16 at 10 05 01 AM" src="https://github.com/user-attachments/assets/b4d791f7-de08-409a-bb1e-2210332db83a" />

So we don't need this validation anymore to alert the user to fill out the Hedis dropdown as we now default to the previous year.
<img width="1286" alt="Screenshot 2025-05-16 at 10 18 56 AM" src="https://github.com/user-attachments/assets/b470bcb7-71ea-4290-a597-4d535b9fe6a7" />

This PR removes the validation from 43 measures.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4664

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Deploy Link: https://dpfc26takf5b7.cloudfront.net/

1) Sign into QMR, any state user.
2) In reporting year 2025, go to AAB-AD
3) Fill out AAB-AD and click validate.
4) Check to see that you **do not** see this validation anymore.
<img width="1286" alt="Screenshot 2025-05-16 at 10 18 56 AM" src="https://github.com/user-attachments/assets/ba85afac-345a-4bf2-98ce-1f79756f07ed" />

4) Go to reporting year 2024, and select AAB-AD
5) Fill it out but do not select a Hedis year.
6) Validate and check to see that the validation is there.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
