### PR TITLE
QMR2025 - Changes to Qualifier Questions

### DIFF
--- a/services/ui-src/src/labels/2021/qualifierFormsData.tsx
+++ b/services/ui-src/src/labels/2021/qualifierFormsData.tsx
@@ -1,13 +1,5 @@
 import { initialAuditValues } from "shared/Qualifiers/Common";
-
-export interface DataDriven {
-  title: string;
-  formData: any;
-  questionTitle: string;
-  qualifierHeader: (year: string) => string;
-  textTable: string[][];
-  fieldValues: string[];
-}
+import { DataDriven } from "shared/types/TypeQualifierForm";
 
 const AdultData: DataDriven = {
   title: "Adult Core Set Qualifiers",

--- a/services/ui-src/src/labels/2022/qualifierFormsData.tsx
+++ b/services/ui-src/src/labels/2022/qualifierFormsData.tsx
@@ -1,13 +1,5 @@
 import { initialAuditValues } from "shared/Qualifiers/Common";
-
-export interface DataDriven {
-  title: string;
-  formData: any;
-  questionTitle: string;
-  qualifierHeader: (year: string) => string;
-  textTable: string[][];
-  fieldValues: string[];
-}
+import { DataDriven } from "shared/types/TypeQualifierForm";
 
 const AdultData: DataDriven = {
   title: "Adult Core Set Qualifiers",

--- a/services/ui-src/src/labels/2023/qualifierFormsData.tsx
+++ b/services/ui-src/src/labels/2023/qualifierFormsData.tsx
@@ -1,13 +1,5 @@
 import { initialAuditValues } from "shared/Qualifiers/Common";
-
-export interface DataDriven {
-  title: string;
-  formData: any;
-  questionTitle: string;
-  qualifierHeader: (year: string) => string;
-  textTable: string[][];
-  fieldValues: string[];
-}
+import { DataDriven } from "shared/types/TypeQualifierForm";
 
 const AdultData: DataDriven = {
   title: "Adult Core Set Qualifiers",

--- a/services/ui-src/src/labels/2025/qualifierFormsData.tsx
+++ b/services/ui-src/src/labels/2025/qualifierFormsData.tsx
@@ -5,9 +5,9 @@ const AdultData: DataDriven = {
   title: "Adult Core Set Qualifiers: Medicaid",
   questionTitle: "Adult Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of December 31, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (age 21 and older) were enrolled in each delivery system?`,
+    `As of December 31, ${year}, approximately what percentage of adults in your state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI) were enrolled in each delivery system?`,
   textTable: [
-    ["Medicaid (Title XIX & XXI)", "Ages 21 to 64"],
+    ["Medicaid (Title XIX & XXI)", "Adults Under Age 65"],
     ["Medicaid (Title XIX & XXI)", "Age 65 and older"],
   ],
   fieldValues: ["TwentyOneToSixtyFour", "GreaterThanSixtyFour"],
@@ -36,14 +36,18 @@ const AdultData: DataDriven = {
       },
     ],
   },
+  ageQuestion: {
+    label:
+      "Generally, what are the ages of adults covered in the state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI)",
+  },
 };
 
 const AdultChipData: DataDriven = {
   title: "Adult Core Set Qualifiers: CHIP",
   questionTitle: "Adult Core Set Questions: CHIP",
   qualifierHeader: (year) =>
-    `As of December 31, ${year}, what percentage of your separate CHIP enrollees (age 21 and older) were enrolled in each delivery system?`,
-  textTable: [["Separate CHIP", "Ages 21 to 64"]],
+    `As of December 31, ${year}, approximately what percentage of adults in your state’s separate CHIP (Title XXI) program were enrolled in each delivery system?`,
+  textTable: [["Separate CHIP"]],
   fieldValues: ["TwentyOneToSixtyFour"],
   formData: {
     CoreSetMeasuresAuditedOrValidatedDetails: [initialAuditValues],
@@ -66,15 +70,19 @@ const AdultChipData: DataDriven = {
       },
     ],
   },
+  ageQuestion: {
+    label:
+      "Generally, what are the ages of adults covered in the state’s separate CHIP (Title XXI) program?",
+  },
 };
 
 const AdultMedicaidData: DataDriven = {
   title: "Adult Core Set Qualifiers: Medicaid",
   questionTitle: "Adult Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of December 31, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (age 21 and older) were enrolled in each delivery system?`,
+    `As of December 31, ${year}, approximately what percentage of adults in your state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI) were enrolled in each delivery system?`,
   textTable: [
-    ["Medicaid (Title XIX & XXI)", "Ages 21 to 64"],
+    ["Medicaid (Title XIX & XXI)", "Adults Under Age 65"],
     ["Medicaid (Title XIX & XXI)", "Age 65 and older"],
   ],
   fieldValues: ["TwentyOneToSixtyFour", "GreaterThanSixtyFour"],
@@ -103,14 +111,18 @@ const AdultMedicaidData: DataDriven = {
       },
     ],
   },
+  ageQuestion: {
+    label:
+      "Generally, what are the ages of adults covered in the state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI)",
+  },
 };
 
 const ChildData: DataDriven = {
   title: "Child Core Set Qualifiers: Medicaid",
   questionTitle: "Child Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of December 31, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system?`,
-  textTable: [["Medicaid (TITLE XIX & XXI)", "Under Age 21"]],
+    `As of December 31, ${year}, approximately what percentage of children in your state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI) were enrolled in each delivery system?`,
+  textTable: [["Medicaid (TITLE XIX & XXI)"]],
   fieldValues: ["UnderTwentyOneMedicaid"],
   formData: {
     PercentageEnrolledInEachDeliverySystem: [
@@ -133,14 +145,18 @@ const ChildData: DataDriven = {
     ],
     CoreSetMeasuresAuditedOrValidatedDetails: [initialAuditValues],
   },
+  ageQuestion: {
+    label:
+      "Generally, what are the ages of children covered in the state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI)",
+  },
 };
 
 const ChildChipData: DataDriven = {
   title: "Child Core Set Qualifiers: CHIP",
   questionTitle: "Child Core Set Questions: CHIP",
   qualifierHeader: (year) =>
-    `As of December 31, ${year}, what percentage of your separate CHIP enrollees (under age 21) were enrolled in each delivery system?`,
-  textTable: [["Separate CHIP", "Under Age 21"]],
+    `As of December 31, ${year}, approximately what percentage of children in your state’s separate CHIP (Title XXI) program were enrolled in each delivery system?`,
+  textTable: [["Separate CHIP"]],
   fieldValues: ["UnderTwentyOne"],
   formData: {
     PercentageEnrolledInEachDeliverySystem: [
@@ -163,14 +179,18 @@ const ChildChipData: DataDriven = {
     ],
     CoreSetMeasuresAuditedOrValidatedDetails: [initialAuditValues],
   },
+  ageQuestion: {
+    label:
+      "Generally, what are the ages of children covered in the state’s separate CHIP (Title XXI) program?",
+  },
 };
 
 const ChildMedicaidData: DataDriven = {
   title: "Child Core Set Qualifiers: Medicaid",
   questionTitle: "Child Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of December 31, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system?`,
-  textTable: [["Medicaid (Title XIX & XXI)", "Under Age 21"]],
+    `As of December 31, ${year}, approximately what percentage of children in your state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI) were enrolled in each delivery system?`,
+  textTable: [["Medicaid (Title XIX & XXI)"]],
   fieldValues: ["UnderTwentyOne"],
   formData: {
     PercentageEnrolledInEachDeliverySystem: [
@@ -192,6 +212,10 @@ const ChildMedicaidData: DataDriven = {
       },
     ],
     CoreSetMeasuresAuditedOrValidatedDetails: [initialAuditValues],
+  },
+  ageQuestion: {
+    label:
+      "Generally, what are the ages of children covered in the state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI)",
   },
 };
 

--- a/services/ui-src/src/labels/2025/qualifierFormsData.tsx
+++ b/services/ui-src/src/labels/2025/qualifierFormsData.tsx
@@ -5,7 +5,7 @@ const AdultData: DataDriven = {
   title: "Adult Core Set Qualifiers: Medicaid",
   questionTitle: "Adult Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of September 30, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (age 21 and older) were enrolled in each delivery system?`,
+    `As of December 31, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (age 21 and older) were enrolled in each delivery system?`,
   textTable: [
     ["Medicaid (Title XIX & XXI)", "Ages 21 to 64"],
     ["Medicaid (Title XIX & XXI)", "Age 65 and older"],
@@ -42,7 +42,7 @@ const AdultChipData: DataDriven = {
   title: "Adult Core Set Qualifiers: CHIP",
   questionTitle: "Adult Core Set Questions: CHIP",
   qualifierHeader: (year) =>
-    `As of September 30, ${year}, what percentage of your separate CHIP enrollees (age 21 and older) were enrolled in each delivery system?`,
+    `As of December 31, ${year}, what percentage of your separate CHIP enrollees (age 21 and older) were enrolled in each delivery system?`,
   textTable: [["Separate CHIP", "Ages 21 to 64"]],
   fieldValues: ["TwentyOneToSixtyFour"],
   formData: {
@@ -72,7 +72,7 @@ const AdultMedicaidData: DataDriven = {
   title: "Adult Core Set Qualifiers: Medicaid",
   questionTitle: "Adult Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of September 30, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (age 21 and older) were enrolled in each delivery system?`,
+    `As of December 31, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (age 21 and older) were enrolled in each delivery system?`,
   textTable: [
     ["Medicaid (Title XIX & XXI)", "Ages 21 to 64"],
     ["Medicaid (Title XIX & XXI)", "Age 65 and older"],
@@ -109,7 +109,7 @@ const ChildData: DataDriven = {
   title: "Child Core Set Qualifiers: Medicaid",
   questionTitle: "Child Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of September 30, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system?`,
+    `As of December 31, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system?`,
   textTable: [["Medicaid (TITLE XIX & XXI)", "Under Age 21"]],
   fieldValues: ["UnderTwentyOneMedicaid"],
   formData: {
@@ -139,7 +139,7 @@ const ChildChipData: DataDriven = {
   title: "Child Core Set Qualifiers: CHIP",
   questionTitle: "Child Core Set Questions: CHIP",
   qualifierHeader: (year) =>
-    `As of September 30, ${year}, what percentage of your separate CHIP enrollees (under age 21) were enrolled in each delivery system?`,
+    `As of December 31, ${year}, what percentage of your separate CHIP enrollees (under age 21) were enrolled in each delivery system?`,
   textTable: [["Separate CHIP", "Under Age 21"]],
   fieldValues: ["UnderTwentyOne"],
   formData: {
@@ -169,7 +169,7 @@ const ChildMedicaidData: DataDriven = {
   title: "Child Core Set Qualifiers: Medicaid",
   questionTitle: "Child Core Set Questions: Medicaid",
   qualifierHeader: (year) =>
-    `As of September 30, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system?`,
+    `As of December 31, ${year}, what percentage of your Medicaid (Title XIX & XXI) enrollees (under age 21) were enrolled in each delivery system?`,
   textTable: [["Medicaid (Title XIX & XXI)", "Under Age 21"]],
   fieldValues: ["UnderTwentyOne"],
   formData: {
@@ -199,7 +199,7 @@ const HomeData: DataDriven = {
   title: "Health Home Core Set Qualifiers",
   questionTitle: `Health Home Core Set Questions: SPA ID:`,
   qualifierHeader: (year) =>
-    `As of September 30, ${year}, what percentage of your Medicaid Health Home enrollees were enrolled in each delivery system?`,
+    `As of December 31, ${year}, what percentage of your Medicaid Health Home enrollees were enrolled in each delivery system?`,
   textTable: [["Ages 0 to 17"], ["Ages 18 to 64"], ["Age 65 and older"]],
   fieldValues: [
     "ZeroToSeventeen",

--- a/services/ui-src/src/shared/Qualifiers/Common/generalAge.tsx
+++ b/services/ui-src/src/shared/Qualifiers/Common/generalAge.tsx
@@ -1,0 +1,24 @@
+import * as QMR from "components";
+import * as Common from ".";
+import * as CUI from "@chakra-ui/react";
+
+import * as Types from "types";
+import { useCustomRegister } from "hooks/useCustomRegister";
+
+export const GeneralAge = () => {
+  const register = useCustomRegister();
+
+  return (
+    <CUI.ListItem m="4">
+      <Common.QualifierHeader
+        header="Generally, what are the ages of children covered in the state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI)?"
+        description=""
+      />
+      <QMR.TextArea
+        {...register("GeneralAge")}
+        label="Example: [State]’s Medicaid (Title XIX and XXI) program covers children under 19."
+        formLabelProps={{ fontWeight: "400" }}
+      />
+    </CUI.ListItem>
+  );
+};

--- a/services/ui-src/src/shared/Qualifiers/Common/generalAge.tsx
+++ b/services/ui-src/src/shared/Qualifiers/Common/generalAge.tsx
@@ -1,22 +1,32 @@
 import * as QMR from "components";
 import * as Common from ".";
 import * as CUI from "@chakra-ui/react";
-
-import * as Types from "types";
 import { useCustomRegister } from "hooks/useCustomRegister";
+import { DataDriven } from "shared/types/TypeQualifierForm";
+import { territoryList } from "libs";
+import { usePathParams } from "hooks/api/usePathParams";
 
-export const GeneralAge = () => {
+interface Props {
+  data: DataDriven;
+}
+
+export const GeneralAge = ({ data }: Props) => {
   const register = useCustomRegister();
+  const { state } = usePathParams();
+
+  const territory =
+    territoryList.find((territory) => territory.value === state)?.label ??
+    "[State]";
+  const description = `Example: ${territory}'s Medicaid (Title XIX and XXI) program covers children under 19.`;
 
   return (
     <CUI.ListItem m="4">
       <Common.QualifierHeader
-        header="Generally, what are the ages of children covered in the state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI)?"
-        description=""
+        header={data.ageQuestion!.label}
+        description={description}
       />
       <QMR.TextArea
         {...register("GeneralAge")}
-        label="Example: [State]’s Medicaid (Title XIX and XXI) program covers children under 19."
         formLabelProps={{ fontWeight: "400" }}
       />
     </CUI.ListItem>

--- a/services/ui-src/src/shared/Qualifiers/Common/index.tsx
+++ b/services/ui-src/src/shared/Qualifiers/Common/index.tsx
@@ -3,3 +3,4 @@ export * from "./audit";
 export * from "./externalContractor";
 export * from "./costSavingsData";
 export * from "./administrativeQuestions";
+export * from "./generalAge";

--- a/services/ui-src/src/shared/Qualifiers/index.tsx
+++ b/services/ui-src/src/shared/Qualifiers/index.tsx
@@ -57,6 +57,7 @@ export const Qualifier = ({
           {type === "HH" && <QMR.HealthHomeInfo />}
         </CUI.Box>
         <CUI.OrderedList width="100%">
+          {type !== "HH" && <Common.GeneralAge></Common.GeneralAge>}
           {type === "HH" && (
             <>
               <Common.AdministrativeQuestions />

--- a/services/ui-src/src/shared/Qualifiers/index.tsx
+++ b/services/ui-src/src/shared/Qualifiers/index.tsx
@@ -44,6 +44,7 @@ export const Qualifier = ({
         | "QualifierFormsData2022"
         | "QualifierFormsData2023"
         | "QualifierFormsData2024"
+        | "QualifierFormsData2025"
     ].Data[coreSet];
 
   return (
@@ -57,7 +58,9 @@ export const Qualifier = ({
           {type === "HH" && <QMR.HealthHomeInfo />}
         </CUI.Box>
         <CUI.OrderedList width="100%">
-          {type !== "HH" && <Common.GeneralAge></Common.GeneralAge>}
+          {type !== "HH" && data.ageQuestion && (
+            <Common.GeneralAge data={data}></Common.GeneralAge>
+          )}
           {type === "HH" && (
             <>
               <Common.AdministrativeQuestions />

--- a/services/ui-src/src/shared/types/TypeQualifierForm.tsx
+++ b/services/ui-src/src/shared/types/TypeQualifierForm.tsx
@@ -5,6 +5,7 @@ export interface DataDriven {
   qualifierHeader: (year: string) => string;
   textTable: string[][];
   fieldValues: string[];
+  ageQuestion?: { label: string };
 }
 
 interface BaseQualifierForm {

--- a/services/ui-src/src/shared/types/TypeQualifierForm.tsx
+++ b/services/ui-src/src/shared/types/TypeQualifierForm.tsx
@@ -8,6 +8,7 @@ export interface DataDriven {
 }
 
 interface BaseQualifierForm {
+  GeneralAge?: string;
   AdministrativeData: AdministrativeQuestions;
   CostSavingsData: CostSavingsData;
   PercentageEnrolledInEachDeliverySystem: DeliverySystem[];


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updated text for the qualifier sections.

Adult - Medicaid
![Screenshot 2025-06-12 at 9 23 13 AM](https://github.com/user-attachments/assets/5a841caa-f7e7-4b17-80f5-49d9367be662)

- New textbox added: _1. Generally, what are the ages of adults covered in the state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI)?_
- Updated parts of Delivery system text to: _As of December 31, 2024, approximately what percentage of adults in your state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI)_
- Change "Ages 21 to 64" to "Adults Under Age 65" in the table header beneath delivery system description.

Adult - Chip
![Screenshot 2025-06-12 at 9 23 23 AM](https://github.com/user-attachments/assets/25761b2c-cd36-40fd-b845-f3ff868746dd)

- New textbox added: _Generally, what are the ages of adults covered in the state’s separate CHIP (Title XXI) program?_
- Updated parts of Delivery system text to: _As of December 31, 2024, approximately what percentage of adults in your state’s separate CHIP (Title XXI) program were enrolled in each delivery system?_
- Remove "Ages 21 to 64" from table header beneath delivery system description.

Child - Medicaid
![Screenshot 2025-06-12 at 9 22 51 AM](https://github.com/user-attachments/assets/c6abb66c-6c64-46d0-99cd-13d77e713ec5)

- New textbox added: _Generally, what are the ages of children covered in the state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI)?_
- Updated parts of Delivery system text to: _As of December 31, 2024, approximately what percentage of children in your state’s Medicaid program (inclusive of CHIP-funded Medicaid Expansion) (Title XIX & XXI) were enrolled in each delivery system?_
- Remove "Under Age 21" from table header beneath delivery system description.

Child - Chip
![Screenshot 2025-06-12 at 9 23 02 AM](https://github.com/user-attachments/assets/b5977a75-d6cb-4115-8e39-29f4df1377af)

- New textbox added: _Generally, what are the ages of children covered in the state’s separate CHIP (Title XXI) program?_
- Updated parts of Delivery system text to: _As of December 31, 2024, approximately what percentage of children in your state’s separate CHIP (Title XXI) program were enrolled in each delivery system?_
- Remove "Under Age 21" from table header beneath delivery system description.

Health Homes
<img width="1165" alt="Screenshot 2025-06-12 at 9 30 50 AM" src="https://github.com/user-attachments/assets/39860a57-d710-4a03-8a52-8817278be12a" />

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4728

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Deploy Link: https://d2c3d0slx9fvo6.cloudfront.net/

1) Sign into QMR, any user with Health Home Core Set (i.e.[stateuserWA@test.com](mailto:stateuserDC@test.com))
2) Go to the qualifier page of Child - Medicaid core set
3) Review that the text matches what is listed in the [jira ticket](https://jiraent.cms.gov/browse/CMDCT-4728)
4) Do the same for the rest of the Core Sets

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
