### PR TITLE
[QMR] GSD-AD Update 2

### DIFF
--- a/services/ui-src/src/measures/2025/GSDAD/data.ts
+++ b/services/ui-src/src/measures/2025/GSDAD/data.ts
@@ -10,9 +10,9 @@ export const data: MeasureTemplateData = {
   hybridMeasure: true,
   performanceMeasure: {
     questionText: [
-      "Percentage of beneficiaries ages 18 to 75 with diabetes (type 1 and type 2) whose most recent glycemic status (hemoglobin A1c [HbA1c] glucose management indicator [GMI]) was at the following levels during the measurement year:",
+      "Percentage of beneficiaries ages 18 to 75 with diabetes (type 1 and type 2) whose most recent glycemic status (hemoglobin A1c [HbA1c] or glucose management indicator [GMI]) was at the following levels during the measurement year:",
     ],
-    questionListItems: ["Glycemic Status (<8.0%)", "Glycemic Status (>9.0%)"],
+    questionListItems: ["Glycemic Status <8.0%", "Glycemic Status >9.0%"],
     categories,
     qualifiers,
   },

--- a/services/ui-src/src/measures/2025/rateLabelText.ts
+++ b/services/ui-src/src/measures/2025/rateLabelText.ts
@@ -949,14 +949,13 @@ export const data = {
         ],
         "categories": [
             {
-                "label": "Glycemic Status (<8.0%)",
-                "text": "Glycemic Status (<8.0%)",
+                "label": "Glycemic Status <8.0%",
+                "text": "Glycemic Status <8.0%",
                 "id":"F9V8xD",
-                "excludeFromOMS": true
             },
             {
-                "label": "Glycemic Status (>9.0%)",
-                "text": "Glycemic Status (>9.0%)",
+                "label": "Glycemic Status >9.0%",
+                "text": "Glycemic Status >9.0%",
                 "id":"MELFVb"
             }
         ]


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR covers tiny content updates for measure GSD-AD for year 2025.
- or added between (hemoglobin A1c [HbA1c] and glucose management indicator [GMI]
- parentheses removed from age ranges
- `Glycemic Status <8.0%` now included in OMS data

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4734

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: 

1. Login with state user.
2. Select GSD-AD under adult core set measures
3. Go to **Measure Specification Question** and select "Yes...."
4. Scroll down to confirm content updates under **Performance Measure** Section
5. Enter values for all glycemic indexes and date ranges in order to confirm OMS data shows
6. Scroll down to **Measure Stratification** section and select one of first two radio options
7. Confirm OMS field values show up for both <8.0% & >9.0% and age ranges "Ages 18 to 64" & "Ages 65 to 75"

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary