### PR TITLE
UAT Defect - Other Data Source

### DIFF
--- a/services/ui-src/src/measures/2025/AISAD/data.ts
+++ b/services/ui-src/src/measures/2025/AISAD/data.ts
@@ -19,6 +19,9 @@ export const data: MeasureTemplateData = {
   dataSource: {
     optionsLabel:
       "If reporting entities (e.g., health plans) used different data sources, please select all applicable data sources used below.",
-    options: [{ value: DC.ELECTRONIC_CLINIC_DATA_SYSTEMS, description: true }],
+    options: [
+      { value: DC.ELECTRONIC_CLINIC_DATA_SYSTEMS, description: true },
+      { value: "Other Data Source", description: true },
+    ],
   },
 };

--- a/services/ui-src/src/measures/2025/PDSAD/data.ts
+++ b/services/ui-src/src/measures/2025/PDSAD/data.ts
@@ -40,6 +40,7 @@ export const data: MeasureTemplateData = {
         ],
         description: true,
       },
+      { value: "Other Data Source", description: true },
     ],
   },
 };

--- a/services/ui-src/src/measures/2025/PDSCH/data.ts
+++ b/services/ui-src/src/measures/2025/PDSCH/data.ts
@@ -40,6 +40,7 @@ export const data: MeasureTemplateData = {
         ],
         description: true,
       },
+      { value: "Other Data Source", description: true },
     ],
   },
 };

--- a/services/ui-src/src/measures/2025/PRSAD/data.ts
+++ b/services/ui-src/src/measures/2025/PRSAD/data.ts
@@ -32,6 +32,7 @@ export const data: MeasureTemplateData = {
         ],
         description: true,
       },
+      { value: "Other Data Source", description: true },
     ],
   },
 };

--- a/services/ui-src/src/measures/2025/PRSCH/data.ts
+++ b/services/ui-src/src/measures/2025/PRSCH/data.ts
@@ -32,6 +32,7 @@ export const data: MeasureTemplateData = {
         ],
         description: true,
       },
+      { value: "Other Data Source", description: true },
     ],
   },
 };

--- a/services/ui-src/src/shared/commonQuestions/MeasurementSpecification.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasurementSpecification.tsx
@@ -50,11 +50,29 @@ export const MeasurementSpecificationQuestionYesNo = (
       ? `${Specifications[type].displayValue} Measurement Year ${year - 1}`
       : Specifications[type].displayValue;
   return (
-    <CUI.Text key="measureSpecAdditionalContext" size="sm" pb="3">
-      Did your state use {year} {label[coreset!]} Core Set measure
-      specifications, which are based on {specification} specifications to
-      calculate this measure?
-    </CUI.Text>
+    <>
+      <CUI.Text
+        key="measureSpecAdditionalContext-HelperText"
+        size="sm"
+        pb="3"
+        fontWeight="bold"
+      >
+        If your state substantially varied from the {label[coreset!]}
+        Core Set measure specifications (including different methodology,
+        timeframe, or reported age groups), please report your data using
+        “Other” specifications.
+      </CUI.Text>
+
+      <CUI.Text
+        key="measureSpecAdditionalContext-YesNoQuestion"
+        size="sm"
+        pb="3"
+      >
+        Did your state use {year} {label[coreset!]} Core Set measure
+        specifications, which are based on {specification} specifications to
+        calculate this measure?
+      </CUI.Text>
+    </>
   );
 };
 
@@ -94,6 +112,8 @@ export const MeasurementSpecification = ({ type, coreset }: Props) => {
   const register = useCustomRegister<Types.MeasurementSpecification>();
   const context: any = useContext(SharedContext);
   const { MeasureSpecifications, year } = context;
+
+  console.log("Measure specifications: ", MeasureSpecifications);
 
   const measureSpecs = { ...Specifications[type] };
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Added "Other Data Source" option to AIS-AD, PDS-AD, PRS-AD, PDS-CH, and PRS-CH.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4683

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Confirm that AIS-AD, PDS-AD, PRS-AD, PDS-CH, and PRS-CH all have an option to select "Other Data Source" 
<img width="1344" alt="Screenshot 2025-05-23 at 5 18 57 PM" src="https://github.com/user-attachments/assets/de8584f7-2152-470a-8877-6c67d4e5049c" />

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
