### PR TITLE
[CMDCT-5050] Measure Stratification Required Banner Updates

### DIFF
--- a/services/app-api/handlers/dynamoUtils/measureList.ts
+++ b/services/app-api/handlers/dynamoUtils/measureList.ts
@@ -1,3 +1,5 @@
+import { CoreSetAbbr } from "../../types";
+
 export enum MeasureType {
   MANDATORY = "Mandatory",
   PROVISIONAL = "Provisional",
@@ -13,7 +15,7 @@ export interface MeasureMetaData {
   autocompleteOnCreation?: boolean;
   placeholder?: boolean;
   measureType?: MeasureType;
-  stratificationRequired?: boolean;
+  stratificationRequired?: CoreSetAbbr[];
 }
 
 export const measures: Measure = {
@@ -1461,13 +1463,13 @@ export const measures: Measure = {
       type: "A",
       measure: "FUA-AD",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [CoreSetAbbr.ACSC],
     },
     {
       type: "A",
       measure: "FUH-AD",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [CoreSetAbbr.ACSC],
     },
     {
       type: "A",
@@ -1491,7 +1493,7 @@ export const measures: Measure = {
       type: "A",
       measure: "IET-AD",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [CoreSetAbbr.ACSC],
     },
     {
       type: "A",
@@ -1633,7 +1635,11 @@ export const measures: Measure = {
       type: "C",
       measure: "FUH-CH",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [
+        CoreSetAbbr.CCS,
+        CoreSetAbbr.CCSC,
+        CoreSetAbbr.CCSM,
+      ],
     },
     {
       type: "C",
@@ -1666,7 +1672,11 @@ export const measures: Measure = {
       type: "C",
       measure: "OEV-CH",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [
+        CoreSetAbbr.CCS,
+        CoreSetAbbr.CCSC,
+        CoreSetAbbr.CCSM,
+      ],
     },
     {
       type: "C",
@@ -1682,7 +1692,11 @@ export const measures: Measure = {
       type: "C",
       measure: "PPC2-CH",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [
+        CoreSetAbbr.CCS,
+        CoreSetAbbr.CCSC,
+        CoreSetAbbr.CCSM,
+      ],
     },
     {
       type: "C",
@@ -1703,7 +1717,11 @@ export const measures: Measure = {
       type: "C",
       measure: "W30-CH",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [
+        CoreSetAbbr.CCS,
+        CoreSetAbbr.CCSC,
+        CoreSetAbbr.CCSM,
+      ],
     },
     {
       type: "C",
@@ -1714,7 +1732,11 @@ export const measures: Measure = {
       type: "C",
       measure: "WCV-CH",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [
+        CoreSetAbbr.CCS,
+        CoreSetAbbr.CCSC,
+        CoreSetAbbr.CCSM,
+      ],
     },
     {
       type: "H",
@@ -1725,7 +1747,7 @@ export const measures: Measure = {
       type: "H",
       measure: "CBP-HH",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [CoreSetAbbr.HHCS],
     },
     {
       type: "H",
@@ -1736,7 +1758,7 @@ export const measures: Measure = {
       type: "H",
       measure: "COL-HH",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [CoreSetAbbr.HHCS],
     },
     {
       type: "H",
@@ -1747,7 +1769,7 @@ export const measures: Measure = {
       type: "H",
       measure: "FUH-HH",
       measureType: MeasureType.MANDATORY,
-      stratificationRequired: true,
+      stratificationRequired: [CoreSetAbbr.HHCS],
     },
     {
       type: "H",

--- a/services/app-api/handlers/dynamoUtils/measureList.ts
+++ b/services/app-api/handlers/dynamoUtils/measureList.ts
@@ -1,9 +1,4 @@
-import { CoreSetAbbr } from "../../types";
-
-export enum MeasureType {
-  MANDATORY = "Mandatory",
-  PROVISIONAL = "Provisional",
-}
+import { CoreSetAbbr, MeasureType } from "../../types";
 
 interface Measure {
   [year: number]: MeasureMetaData[];

--- a/services/app-api/handlers/measures/get.ts
+++ b/services/app-api/handlers/measures/get.ts
@@ -48,7 +48,7 @@ export const listMeasures = handler(async (event, context) => {
 
     v.autoCompleted = !!measure?.autocompleteOnCreation;
     v.measureType = measure?.measureType;
-    v.stratificationRequired = !!measure?.stratificationRequired;
+    v.stratificationRequired = measure?.stratificationRequired;
   }
 
   return {
@@ -99,7 +99,7 @@ export const getMeasure = handler(async (event, context) => {
       queryValue.autoCompleted = !!measureMetadata.autocompleteOnCreation;
       queryValue.measureType = measureMetadata.measureType;
       queryValue.stratificationRequired =
-        !!measureMetadata.stratificationRequired;
+        measureMetadata.stratificationRequired;
     }
   }
 

--- a/services/app-api/handlers/rate/rateNDRCalculations.ts
+++ b/services/app-api/handlers/rate/rateNDRCalculations.ts
@@ -1,10 +1,10 @@
 import {
   CombinedRatesPayload,
-  isDefined,
   isRateNDRShape,
   Measure,
   WeightedRateShape,
 } from "../../types";
+import { isDefined } from "../../utils/filters";
 import {
   addSafely,
   divideSafely,

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -63,7 +63,7 @@ export interface Measure {
    */
   autoCompleted?: boolean;
   measureType?: MeasureType;
-  stratificationRequired?: boolean;
+  stratificationRequired?: CoreSetAbbr[];
   data?: {
     /**
      * An array of strings from the `DataSource` enum.

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -1,5 +1,4 @@
-import { measures, MeasureType } from "./handlers/dynamoUtils/measureList";
-import { states, bannerIds } from "./utils/constants/constants";
+import { states } from "./utils/constants/constants";
 export interface CoreSet {
   compoundKey: string;
   coreSet: CoreSetAbbr;
@@ -13,6 +12,11 @@ export interface CoreSet {
   state: string;
   submitted: boolean;
   year: number;
+}
+
+export enum MeasureType {
+  MANDATORY = "Mandatory",
+  PROVISIONAL = "Provisional",
 }
 
 export type StandardRateShape = RateNDRShape | RateValueShape;
@@ -363,25 +367,5 @@ export type WeightedRateShape = {
  * const c = a.filter(isDefined);
  * // c's type is just string[], hurray!
  */
-export const isDefined = <T>(x: T | undefined): x is T => x !== undefined;
 
 export type State = typeof states[number];
-
-export const isState = (state: unknown): state is State => {
-  return states.includes(state as State);
-};
-
-export const isValidYear = (year: string) => {
-  const reportingYears = Object.keys(measures);
-  return reportingYears.includes(year);
-};
-
-export const isMeasure = (year: string, measure: string | undefined) => {
-  return measures[parseInt(year)]?.some(
-    (measureObject) => measureObject.measure === measure
-  );
-};
-
-export const isBannerId = (bannerId: string) => {
-  return bannerIds.includes(bannerId);
-};

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -353,19 +353,4 @@ export type WeightedRateShape = {
   weightedRate?: number;
 };
 
-/**
- * This utility is most useful when filtering undefined values from an array,
- * _while convincing Typescript you've done so_.
- *
- * @example
- * const a = words.map(word => getThirdChar(word));
- * // a's type is (string | undefined)[]
- *
- * const b = a.filter(char => char !== undefined);
- * // b's type is still (string | undefined)[], boo!
- *
- * const c = a.filter(isDefined);
- * // c's type is just string[], hurray!
- */
-
 export type State = typeof states[number];

--- a/services/app-api/utils/filters.ts
+++ b/services/app-api/utils/filters.ts
@@ -2,6 +2,20 @@ import { measures } from "../handlers/dynamoUtils/measureList";
 import { State } from "../types";
 import { states, bannerIds } from "./constants/constants";
 
+/**
+ * This utility is most useful when filtering undefined values from an array,
+ * _while convincing Typescript you've done so_.
+ *
+ * @example
+ * const a = words.map(word => getThirdChar(word));
+ * // a's type is (string | undefined)[]
+ *
+ * const b = a.filter(char => char !== undefined);
+ * // b's type is still (string | undefined)[], boo!
+ *
+ * const c = a.filter(isDefined);
+ * // c's type is just string[], hurray!
+ */
 export const isDefined = <T>(x: T | undefined): x is T => x !== undefined;
 
 export const isState = (state: unknown): state is State => {

--- a/services/app-api/utils/filters.ts
+++ b/services/app-api/utils/filters.ts
@@ -1,0 +1,24 @@
+import { measures } from "../handlers/dynamoUtils/measureList";
+import { State } from "../types";
+import { states, bannerIds } from "./constants/constants";
+
+export const isDefined = <T>(x: T | undefined): x is T => x !== undefined;
+
+export const isState = (state: unknown): state is State => {
+  return states.includes(state as State);
+};
+
+export const isValidYear = (year: string) => {
+  const reportingYears = Object.keys(measures);
+  return reportingYears.includes(year);
+};
+
+export const isMeasure = (year: string, measure: string | undefined) => {
+  return measures[parseInt(year)]?.some(
+    (measureObject) => measureObject.measure === measure
+  );
+};
+
+export const isBannerId = (bannerId: string) => {
+  return bannerIds.includes(bannerId);
+};

--- a/services/app-api/utils/parseParameters.ts
+++ b/services/app-api/utils/parseParameters.ts
@@ -1,12 +1,6 @@
 import { logger } from "../libs/debug-lib";
-import {
-  APIGatewayProxyEvent,
-  isBannerId,
-  isCoreSetAbbr,
-  isMeasure,
-  isState,
-  isValidYear,
-} from "../types";
+import { APIGatewayProxyEvent, isCoreSetAbbr } from "../types";
+import { isBannerId, isState, isValidYear, isMeasure } from "./filters";
 
 export const parseBannerParameters = (event: APIGatewayProxyEvent) => {
   const { bannerId } = event.pathParameters ?? {};

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -482,7 +482,7 @@ export const MeasureWrapper = ({
                     <CUI.Box mb="1rem">
                       <Alert heading="Reminder: Measure Stratification Required">
                         <CUI.Text>
-                          {`For ${year}, Core Sets reporting, states are expected to report stratified data for this measure.`}
+                          {`For ${year} Core Sets reporting, states are expected to report stratified data for this measure.`}
                         </CUI.Text>
                       </Alert>
                     </CUI.Box>

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -478,7 +478,7 @@ export const MeasureWrapper = ({
                 <CUI.Container maxW="7xl" as="section" px="0">
                   <QMR.SessionTimeout handleSave={handleSave} />
                   <LastModifiedBy user={measureData?.lastAlteredBy} />
-                  {stratificationRequired && (
+                  {stratificationRequired?.includes(coreSet) && (
                     <CUI.Box mb="1rem">
                       <Alert heading="Reminder: Measure Stratification Required">
                         <CUI.Text>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR expands on when to display the Measure Stratification Required Banner. Before it was a boolean, but it needed to be expanded to filter whether to show it on CHIP, Medicaid or both. So now the type is CoreSetAbbr.

There's also a text update to the banner to remove the comma so the text should read:
_For 2025 Core Sets reporting, states are expected to report stratified data for this measure._

**Note:**
- I create a `filters.ts` file to move the functions stored in _types.ts_. The function `isValidYear` was calling measures from the _measureList.ts_ file which caused a circular loading issue as measureList.ts needed access to the _types.ts_ file.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5050

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Deploy Link: https://d3gzciezg4ao4f.cloudfront.net/

1) Sign into QMR, any state user.
2) Check that measures: FUA-AD, FUH-AD, IET-AD, only has a warning banner in the Separate CHIP measure and not in the Medicaid measure.
3)  Check that the warning banner reads: _For 2025 Core Sets reporting, states are expected to report stratified data for this measure._

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
