### PR TITLE
Stratification - Validation Warning Issues

### DIFF
--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/NDR/ndrFields.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/NDR/ndrFields.tsx
@@ -153,10 +153,10 @@ const buildNDRComponent = (
         Please review the auto-calculated rate and revise if needed.
       </CUI.Heading>
       {sets.map(
-        (_label, idx) =>
+        (set, idx) =>
           rateArrays[idx].length > 0 && (
             <CUI.Box mt="1rem">
-              <CUI.Heading fontSize="16px">{_label.label}</CUI.Heading>
+              <CUI.Heading fontSize="16px">{set.label}</CUI.Heading>
               {rateArrays[idx]}
             </CUI.Box>
           )

--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/NDR/ndrFields.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/NDR/ndrFields.tsx
@@ -152,12 +152,15 @@ const buildNDRComponent = (
       >
         Please review the auto-calculated rate and revise if needed.
       </CUI.Heading>
-      {sets.map((_label, idx) => (
-        <CUI.Box mt="1rem">
-          <CUI.Heading fontSize="16px">{_label.label}</CUI.Heading>
-          {rateArrays[idx]}
-        </CUI.Box>
-      ))}
+      {sets.map(
+        (_label, idx) =>
+          rateArrays[idx].length > 0 && (
+            <CUI.Box mt="1rem">
+              <CUI.Heading fontSize="16px">{_label.label}</CUI.Heading>
+              {rateArrays[idx]}
+            </CUI.Box>
+          )
+      )}
     </CUI.Box>
   );
 };

--- a/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
@@ -447,5 +447,15 @@ export const omsValidations = ({
     }
   }
 
-  return errorArray;
+  //temporary fix for why the same errors are being generated multiple times
+  const uniqueErrors = errorArray.filter(
+    (error, i, a) =>
+      a.findIndex(
+        (errorNext) =>
+          error.errorLocation === errorNext.errorLocation &&
+          error.errorMessage === errorNext.errorMessage
+      ) == i
+  );
+
+  return uniqueErrors;
 };

--- a/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
@@ -208,14 +208,16 @@ const getAccordionClassificationRates = (
           );
 
           for (const rates of values) {
-            const filledRates = (
-              Object.values(rates).flat() as RateFields[]
-            ).filter(
-              (rate) =>
-                rate.numerator != undefined || rate.denominator != undefined
-            );
-            if (filledRates.length > 0)
+            if (
+              (Object.values(rates).flat() as RateFields[]).filter(
+                (rate) =>
+                  (rate.numerator != undefined && rate.numerator != "") ||
+                  (rate.denominator != undefined && rate.denominator != "")
+              ).length > 0
+            ) {
               omsRates.push({ key: midLabel, ...midLevel });
+              break;
+            }
           }
         }
       }
@@ -447,15 +449,5 @@ export const omsValidations = ({
     }
   }
 
-  //temporary fix for why the same errors are being generated multiple times
-  const uniqueErrors = errorArray.filter(
-    (error, i, a) =>
-      a.findIndex(
-        (errorNext) =>
-          error.errorLocation === errorNext.errorLocation &&
-          error.errorMessage === errorNext.errorMessage
-      ) == i
-  );
-
-  return uniqueErrors;
+  return errorArray;
 };

--- a/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
@@ -203,21 +203,18 @@ const getAccordionClassificationRates = (
          * we have to look through the actual rate data to see if they entered any value to trigger a partial validation
          */
         if (midLevel.rateData?.rates) {
-          const values = Object.values(
-            midLevel.rateData?.rates as OMS.OmsRateFields
-          );
+          const values = Object.values(midLevel.rateData.rates);
 
-          for (const rates of values) {
-            if (
-              (Object.values(rates).flat() as RateFields[]).filter(
-                (rate) =>
-                  (rate.numerator != undefined && rate.numerator != "") ||
-                  (rate.denominator != undefined && rate.denominator != "")
-              ).length > 0
-            ) {
-              omsRates.push({ key: midLabel, ...midLevel });
-              break;
-            }
+          const isFilled = (str: string | undefined) =>
+            str !== undefined && str !== "";
+
+          const hasNumOrDenom = (rates: any) =>
+            (Object.values(rates).flat() as RateFields[]).some(
+              (rate) => isFilled(rate.numerator) || isFilled(rate.denominator)
+            );
+
+          if (values.some(hasNumOrDenom)) {
+            omsRates.push({ key: midLabel, ...midLevel });
           }
         }
       }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR tackles a couple more validation issues.
1) **Validation labels are showing object id's as part of the labels and also not showing the correct labels when switching between 1997 race categories and 2024 race categories.** 
This was caused by the `locationDictionary` using 2024 race categories data as the look up no matter which version we were on.

2) **Some of the stratification subcategories create one validation per rate, whereas other subcategories create one validation per subcategory.**
This was caused by pushing the same rates data multiple times when building the oms rates to run the error validation against. We only needed to see if one in the category set was filled and add that. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4875
CMDCT-4876

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Deploy Link: https://d2zewt27y5qhho.cloudfront.net/

1) Sign into QMR, any state user (i.e. [stateuser1@test.com](mailto:stateuser1@test.com))
2) In reporting year 2025, select any measure that has a **Measure Stratification** section (i.e. WCC-CH)
3) In the **Measure Specification** section, select the first radio button, this will enable the Performance Measure section
4) Scroll down to the **Performance Measure** section and fill out the N/D/R sets. This will enable the **Measure Stratification** section
5) Go to the  **Measure Stratification** section and in the radio button section select 2024
6) Fill out an N/D/R set with different denominators. 
<img width="886" height="633" alt="Screenshot 2025-07-24 at 3 57 08 PM" src="https://github.com/user-attachments/assets/ff13eeb5-9797-4cfe-bee2-17a65225f3ce" />

7) Scroll down and validate. You should only see 1 of each error with no duplicates
<img width="1271" height="204" alt="Screenshot 2025-07-24 at 3 57 18 PM" src="https://github.com/user-attachments/assets/5164a93f-9e99-4a10-b505-a3d77e6a5cb2" />

8) Switch to 1997 race category and fill out an N/D/R set with different denominators. Validate it.
- The validation should have a different text label.
<img width="1272" height="171" alt="Screenshot 2025-07-24 at 3 58 35 PM" src="https://github.com/user-attachments/assets/5d662f07-e9ef-4fcd-b3a2-3219c94cdfcb" />


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
