### PR TITLE
CMDCT-4863 - More stratification text changes

### DIFF
--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/Stratification/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/Stratification/index.tsx
@@ -162,12 +162,12 @@ export const Stratification = ({
         }}
       >
         <CUI.Text>
-          Do not select categories and sub-categories for which you will not be
-          reporting any data.
+          Do not select categories and subcategories for which your state does
+          not collect data.
         </CUI.Text>
         <CUI.Text>
-          For each category and sub-category, enter a number for the numerator
-          and denominator. The rate will auto-calculated but can be revised if
+          For each category and subcategory, enter a number for the numerator
+          and denominator. The rate will auto-calculate but can be revised if
           needed.
         </CUI.Text>
         <CUI.UnorderedList

--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
@@ -57,12 +57,9 @@ export const GetLinks = (type: string) => {
 
 export const StratificationAdditionalNotes = ({ register }: Props) => {
   return (
-    <QMR.CoreQuestionWrapper
-      testid="additional-notes"
-      label="Additional notes/comments (optional)"
-    >
+    <QMR.CoreQuestionWrapper testid="additional-notes" label="">
       <QMR.TextArea
-        label="If your state would like to provide additional context about the reported stratified data, including stratification categories, please add notes below."
+        label="If your state would like to provide additional context about the reported stratified data, including stratification categories, please add notes below (optional)."
         {...register(`OptionalMeasureStratification.${DC.ADDITIONAL_CONTEXT}`)}
       />
     </QMR.CoreQuestionWrapper>

--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/omsNodeBuilder.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/omsNodeBuilder.tsx
@@ -43,7 +43,7 @@ const omsLabels = (omsNode: OmsNode) => {
       } categories.`,
       NoIndependentData: `No, we are reporting disaggregated data for ${
         omsNode?.aggregateTitle || omsNode?.label
-      } sub-categories`,
+      } subcategories`,
     };
   }
   return {

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/omsNodeBuilder.tsx
@@ -42,7 +42,7 @@ const omsLabels = (omsNode: OmsNode) => {
       } categories.`,
       NoIndependentData: `No, we are reporting disaggregated data for ${
         omsNode?.aggregateTitle || omsNode?.label
-      } sub-categories`,
+      } subcategories`,
     };
   }
   return {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- More stratification text changes


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4863

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login: https://d2tkymnr9ew7bi.cloudfront.net/
- Go to measure AAB-CH
- Under Measurement Specification select the first radio "Yes, ..."
- Scroll down to Performance Measure and type something into the Text Area underneath, and fill out the numerator and denominator further below
- Under **Measure Stratification** select radio button 1 or 2
- Verify the text changes match the story


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
