### PR TITLE
[CMDCT-4687] UAT Defect - PCR-HH Measure Section

### DIFF
--- a/services/ui-src/src/measures/2025/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2025/PCRHH/index.tsx
@@ -35,7 +35,7 @@ export const PCRHH = ({
       {!isNotReportingData && (
         <>
           <CMQ.StatusOfData />
-          <CMQ.MeasurementSpecification type="HEDIS" />
+          <CMQ.MeasurementSpecification type="HEDIS" coreset="health" />
           <CMQ.DataSource />
           <CMQ.DateRange type="health" />
           <CMQ.DefinitionOfPopulation coreset="health" />


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
For PCR-HH, the text Health Home didn't dynamically generate in the Measure Specification section.
![Screenshot 2025-05-28 at 2 28 38 PM](https://github.com/user-attachments/assets/f7b13537-ab8f-40bb-98d1-b6ec41d16d3f)

Easy fix, the core set prop wasn't set for that measure. i checked all the other 2025 index.tsx files and this was the only one missing.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4687

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Deploy Link: https://d2vr410j5k9t0q.cloudfront.net/

1) Sign into QMR, [stateuserWA@test.com](mailto:stateuserDC@test.com)
2) In reporting year 2025, add Health Home Core Set 
3) Go to PCR-HH
4) Check that Measure Specification section shows Health Home 
<img width="1268" alt="Screenshot 2025-05-28 at 2 31 27 PM" src="https://github.com/user-attachments/assets/0c3b6d17-979c-4740-b887-b15666f6481d" />



### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
