### PR TITLE
[CMDCT-4775] GitHub actions to auto-create val and production PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,16 +8,16 @@
 CMDCT-
 
 ---
+
 ### How to test
 <!-- Step-by-step instructions on how to test, if necessary -->
-
 
 ### Notes
 <!-- Changed dependencies, .env files, configs, etc. -->
 <!-- Instructions for local dev, e.g. requires new installs in directories -->
 
-
 ---
+
 ### Pre-review checklist
 <!-- Complete the following steps before opening for review -->
 - [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
@@ -26,19 +26,23 @@ CMDCT-
 - [ ] I have manually tested this PR in the deployed cloud environment
 
 ---
+
 ### Pre-merge checklist
 <!-- Complete the following steps before merging -->
 
 #### Review
+
 - [ ] Design: This work has been reviewed and approved by design, if necessary
 - [ ] Product: This work has been reviewed and approved by product owner, if necessary
 
 #### Security
+
 _If either of the following are true, notify the team's ISSO (Information System Security Officer)._
 
 - [ ] These changes are significant enough to require an update to the SIA.
 - [ ] These changes are significant enough to require a penetration test.
+
 ---
 
 <!-- If deploying to val or prod, click 'Preview' and select template -->
-_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
+_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_

--- a/.github/PULL_REQUEST_TEMPLATE/production-deployment.md
+++ b/.github/PULL_REQUEST_TEMPLATE/production-deployment.md
@@ -1,0 +1,14 @@
+## production release
+
+### In this deployment
+<!-- List all work that is part of this deployment -->
+<!-- - Description of work (CMDCT-<ticket-number>) -->
+
+- Description of work (CMDCT-)
+
+### Dependency updates
+<!-- List package updates that are part of this deployment -->
+
+| package | prior version | upgraded version|
+|-|-|-|
+| `package-name` | 0.0.0 | 1.0.0 |

--- a/.github/PULL_REQUEST_TEMPLATE/test-to-val-deployment.md
+++ b/.github/PULL_REQUEST_TEMPLATE/test-to-val-deployment.md
@@ -1,7 +1,0 @@
-## test → val
----
-### In this deployment:
-<!-- List all work that is part of this deployment -->
-<!-- - Description of work (CMDCT-<ticket-number>) -->
-
-- Description of work (CMDCT-)

--- a/.github/PULL_REQUEST_TEMPLATE/val-deployment.md
+++ b/.github/PULL_REQUEST_TEMPLATE/val-deployment.md
@@ -1,0 +1,14 @@
+## val release
+
+### In this deployment
+<!-- List all work that is part of this deployment -->
+<!-- - Description of work (CMDCT-<ticket-number>) -->
+
+- Description of work (CMDCT-)
+
+### Dependency updates
+<!-- List package updates that are part of this deployment -->
+
+| package | prior version | upgraded version|
+|-|-|-|
+| `package-name` | 0.0.0 | 1.0.0 |

--- a/.github/PULL_REQUEST_TEMPLATE/val-to-prod-deployment.md
+++ b/.github/PULL_REQUEST_TEMPLATE/val-to-prod-deployment.md
@@ -1,7 +1,0 @@
-## val → prod
----
-### In this deployment:
-<!-- List all work that is part of this deployment -->
-<!-- - Description of work (CMDCT-<ticket-number>) -->
-
-- Description of work (CMDCT-)

--- a/.github/commit-log.sh
+++ b/.github/commit-log.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+HEAD="${1}"
+BASE="${2}"
+
+git fetch origin "$HEAD" >/dev/null 2>&1
+git fetch origin "$BASE" >/dev/null 2>&1
+
+COMMIT_LOG=$(git log "origin/$BASE..origin/$HEAD" --no-merges --pretty=format:"%s" | \
+  sed -E 's/ *\(#[0-9]+\)*//g' | \
+  awk '{
+    orig_line = $0;
+    line = tolower($0);
+    tickets = "";
+    output_line = orig_line;
+
+    # Find ticket(s) in commit message, case-insensitive
+    while (match(line, /cmdct[ -]?[0-9]+/)) {
+      ticket = substr(orig_line, RSTART, RLENGTH);
+      ref = substr(line, RSTART, RLENGTH);
+      
+      # Normalize ticket number
+      gsub(/[^0-9]/, "", ref);
+      ticket_str = "CMDCT-" ref;
+
+      # Deduplicate
+      if (tickets !~ ticket_str) {
+        tickets = tickets ? tickets ", " ticket_str : ticket_str;
+      }
+
+      # Remove original ticket(s)
+      output_line = substr(output_line, 1, RSTART - 1) substr(output_line, RSTART + RLENGTH);
+      line = substr(line, RSTART + RLENGTH);
+      orig_line = output_line;
+    }
+
+    # Remove empty square brackets
+    gsub(/\[\]/, "", output_line);
+
+    # Trim leading/trailing spaces, dashes, and colons
+    gsub(/^[ \-:]+|[ \-:]+$/, "", output_line);
+
+    # Add ticket or placeholder to the end
+    printf "- %s (%s)\n", output_line, tickets ? tickets : "CMDCT-";
+  }')
+
+# No diff between branches, so exit
+if [ -z "$COMMIT_LOG" ]; then
+  exit 1
+fi
+
+TEMPLATE_PATH=".github/PULL_REQUEST_TEMPLATE/${BASE}-deployment.md"
+DEFAULT_TEMPLATE=".github/PULL_REQUEST_TEMPLATE/val-deployment.md"
+
+if [ -f "$TEMPLATE_PATH" ]; then
+  TEMPLATE=$(cat "$TEMPLATE_PATH")
+else
+  TEMPLATE=$(cat "$DEFAULT_TEMPLATE")
+  # Replace PR heading
+  SEARCH="## val release"
+  REPLACEMENT="## ${BASE} release"
+
+  # Escape slashes and other special characters for sed
+  ESCAPED_REPLACEMENT=$(printf '%s\n' "$REPLACEMENT" | sed 's/[\/&]/\\&/g')
+  TEMPLATE=$(echo "$TEMPLATE" | sed "s|^$SEARCH|$ESCAPED_REPLACEMENT|")
+fi
+
+# Strip comments
+TEMPLATE=$(echo "$TEMPLATE" | perl -0777 -pe 's/^[ \t]*<!--.*?-->[ \t]*\n?//gm')
+
+# Replace commits placeholder
+BODY="${TEMPLATE//- Description of work (CMDCT-)/$COMMIT_LOG}"
+
+# Create dependency updates table
+TABLE_HEADERS="| directory | package | prior version | upgraded version |
+|-|-|-|-|"
+TABLE_BODY=""
+
+# Check for yarn.lock files in diff
+YARN_LOCK_FILES=$(
+  git diff --name-only "origin/$BASE..origin/$HEAD" \
+    -- "**/yarn.lock" "yarn.lock"
+)
+
+for FILE in $YARN_LOCK_FILES; do
+  DIRNAME=$(dirname "$FILE")
+
+  # Create temp copies of yarn.lock and package.json files
+  TEMP_DIR=$(mktemp -d)
+  trap 'rm -Rf "$TEMP_DIR"' EXIT
+  git show "origin/$BASE:$FILE" > "$TEMP_DIR/yarn.lock.new"
+  git show "origin/$HEAD:$FILE" > "$TEMP_DIR/yarn.lock.old"
+  git show "origin/$BASE:$DIRNAME/package.json" > "$TEMP_DIR/package.json.new"
+  git show "origin/$HEAD:$DIRNAME/package.json" > "$TEMP_DIR/package.json.old"
+
+  # Run diff script
+  DIFF_OUTPUT=$(
+    node ./scripts/yarn-lock-diff.cjs \
+      "$TEMP_DIR/yarn.lock.new" \
+      "$TEMP_DIR/yarn.lock.old" \
+      "$TEMP_DIR/package.json.new" \
+      "$TEMP_DIR/package.json.old"
+  )
+
+  if [[ -n "$DIFF_OUTPUT" && "$DIFF_OUTPUT" != "[]" ]]; then
+    if [ "$DIRNAME" = "." ]; then
+      DIRECTORY="/"
+    else
+      DIRECTORY="/$DIRNAME"
+    fi
+
+    ADD_DIRNAME=$(
+      echo "$DIFF_OUTPUT" | jq --arg d "$DIRECTORY" '
+        .[] |= . + {directory: $d}
+      '
+    )
+    PARSED_ROW=$(
+      echo "$ADD_DIRNAME" | jq -r '
+        .[] |
+        "| `\(.directory)` | `\(.package)` | \(.priorVersion) | \(.upgradedVersion) |"
+      '
+    )
+    TABLE_BODY+="$PARSED_ROW"$'\n'
+  fi
+done
+
+# Remove dependency updates placeholder
+BODY=$(echo "$BODY" | perl -0777 -pe 's/^### Dependency updates\b.*?(?=^### |\z)//sm')
+
+if [ -n "$TABLE_BODY" ]; then
+  TABLE_BODY=$(echo "$TABLE_BODY" | sort -u)
+
+  # Insert dependency updates table
+  BODY+=$'\n\n### Dependency updates\n\n'
+  BODY+="$TABLE_HEADERS"
+  BODY+="$TABLE_BODY"
+fi
+
+echo "$BODY"

--- a/.github/workflows/create-master-to-val-pr.yml
+++ b/.github/workflows/create-master-to-val-pr.yml
@@ -1,9 +1,10 @@
-name: Create val to prod PR
+name: Create master to val PR
 
 on:
   push:
     branches:
-      - val
+      - master
+      - bs-auto-prs
   workflow_dispatch:
 
 permissions:
@@ -25,8 +26,8 @@ jobs:
     - name: Set branch variables
       id: set-vars
       run: |
-        echo "HEAD_BRANCH=val" >> $GITHUB_ENV
-        echo "BASE_BRANCH=production" >> $GITHUB_ENV
+        echo "HEAD_BRANCH=master" >> $GITHUB_ENV
+        echo "BASE_BRANCH=val" >> $GITHUB_ENV
     - name: Generate PR body
       id: pr_body
       run: |
@@ -62,7 +63,7 @@ jobs:
         set -euo pipefail
  
         current_date=$(date '+%-d %B %Y')
-        title="CARTS production release (${current_date})"
+        title="CARTS val release (${current_date})"
 
         decoded_body="${RAW_BODY//%25/%}"
         decoded_body="${decoded_body//%0A/__NEWLINE__}"

--- a/.github/workflows/create-master-to-val-pr.yml
+++ b/.github/workflows/create-master-to-val-pr.yml
@@ -63,7 +63,7 @@ jobs:
         set -euo pipefail
  
         current_date=$(date '+%-d %B %Y')
-        title="CARTS val release (${current_date})"
+        title="QMR val release (${current_date})"
 
         decoded_body="${RAW_BODY//%25/%}"
         decoded_body="${decoded_body//%0A/__NEWLINE__}"

--- a/.github/workflows/create-master-to-val-pr.yml
+++ b/.github/workflows/create-master-to-val-pr.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - bs-auto-prs
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/create-master-to-val-pr.yml
+++ b/.github/workflows/create-master-to-val-pr.yml
@@ -1,0 +1,93 @@
+name: Create val to prod PR
+
+on:
+  push:
+    branches:
+      - val
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: ".nvmrc"
+    - name: Prepare for yarn-lock-diff
+      run: yarn install --frozen-lockfile
+    - name: Set branch variables
+      id: set-vars
+      run: |
+        echo "HEAD_BRANCH=val" >> $GITHUB_ENV
+        echo "BASE_BRANCH=production" >> $GITHUB_ENV
+    - name: Generate PR body
+      id: pr_body
+      run: |
+        body=$(.github/commit-log.sh "$HEAD_BRANCH" "$BASE_BRANCH") || exit_code=$?
+        if [ "$exit_code" == "1" ]; then
+          echo "No commits. Skipping PR."
+          echo "skip=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        echo "$body"
+        body="${body//'%'/'%25'}"
+        body="${body//$'\n'/'%0A'}"
+        body="${body//$'\r'/'%0D'}"
+        echo "body=$body" >> $GITHUB_OUTPUT
+        echo "skip=false" >> $GITHUB_OUTPUT
+    - name: Check if PR already exists
+      if: steps.pr_body.outputs.skip != 'true'
+      id: check_pr
+      run: |
+        pr_number=$(gh pr list --head "$HEAD_BRANCH" --base "$BASE_BRANCH" --json number --jq '.[0].number' || echo "")
+        if [ -n "$pr_number" ]; then
+          echo "PR already exists: #$pr_number"
+          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "number=${pr_number}" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create or update PR
+      if: steps.pr_body.outputs.skip != 'true'
+      run: |
+        set -euo pipefail
+ 
+        current_date=$(date '+%-d %B %Y')
+        title="CARTS production release (${current_date})"
+
+        decoded_body="${RAW_BODY//%25/%}"
+        decoded_body="${decoded_body//%0A/__NEWLINE__}"
+        decoded_body="${decoded_body//%0D/__CARRIAGERETURN__}"
+        decoded_body="$(printf '%s' "$decoded_body" | sed 's/__NEWLINE__/\n/g; s/__CARRIAGERETURN__/\r/g')"
+
+        tmpfile=$(mktemp)
+        printf '%s\n' "$decoded_body" > "$tmpfile"
+
+        if [ "$PR_EXISTS" == "true" ]; then
+          echo "Updating existing PR #$PR_NUMBER"
+          gh pr edit $PR_NUMBER \
+            --title "$title" \
+            --body-file "$tmpfile"
+        else
+          echo "Creating new PR"
+          gh pr create \
+            --head "$HEAD_BRANCH" \
+            --base "$BASE_BRANCH" \
+            --title "$title" \
+            --body-file "$tmpfile" \
+            --draft
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_EXISTS: ${{ steps.check_pr.outputs.exists }}
+        PR_NUMBER: ${{ steps.check_pr.outputs.number }}
+        RAW_BODY: ${{ steps.pr_body.outputs.body }}

--- a/.github/workflows/create-val-to-prod-pr.yml
+++ b/.github/workflows/create-val-to-prod-pr.yml
@@ -62,7 +62,7 @@ jobs:
         set -euo pipefail
  
         current_date=$(date '+%-d %B %Y')
-        title="CARTS production release (${current_date})"
+        title="QMR production release (${current_date})"
 
         decoded_body="${RAW_BODY//%25/%}"
         decoded_body="${decoded_body//%0A/__NEWLINE__}"

--- a/.github/workflows/create-val-to-prod-pr.yml
+++ b/.github/workflows/create-val-to-prod-pr.yml
@@ -1,0 +1,93 @@
+name: Create master to val PR
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: ".nvmrc"
+    - name: Prepare for yarn-lock-diff
+      run: yarn install --frozen-lockfile
+    - name: Set branch variables
+      id: set-vars
+      run: |
+        echo "HEAD_BRANCH=master" >> $GITHUB_ENV
+        echo "BASE_BRANCH=val" >> $GITHUB_ENV
+    - name: Generate PR body
+      id: pr_body
+      run: |
+        body=$(.github/commit-log.sh "$HEAD_BRANCH" "$BASE_BRANCH") || exit_code=$?
+        if [ "$exit_code" == "1" ]; then
+          echo "No commits. Skipping PR."
+          echo "skip=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        echo "$body"
+        body="${body//'%'/'%25'}"
+        body="${body//$'\n'/'%0A'}"
+        body="${body//$'\r'/'%0D'}"
+        echo "body=$body" >> $GITHUB_OUTPUT
+        echo "skip=false" >> $GITHUB_OUTPUT
+    - name: Check if PR already exists
+      if: steps.pr_body.outputs.skip != 'true'
+      id: check_pr
+      run: |
+        pr_number=$(gh pr list --head "$HEAD_BRANCH" --base "$BASE_BRANCH" --json number --jq '.[0].number' || echo "")
+        if [ -n "$pr_number" ]; then
+          echo "PR already exists: #$pr_number"
+          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "number=${pr_number}" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create or update PR
+      if: steps.pr_body.outputs.skip != 'true'
+      run: |
+        set -euo pipefail
+ 
+        current_date=$(date '+%-d %B %Y')
+        title="CARTS val release (${current_date})"
+
+        decoded_body="${RAW_BODY//%25/%}"
+        decoded_body="${decoded_body//%0A/__NEWLINE__}"
+        decoded_body="${decoded_body//%0D/__CARRIAGERETURN__}"
+        decoded_body="$(printf '%s' "$decoded_body" | sed 's/__NEWLINE__/\n/g; s/__CARRIAGERETURN__/\r/g')"
+
+        tmpfile=$(mktemp)
+        printf '%s\n' "$decoded_body" > "$tmpfile"
+
+        if [ "$PR_EXISTS" == "true" ]; then
+          echo "Updating existing PR #$PR_NUMBER"
+          gh pr edit $PR_NUMBER \
+            --title "$title" \
+            --body-file "$tmpfile"
+        else
+          echo "Creating new PR"
+          gh pr create \
+            --head "$HEAD_BRANCH" \
+            --base "$BASE_BRANCH" \
+            --title "$title" \
+            --body-file "$tmpfile" \
+            --draft
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_EXISTS: ${{ steps.check_pr.outputs.exists }}
+        PR_NUMBER: ${{ steps.check_pr.outputs.number }}
+        RAW_BODY: ${{ steps.pr_body.outputs.body }}

--- a/.github/workflows/create-val-to-prod-pr.yml
+++ b/.github/workflows/create-val-to-prod-pr.yml
@@ -26,7 +26,7 @@ jobs:
       id: set-vars
       run: |
         echo "HEAD_BRANCH=val" >> $GITHUB_ENV
-        echo "BASE_BRANCH=production" >> $GITHUB_ENV
+        echo "BASE_BRANCH=prod" >> $GITHUB_ENV
     - name: Generate PR body
       id: pr_body
       run: |

--- a/.github/workflows/create-val-to-prod-pr.yml
+++ b/.github/workflows/create-val-to-prod-pr.yml
@@ -1,9 +1,9 @@
-name: Create master to val PR
+name: Create val to prod PR
 
 on:
   push:
     branches:
-      - master
+      - val
   workflow_dispatch:
 
 permissions:
@@ -25,8 +25,8 @@ jobs:
     - name: Set branch variables
       id: set-vars
       run: |
-        echo "HEAD_BRANCH=master" >> $GITHUB_ENV
-        echo "BASE_BRANCH=val" >> $GITHUB_ENV
+        echo "HEAD_BRANCH=val" >> $GITHUB_ENV
+        echo "BASE_BRANCH=production" >> $GITHUB_ENV
     - name: Generate PR body
       id: pr_body
       run: |
@@ -62,7 +62,7 @@ jobs:
         set -euo pipefail
  
         current_date=$(date '+%-d %B %Y')
-        title="CARTS val release (${current_date})"
+        title="CARTS production release (${current_date})"
 
         decoded_body="${RAW_BODY//%25/%}"
         decoded_body="${decoded_body//%0A/__NEWLINE__}"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/yargs": "^15.0.10",
     "@typescript-eslint/eslint-plugin": "5.18.0",
     "@typescript-eslint/parser": "5.18.0",
+    "@yarnpkg/lockfile": "^1.1.0",
     "aws-cdk": "^2.1007.0",
     "aws-cdk-local": "^2.19.2",
     "chromedriver": ">=135.0.1",

--- a/scripts/yarn-lock-diff.cjs
+++ b/scripts/yarn-lock-diff.cjs
@@ -1,0 +1,102 @@
+/* eslint-disable no-console */
+/*
+ * Usage:
+ *   node ./scripts/yarn-lock-diff.cjs \
+ *     yarn.lock.new \
+ *     yarn.lock.old \
+ *     package.json.new \
+ *     package.json.old
+ */
+
+const fs = require("fs");
+const { parse } = require("@yarnpkg/lockfile");
+
+const getPackageName = (key) => {
+  const match = key.match(/^(@?[^@]+(?:\/[^@]+)?)@/);
+  return match ? match[1] : key;
+};
+
+const parseLockFile = (filePath) => {
+  const content = fs.readFileSync(filePath, "utf8");
+  const parsed = parse(content);
+  return parsed.object;
+};
+
+const parsePackageJson = (filePath) => {
+  const content = fs.readFileSync(filePath, "utf8");
+  const json = JSON.parse(content);
+
+  return {
+    ...json.dependencies,
+    ...json.devDependencies,
+  };
+};
+
+const compareLockFiles = (oldLockFile, newLockFile) => {
+  const keys = new Set([
+    ...Object.keys(oldLockFile),
+    ...Object.keys(newLockFile),
+  ]);
+  const packages = [];
+
+  for (const key of keys) {
+    const packageName = getPackageName(key);
+    const priorEntry = oldLockFile[key];
+    const upgradedEntry = newLockFile[key];
+
+    const priorVersion = priorEntry?.version || "-";
+    const upgradedVersion = upgradedEntry?.version || "-";
+
+    let status = "";
+    if (!priorEntry && upgradedEntry) status = "added";
+    else if (priorEntry && !upgradedEntry) status = "removed";
+    else if (priorEntry.version === upgradedEntry.version) status = "unchanged";
+
+    // Skip unchanged packages
+    if (status === "unchanged") continue;
+
+    const packageIndex = packages.findIndex(
+      (pkg) => pkg.package === packageName
+    );
+
+    // Package has multiple entries, so combine them
+    if (packageIndex > -1) {
+      if (status === "added") {
+        packages[packageIndex].upgradedVersion = upgradedVersion;
+      }
+      if (status === "removed") {
+        packages[packageIndex].priorVersion = priorVersion;
+      }
+    } else {
+      const pkg = {
+        package: packageName,
+        priorVersion,
+        upgradedVersion,
+      };
+      packages.push(pkg);
+    }
+  }
+
+  return packages;
+};
+
+const parsedOldPackageJson = parsePackageJson(process.argv[4]);
+const parsedNewPackageJson = parsePackageJson(process.argv[5]);
+
+const packageJsonDependencies = new Set([
+  ...Object.keys(parsedOldPackageJson),
+  ...Object.keys(parsedNewPackageJson),
+]);
+
+const parsedOldLockFile = parseLockFile(process.argv[2]);
+const parsedNewLockFile = parseLockFile(process.argv[3]);
+
+const diff = compareLockFiles(parsedOldLockFile, parsedNewLockFile);
+
+// Filter diff to non-transitive packages
+const filteredDiff = diff.filter((pkg) =>
+  packageJsonDependencies.has(pkg.package)
+);
+
+// Print diff
+console.log(JSON.stringify(filteredDiff, null, 2));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,6 +1545,11 @@
     "@typescript-eslint/types" "5.18.0"
     eslint-visitor-keys "^3.0.0"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR adds GitHub actions that will check for differences between `master → val`, and `val → prod` and will auto create a release PR with commit list and package update table. The `master → val` action updated this PR (https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2661) on a push trigger to this branch which I added just for testing, but have removed for final PR review.

#### Notable features
1. The `master → val` action is set to run with merges to `master`, and `val → prod` with merges to `val`
    - If there are no differences between the branches, the actions abort
2. The PR that gets created will have a title like `QMR val release (9 June 2025)` and starts off as a draft PR
3. If the PR doesn't get merged and more changes are added, the PR will auto-update including the title
    - i.e. If you update `master` on June 10, the PR title will become `QMR val release (10 June 2025)` and the PR body will be updated
4. If the commit message has a CMDCT- ticket (case-insensitive) in the message, it'll get extracted and added to the end of the commit list
    - Multiple tickets should be extracted fine, such as from this PR: https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2652
    - If it doesn't, a placeholder (CMDCT-) will be added and these have to be manually edited or removed if there's no associated ticket
6. The actions can also be run manually after merge to `master` from the [Actions](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/actions) tab

#### Other changes
- Slight spacing and punctuation changes to the pull request templates, based on markdown lint
- Rename templates to simpler names

### Related ticket(s) 
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4775

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. The script that generates the PR body can be run on its own to compare any two branches
    - For a `master → val` PR, run `./.github/commit-log.sh master val`
2. After merging this PR, https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2661 should auto-update

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
