### PR TITLE
[QMR] 2025 - Adult Core Set Qualifier Intro Bug

### DIFF
--- a/services/ui-src/src/labels/2025/qualifierFormsData.tsx
+++ b/services/ui-src/src/labels/2025/qualifierFormsData.tsx
@@ -5,7 +5,7 @@ const AdultData: DataDriven = {
   title: "Adult Core Set Qualifiers: Medicaid",
   questionTitle: "Adult Core Set Questions: Medicaid",
   questionIntro:
-    "Please report data on Title XIX-funded Medicaid (Medicaid) and Title XXI-funded Medicaid expansion CHIP (Medicaid expansion CHIP) (if applicable for your state) here. If your state has separate CHIP, please report only Title XIX- funded Medicaid and Medicaid expansion CHIP children in this section. Report Separate CHIP on the Child Core Set – Separate CHIP page.",
+    "Please report data on Title XIX-funded Medicaid (Medicaid) and Title XXI-funded Medicaid expansion CHIP (Medicaid expansion CHIP) (if applicable for your state) here. If your state wishes to separately report the Adult Core Set for separate CHIP (separate from Medicaid and Medicaid expansion CHIP), please use Adult Core Set Qualifiers: Separate CHIP page.",
   qualifierHeader: (year) =>
     `As of December 31, ${year}, approximately what percentage of adults in your state’s Medicaid program (inclusive of Medicaid expansion CHIP, if applicable for the state) were enrolled in each delivery system?`,
   textTable: [["Adults Under Age 65"], ["Adults Age 65+"]],

--- a/services/ui-src/src/labels/2025/qualifierFormsData.tsx
+++ b/services/ui-src/src/labels/2025/qualifierFormsData.tsx
@@ -81,7 +81,7 @@ const AdultMedicaidData: DataDriven = {
   title: "Adult Core Set Qualifiers: Medicaid",
   questionTitle: "Adult Core Set Questions: Medicaid",
   questionIntro:
-    "Please report data on Title XIX-funded Medicaid (Medicaid) and Title XXI-funded Medicaid expansion CHIP (Medicaid expansion CHIP) (if applicable for your state) here. If your state has separate CHIP, please report only Title XIX- funded Medicaid and Medicaid expansion CHIP children in this section. Report Separate CHIP on the Child Core Set – Separate CHIP page.",
+    "Please report data on Title XIX-funded Medicaid (Medicaid) and Title XXI-funded Medicaid expansion CHIP (Medicaid expansion CHIP) (if applicable for your state) here. If your state wishes to separately report the Adult Core Set for separate CHIP (separate from Medicaid and Medicaid expansion CHIP), please use Adult Core Set Qualifiers: Separate CHIP page.",
   qualifierHeader: (year) =>
     `As of December 31, ${year}, approximately what percentage of adults in your state’s Medicaid program (inclusive of Medicaid expansion CHIP, if applicable for the state) were enrolled in each delivery system?`,
   textTable: [["Adults Under Age 65"], ["Adults Age 65+"]],


### PR DESCRIPTION
### Description
This PR covers a tiny content update.
For Adult Medicaid Qualifiers Introduction, it previously had the same language as Child Core Set. This has been updated to reflect the correct Core Set language.

### Related ticket(s)
CMDCT-5048

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
**Deploy Link:** https://ds70ocw7wyymr.cloudfront.net/
1. Check with both users: stateuser1@test.com & stateuser3@test.com
2. Select `Adult Core Set Measures: Medicaid (Title XIX & XXI)` for 2025
3. Select `Adult Core Set Questions: Medicaid (inclusive of both Title XIX-funded Medicaid and Title XXI-funded Medicaid Expansion CHIP)`
4. Confirm introduction paragraph matches Jira ticket

   | Before |
   | ------ |
   | <img width="600" height="300" alt="Before-Adult-Medicaid_Qualifiers-Intro-Paragraph" src="https://github.com/user-attachments/assets/944cac66-7c49-466c-adc8-483540963402" /> |

   | After |
   | ------ |
   | <img width="600" height="300" alt="After-Adult-Medicaid_Qualifiers-Intro-Paragraph" src="https://github.com/user-attachments/assets/2aecc2f0-06c9-40ab-bad3-b6078d9a413c" /> |

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary
