### PR TITLE
Add some unit tests around ExportAll

### DIFF
--- a/services/ui-src/src/libs/spaLib.test.ts
+++ b/services/ui-src/src/libs/spaLib.test.ts
@@ -1,0 +1,17 @@
+import { SPA } from "./spaLib";
+
+describe("spaLib", () => {
+  it("Should contain properly-shaped data", () => {
+    // Technically, this test is redundant with the Typescript definitions.
+    for (let yearlySpas of Object.values(SPA)) {
+      for (let spa of yearlySpas) {
+        expect(typeof spa.id).toBe("string");
+        expect(typeof spa.state).toBe("string");
+        expect(typeof spa.name).toBe("string");
+        expect(spa.id).toBeTruthy();
+        expect(spa.state).toBeTruthy();
+        expect(spa.name).toBeTruthy();
+      }
+    }
+  });
+});

--- a/services/ui-src/src/views/ExportAll/index.test.tsx
+++ b/services/ui-src/src/views/ExportAll/index.test.tsx
@@ -1,0 +1,166 @@
+import { ExportAll } from "./index";
+import { render, screen } from "@testing-library/react";
+import { PrintableMeasureWrapper } from "components";
+import { useGetMeasures } from "hooks/api";
+import { QualifierData } from "../../measures/2025";
+
+jest.mock("hooks/api", () => ({
+  useGetMeasures: jest.fn(),
+}));
+const mockedGetMeasures = useGetMeasures as jest.MockedFunction<
+  typeof useGetMeasures
+>;
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: jest.fn().mockReturnValue({
+    state: "CO",
+    year: "2025",
+    coreSetId: "ACS",
+  }),
+}));
+
+jest.mock("components", () => ({
+  ...jest.requireActual("components"),
+  PrintableMeasureWrapper: jest.fn(),
+}));
+const mockMeasureWrapper = PrintableMeasureWrapper as jest.Mock;
+mockMeasureWrapper.mockImplementation((props) => {
+  const stringifiableProps = { ...props, measure: undefined };
+  return <div className="pmw">{JSON.stringify(stringifiableProps)}</div>;
+});
+
+describe("ExportAll", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render measure components inside a wrapper", () => {
+    const mockCsqData = {
+      measure: "CSQ",
+      year: "2025",
+      description: "mockCsqDescription",
+    };
+    const mockAabData = {
+      measure: "AAB-AD",
+      year: "2025",
+      description: "mockAabDescription",
+    };
+    const mockBcsData = {
+      measure: "BCS-AD",
+      year: "2025",
+      description: "mockBcsDescription",
+    };
+    const mockMeasureData = {
+      isLoading: false,
+      data: { Items: [mockCsqData, mockAabData, mockBcsData] },
+    } as ReturnType<typeof useGetMeasures>;
+    mockedGetMeasures.mockReturnValue(mockMeasureData);
+
+    render(<ExportAll />);
+
+    expect(mockMeasureWrapper).toHaveBeenCalledWith(
+      {
+        measure: expect.anything(),
+        measureData: mockCsqData,
+        measureId: "CSQ",
+        name: "mockCsqDescription",
+        year: "2025",
+        defaultData: QualifierData,
+        spaName: undefined,
+      },
+      expect.any(Object)
+    );
+
+    expect(mockMeasureWrapper).toHaveBeenCalledWith(
+      {
+        measure: expect.anything(),
+        measureData: mockAabData,
+        measureId: "AAB-AD",
+        name: "mockAabDescription",
+        year: "2025",
+        defaultData: undefined,
+        spaName: undefined,
+      },
+      expect.any(Object)
+    );
+
+    expect(mockMeasureWrapper).toHaveBeenCalledWith(
+      {
+        measure: expect.anything(),
+        measureData: mockBcsData,
+        measureId: "BCS-AD",
+        name: "mockBcsDescription",
+        year: "2025",
+        defaultData: undefined,
+        spaName: undefined,
+      },
+      expect.any(Object)
+    );
+  });
+
+  it("should sort measures: CSQ first, then alphabetically", () => {
+    const mockMeasureData = {
+      isLoading: false,
+      data: {
+        Items: [
+          {
+            measure: "BCS-AD",
+            year: "2025",
+          },
+          {
+            measure: "CSQ",
+            year: "2025",
+          },
+          {
+            measure: "AAB-AD",
+            year: "2025",
+          },
+        ],
+      },
+    } as ReturnType<typeof useGetMeasures>;
+    mockedGetMeasures.mockReturnValue(mockMeasureData);
+
+    render(<ExportAll />);
+
+    const jumpLinks = screen
+      .getAllByRole("link")
+      // There are lots of links on this page, but only the jump links
+      // at the top of the page are styled as buttons.
+      .filter((link) => link.classList.contains("chakra-button"))
+      .map((link) => link.textContent);
+    expect(jumpLinks).toEqual(["CSQ", "AAB-AD", "BCS-AD"]);
+  });
+
+  it("should filter out certain measures", () => {
+    const mockMeasureData = {
+      isLoading: false,
+      data: {
+        Items: [
+          {
+            // Note that the CSQ measure is required for the page to render.
+            measure: "CSQ",
+            year: "2025",
+          },
+          {
+            measure: "SS-1-HH",
+            year: "2025",
+          },
+          {
+            measure: "SS-2-HH",
+            userCreated: true,
+            year: "2025",
+          },
+        ],
+      },
+    } as ReturnType<typeof useGetMeasures>;
+    mockedGetMeasures.mockReturnValue(mockMeasureData);
+
+    render(<ExportAll />);
+
+    // Measures matching this pattern are excluded from the page
+    expect(screen.queryByText("SS-1-HH")).not.toBeInTheDocument();
+    // UNLESS they are user-created
+    expect(screen.getByText("SS-2-HH")).toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/views/ExportAll/util.test.ts
+++ b/services/ui-src/src/views/ExportAll/util.test.ts
@@ -1,0 +1,34 @@
+import { getSpaName } from "./util";
+
+describe("ExportAll utils", () => {
+  describe("getSpaName", () => {
+    const props = {
+      coreSetId: "HHCS_24-0020",
+      state: "DC",
+      year: "2025",
+    };
+
+    it("should return undefined if the needed params are missing", () => {
+      expect(getSpaName({ ...props, coreSetId: undefined })).toBeUndefined();
+      expect(getSpaName({ ...props, state: undefined })).toBeUndefined();
+      expect(getSpaName({ ...props, year: undefined })).toBeUndefined();
+    });
+
+    it("should return undefined if the coreSetId does not contain an underscore", () => {
+      expect(getSpaName({ ...props, coreSetId: "HHCS" })).toBeUndefined();
+    });
+
+    it("should return undefined if the year does not have defined SPAs", () => {
+      expect(getSpaName({ ...props, year: "1999" })).toBeUndefined();
+    });
+
+    it("should return undefined if matching spa info cannot be found", () => {
+      expect(getSpaName({ ...props, state: "ZZ" })).toBeUndefined();
+      expect(getSpaName({ ...props, coreSetId: "HHCS_nope" })).toBeUndefined();
+    });
+
+    it("should find the SPA info for a specific core set ID", () => {
+      expect(getSpaName(props)).toBe("DC 24-0020 - Chronic Conditions");
+    });
+  });
+});

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -4,7 +4,7 @@ import { SPA } from "libs/spaLib";
 import { getPDF } from "libs/api";
 
 interface HookProps {
-  coreSetId: any;
+  coreSetId?: string;
   state?: string;
   year?: string;
 }
@@ -211,18 +211,20 @@ export const htmlStringCleanup = (html: string): string => {
  * Retrieve this core-set's SPA ID/Name if applicable
  */
 export const getSpaName = ({ coreSetId, state, year }: HookProps) => {
-  const coreSetInfo = coreSetId?.split("_") ?? [coreSetId];
-  const tempSpa =
-    coreSetInfo.length > 1
-      ? SPA[year!].filter(
-          (s) => s.id === coreSetInfo[1] && s.state === state
-        )[0]
-      : undefined;
-  const spaName =
-    tempSpa && tempSpa?.id && tempSpa?.name && tempSpa.state
-      ? `${tempSpa.state} ${tempSpa.id} - ${tempSpa.name}`
-      : undefined;
-  return spaName;
+  if (!coreSetId || !state || !year) {
+    return undefined;
+  }
+  if (!coreSetId.includes("_") || !(year in SPA)) {
+    return undefined;
+  }
+
+  const spaId = coreSetId.split("_")[1];
+  const spa = SPA[year].find((s) => s.id === spaId && s.state === state);
+  if (!spa) {
+    return undefined;
+  }
+
+  return `${spa.state} ${spa.id} - ${spa.name}`;
 };
 
 /**


### PR DESCRIPTION
### Description
It does what it says.

`getSpaName`, I refactored for clarity. The test for spaLib, I added so that I could justify excluding the check previously on line 222 in `getSpaName`. It was checking to see, not only whether it found an object, but also whether that object had truthy id, name, and state. If those are always truthy for every object in `SPA`, then that check is unneeded. And the unit test for spaLib asserts that truthiness.

I would have liked to add more tests around the helper functions within util.tsx. But I wanted to try to test them from the actual call site, if possible. Helpers like `openPdf` and `cloneChakraVariables` are only ever called from within `usePrinceRequest`, so I wanted to test them by calling them indirectly. But writing tests for `usePrinceRequest` is hard, because it calls React Hooks, and you're not allowed to call hooks unless you're already in a hook - which a unit test is not.

It is possible to work around this - for example, by using `react-hooks-testing-library`. But [they discourage](https://github.com/testing-library/react-hooks-testing-library?tab=readme-ov-file#when-to-use-this-library) use of their own tool when avoidable. And in theory, it is avoidable here - by writing tests for the ExportAll page, and clicking the button to call the hook.

But by the time I'd written some tests for the page and was ready to dig in to test the Prince hook, I had sunk in enough time to make this PR and call it a day. I'll get you next time, `usePrinceRequest` 💪 


### Related ticket(s)
n/a

---
### How to test

https://dtq45arh0fflf.cloudfront.net/

The unit tests should pass.

Visiting the ExportAll page for a Health Home core set should display the correct SPA name.


### Notes
n/a

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
