### PR TITLE
2025 - Remove Text on ECDS

### DIFF
--- a/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
+++ b/services/ui-src/src/labels/2025/commonQuestionsLabel.tsx
@@ -14,8 +14,7 @@ export const commonQuestionsLabel = {
     ehrSrc: "Optional - Describe the data source(s) used:",
     describeDataSrc:
       "Describe the data source (<em>text in this field is included in publicly-reported state-specific comments</em>):",
-    describeOptionalDataSrc:
-      "Optional - Describe the data source(s) used: (<em>text in this field is included in publicly-reported state-specific comments</em>):",
+    describeOptionalDataSrc: "Optional - Describe the data source(s) used:",
     srcExplanation: "Data Source Explanation",
     srcExplanationText:
       "For each data source selected above, describe which reporting entities used each data source (e.g., health plans, FFS). If the data source differed across health plans or delivery systems, identify the number of plans or delivery systems that used each data source (<em>text in this field is included in publicly-reported state-specific comments</em>).",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Remove the text from the ECDS text box that reads, “(text in this field is included in publicly-reported state-specific comments)”? It should just say, “Optional – Describe the data source(s) used:” 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4833

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d3p4iabyszeuqy.cloudfront.net/

1. Go to any ECDS measure (ADD-CH, APM-CH, CIS-CH, IMA-CH, PDS-CH, PRS-CH, CCS-AD, COL-AD, BCS-AD, AIS-AD, PRS-AD, PDS-AD, COL-HH)
2. Under Data source, click ECDS 
3. Check that the hint text for the optional text box no longer includes (text in this field is included in publicly-reported state-specific comments)”

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
