### PR TITLE
CMDCT-4660 - ECDS Optional Field Language Update

### DIFF
--- a/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
@@ -11,9 +11,11 @@ export const commonQuestionsLabel = {
     },
   },
   DataSource: {
-    ehrSrc: "Describe the data source:",
+    ehrSrc: "Optional - Describe the data source(s) used:",
     describeDataSrc:
       "Describe the data source (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+    describeOptionalDataSrc:
+      "Optional - Describe the data source(s) used: (<em>text in this field is included in publicly-reported state-specific comments</em>):",
     srcExplanation: "Data Source Explanation",
     srcExplanationText:
       "For each data source selected above, describe which reporting entities used each data source (e.g., health plans, FFS). If the data source differed across health plans or delivery systems, identify the number of plans or delivery systems that used each data source (<em>text in this field is included in publicly-reported state-specific comments</em>).",

--- a/services/ui-src/src/shared/commonQuestions/DataSource.tsx
+++ b/services/ui-src/src/shared/commonQuestions/DataSource.tsx
@@ -128,11 +128,16 @@ const buildDataSourceOptions: DSCBFunc = ({
 const addHintLabel = (options: OptionNode[], labels: AnyObject) => {
   options.forEach((options) => {
     if (options.description)
-      options.hint =
-        options.value === DC.ELECTRONIC_HEALTH_RECORDS && labels.ehrSrc
-          ? labels.ehrSrc!
-          : labels.describeDataSrc!;
-
+      if (options.value === DC.ELECTRONIC_HEALTH_RECORDS && labels.ehrSrc) {
+        options.hint = labels.ehrSrc;
+      } else if (
+        options.value === DC.ELECTRONIC_CLINIC_DATA_SYSTEMS &&
+        labels.describeOptionalDataSrc
+      ) {
+        options.hint = labels.describeOptionalDataSrc;
+      } else {
+        options.hint = labels.describeDataSrc;
+      }
     if (options.subOptions) {
       options.subOptions.forEach((subOption) => {
         addHintLabel(subOption.options, labels);

--- a/services/ui-src/src/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
+++ b/services/ui-src/src/shared/globalValidations/validateAtLeastOneDataSourceType/index.test.ts
@@ -83,4 +83,17 @@ describe("validateOneDataSourceType", () => {
     expect(errorArray.length).toBe(1);
     expect(errorArray[0].errorMessage).toBe(errorMessage);
   });
+
+  it("When data sources with optional descriptions are selected no validation warning shows", () => {
+    formData[DC.DATA_SOURCE] = [];
+    formData[DC.DATA_SOURCE_SELECTIONS] = {
+      ElectronicHealthRecords: {
+        description: undefined,
+      },
+      ElectronicClinicalDataSystemsECDS: {
+        description: undefined,
+      },
+    };
+    _check_errors(formData, 0);
+  });
 });

--- a/services/ui-src/src/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateAtLeastOneDataSourceType/index.ts
@@ -1,4 +1,7 @@
 import * as Types from "shared/types";
+import { DataSource } from "../../../types";
+
+const OPTIONAL_DATA_SOURCES = new Set([DataSource.EHR, DataSource.ECDS]);
 
 export const validateAtLeastOneDataSourceType = (
   data: Types.DataSource,
@@ -7,16 +10,17 @@ export const validateAtLeastOneDataSourceType = (
   const errorArray: FormError[] = [];
   const dataSources = data.DataSourceSelections;
   if (dataSources) {
-    //find selected data sources with unfilled explanation boxes
+    //find selected data sources with unfilled explanation boxes, which are not optional
     const unfilledDataSources = Object.keys(dataSources).filter(
       (key) =>
-        "description" in dataSources[key] && !dataSources[key]["description"]
+        "description" in dataSources[key] &&
+        !dataSources[key]["description"] &&
+        !OPTIONAL_DATA_SOURCES.has(key as DataSource)
     );
     errorArray.push(
       ...unfilledDataSources.map((key) => {
         const lookupKey = key.split("-")?.[1] ?? key;
         const label = Types.dataSourceDisplayNames[lookupKey];
-
         return {
           errorLocation: "Data Source",
           errorMessage:
@@ -41,6 +45,5 @@ export const validateAtLeastOneDataSourceType = (
       }))
     );
   }
-
   return errorArray;
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Added "Optional" descriptions to EHR and ECDS data source explanation text fields
- Changed form verification to not show errors in the above cases
- Added test for the above scenario


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4660

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Deployed link: https://d14pczia22cda.cloudfront.net/
- Log in
- Select Child Core Set Measures: Medicaid (first set)
- Select AAD-CH (2nd in list)
- Under "Data Source", select: 
  - ECDS -> Administrative Data
  - Electronic Health Records
  - Other Data Source

- Observe that ECDS and EHC text boxes start with "Optional"
- Click "Validate Measure" at the bottom of the field
- Observe that the only Data Source Error is about the "Other Data Source" and not any other data source



---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
~- [ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
