### PR TITLE
Allow numerator > denominator in Combined Rates for certain measures

### DIFF
--- a/services/app-api/handlers/rate/rateNDRCalculations.test.ts
+++ b/services/app-api/handlers/rate/rateNDRCalculations.test.ts
@@ -366,4 +366,273 @@ describe("NDR calculations for Combined Rates", () => {
       },
     ]);
   });
+
+  it("Should refuse to calculate if numerator > denominator (standard formula)", () => {
+    const dataSources = {
+      Medicaid: {},
+      CHIP: {},
+    } as CombinedRatesPayload["DataSources"];
+
+    const medicaidMeasure = {
+      data: {
+        PerformanceMeasure: {
+          rates: {
+            cat0: [
+              {
+                uid: "cat0.qual0",
+                label: "mock rate",
+                numerator: "12",
+                denominator: "10",
+                rate: "20",
+              },
+            ],
+          },
+        },
+      } as Measure["data"],
+    } as Measure;
+
+    const chipMeasure = {
+      data: {
+        PerformanceMeasure: {
+          rates: {
+            cat0: [
+              {
+                uid: "cat0.qual0",
+                label: "mock rate",
+                numerator: "23",
+                denominator: "5",
+                rate: "60",
+              },
+            ],
+          },
+        },
+      } as Measure["data"],
+    } as Measure;
+
+    const result = combineRates(
+      "ZZZ-AD",
+      dataSources,
+      medicaidMeasure,
+      chipMeasure
+    );
+
+    expect(result).toEqual([
+      {
+        uid: "cat0.qual0",
+        label: "mock rate",
+        CHIP: { denominator: 5, numerator: 23, rate: 60 },
+        Medicaid: { denominator: 10, numerator: 12, rate: 20 },
+        Combined: {},
+      },
+    ]);
+  });
+
+  it("Should refuse to calculate if numerator > denominator (weighted formula)", () => {
+    const dataSources = {
+      Medicaid: { requiresWeightedCalc: true },
+      CHIP: { requiresWeightedCalc: true },
+    } as CombinedRatesPayload["DataSources"];
+
+    const medicaidMeasure = {
+      data: {
+        HybridMeasurePopulationIncluded: "5",
+        PerformanceMeasure: {
+          rates: {
+            cat0: [
+              {
+                uid: "cat0.qual0",
+                label: "mock rate",
+                numerator: "12",
+                denominator: "10",
+                rate: "120",
+              },
+            ],
+          },
+        },
+      } as Measure["data"],
+    } as Measure;
+
+    const chipMeasure = {
+      data: {
+        HybridMeasurePopulationIncluded: "2",
+        PerformanceMeasure: {
+          rates: {
+            cat0: [
+              {
+                uid: "cat0.qual0",
+                label: "mock rate",
+                numerator: "23",
+                denominator: "5",
+                rate: "460",
+              },
+            ],
+          },
+        },
+      } as Measure["data"],
+    } as Measure;
+
+    const result = combineRates(
+      "ZZZ-AD",
+      dataSources,
+      medicaidMeasure,
+      chipMeasure
+    );
+
+    expect(result).toEqual([
+      {
+        uid: "cat0.qual0",
+        label: "mock rate",
+        CHIP: {
+          denominator: 5,
+          numerator: 23,
+          rate: 460,
+          population: 2,
+        },
+        Medicaid: {
+          denominator: 10,
+          numerator: 12,
+          rate: 120,
+          population: 5,
+        },
+        Combined: {},
+      },
+    ]);
+  });
+
+  it("Should calculate even if numerator > denominator, for certain measures (standard formula)", () => {
+    const dataSources = {
+      Medicaid: {},
+      CHIP: {},
+    } as CombinedRatesPayload["DataSources"];
+
+    const medicaidMeasure = {
+      data: {
+        PerformanceMeasure: {
+          rates: {
+            cat0: [
+              {
+                uid: "cat0.qual0",
+                label: "mock rate",
+                numerator: "12",
+                denominator: "10",
+                rate: "20",
+              },
+            ],
+          },
+        },
+      } as Measure["data"],
+    } as Measure;
+
+    const chipMeasure = {
+      data: {
+        PerformanceMeasure: {
+          rates: {
+            cat0: [
+              {
+                uid: "cat0.qual0",
+                label: "mock rate",
+                numerator: "23",
+                denominator: "5",
+                rate: "60",
+              },
+            ],
+          },
+        },
+      } as Measure["data"],
+    } as Measure;
+
+    const result = combineRates(
+      "PQI01-AD",
+      dataSources,
+      medicaidMeasure,
+      chipMeasure
+    );
+
+    expect(result).toEqual([
+      {
+        uid: "cat0.qual0",
+        label: "mock rate",
+        CHIP: { denominator: 5, numerator: 23, rate: 60 },
+        Medicaid: { denominator: 10, numerator: 12, rate: 20 },
+        Combined: { denominator: 15, numerator: 35, rate: 233333.3 },
+      },
+    ]);
+  });
+
+  it("Should calculate even if numerator > denominator, for certain measures (weighted formula)", () => {
+    const dataSources = {
+      Medicaid: { requiresWeightedCalc: true },
+      CHIP: { requiresWeightedCalc: true },
+    } as CombinedRatesPayload["DataSources"];
+
+    const medicaidMeasure = {
+      data: {
+        HybridMeasurePopulationIncluded: "5",
+        PerformanceMeasure: {
+          rates: {
+            cat0: [
+              {
+                uid: "cat0.qual0",
+                label: "mock rate",
+                numerator: "12",
+                denominator: "10",
+                rate: "120",
+              },
+            ],
+          },
+        },
+      } as Measure["data"],
+    } as Measure;
+
+    const chipMeasure = {
+      data: {
+        HybridMeasurePopulationIncluded: "2",
+        PerformanceMeasure: {
+          rates: {
+            cat0: [
+              {
+                uid: "cat0.qual0",
+                label: "mock rate",
+                numerator: "23",
+                denominator: "5",
+                rate: "460",
+              },
+            ],
+          },
+        },
+      } as Measure["data"],
+    } as Measure;
+
+    const result = combineRates(
+      "EDV-AD",
+      dataSources,
+      medicaidMeasure,
+      chipMeasure
+    );
+
+    expect(result).toEqual([
+      {
+        uid: "cat0.qual0",
+        label: "mock rate",
+        CHIP: {
+          denominator: 5,
+          numerator: 23,
+          rate: 460,
+          population: 2,
+          weightedRate: 131.4,
+        },
+        Medicaid: {
+          denominator: 10,
+          numerator: 12,
+          rate: 120,
+          population: 5,
+          weightedRate: 85.7,
+        },
+        Combined: {
+          population: 7,
+          weightedRate: 217.1,
+        },
+      },
+    ]);
+  });
 });

--- a/services/app-api/handlers/rate/rateNDRCalculations.ts
+++ b/services/app-api/handlers/rate/rateNDRCalculations.ts
@@ -92,26 +92,25 @@ export const combineRates = (
         population: chipPopulation,
       };
 
-      let Combined;
-      if (
-        (DataSources.Medicaid.isUnusableForCalc ||
-          mNumerator! > mDenominator!) &&
-        (DataSources.CHIP.isUnusableForCalc || cNumerator! > cDenominator!)
-      ) {
-        Combined = {};
-      } else if (
+      const medicaidUnusable =
         DataSources.Medicaid.isUnusableForCalc ||
-        mNumerator! > mDenominator!
-      ) {
+        (mNumerator! > mDenominator! &&
+          !PER_MONTH_MEASURES.includes(measureAbbr));
+      const chipUnusable =
+        DataSources.CHIP.isUnusableForCalc ||
+        (cNumerator! > cDenominator! &&
+          !PER_MONTH_MEASURES.includes(measureAbbr));
+
+      let Combined;
+      if (medicaidUnusable && chipUnusable) {
+        Combined = {};
+      } else if (medicaidUnusable) {
         CHIP.weightedRate = cRate;
         Combined = {
           population: chipPopulation,
           weightedRate: cRate,
         };
-      } else if (
-        DataSources.CHIP.isUnusableForCalc ||
-        cNumerator! > cDenominator!
-      ) {
+      } else if (chipUnusable) {
         Medicaid.weightedRate = mRate;
         Combined = {
           population: medicaidPopulation,
@@ -166,22 +165,21 @@ export const combineRates = (
         rate: cRate,
       };
 
-      let Combined;
-      if (
-        (DataSources.Medicaid.isUnusableForCalc ||
-          mNumerator! > mDenominator!) &&
-        (DataSources.CHIP.isUnusableForCalc || cNumerator! > cDenominator!)
-      ) {
-        Combined = {};
-      } else if (
+      const medicaidUnusable =
         DataSources.Medicaid.isUnusableForCalc ||
-        mNumerator! > mDenominator!
-      ) {
-        Combined = { rate: cRate };
-      } else if (
+        (mNumerator! > mDenominator! &&
+          !PER_MONTH_MEASURES.includes(measureAbbr));
+      const chipUnusable =
         DataSources.CHIP.isUnusableForCalc ||
-        cNumerator! > cDenominator!
-      ) {
+        (cNumerator! > cDenominator! &&
+          !PER_MONTH_MEASURES.includes(measureAbbr));
+
+      let Combined;
+      if (medicaidUnusable && chipUnusable) {
+        Combined = {};
+      } else if (medicaidUnusable) {
+        Combined = { rate: cRate };
+      } else if (chipUnusable) {
         Combined = { rate: mRate };
       } else {
         const combinedNumerator = addSafely(mNumerator, cNumerator);
@@ -243,7 +241,6 @@ const transformQuotient = (
   if (quotient === undefined) return undefined;
   switch (measureAbbr) {
     case "AAB-AD":
-      return (1 - quotient) * 100;
     case "AAB-CH":
       return (1 - quotient) * 100;
     case "AMB-CH":
@@ -258,3 +255,18 @@ const transformQuotient = (
       return quotient * 100;
   }
 };
+
+/**
+ * For most measures, the numerator cannot exceed the denominator.
+ * If it does, we will not compute a combined rate.
+ * These measures are special; their numerators *can* exceed their denominators.
+ *
+ * Specifically, these measures track data "per 100,000 beneficiary months".
+ */
+const PER_MONTH_MEASURES = [
+  "PQI01-AD",
+  "PQI05-AD",
+  "PQI08-AD",
+  "PQI15-AD",
+  "EDV-AD",
+];


### PR DESCRIPTION
### Description
Every measure in QMR has a fantastic, comprehensive amount of validation on the frontend. However, even data that has not passed validation can still be used for the Combined Rates page. When calculating combined rates, we just use whatever data was saved, without performing any validation - with one exception. We _do_ check to make sure that the numerator is not greater than the denominator. This is a simple check that applies to all measures, so it was not a huge cost to re-implement it within the combined rates code.

Well now, even that exception has an exception. There are a handful of measures to which that check does not apply. For EDV and PQI measures, it is possible and valid for the numerator to exceed the denominator. Most of our measures are about subsets (like, "Of the eligible population, how many received the service?"). But EDV and PQI aren't subsets, they're more general ratios (like "How many incidents per month?").

This PR implements that exception. We will now calculate combined rates _even if_ the numerator exceeds the denominator, for EDV and PQI measures only.

### Related ticket(s)
CMDCT-5020

---
### How to test
https://d28fa8f4f8vlo.cloudfront.net/

1. Log in as a state user, for a state with combined rates. For example, `stateuser1@test.com`
2. Confirm that "normal" measures still work as expected - standard calculation
   1. Fill out a normal measure, for both Medicaid and CHIP. For example, `AAB-CH`. Use an administrative data source for both individual measures.
   2. Note that the combined rate is calculated
   3. Change one of the individual measures to have numerator > denominator. You will see a warning on the page, but the data will still be saved when you click the Save button.
   4. Note that the combined rate now excludes that improper fraction.
3. Confirm that "normal" measures still work as expected - weighted calculation
   1. Fill out a normal measure that allows for a non-admin data source, for both Medicaid and CHIP. For example, `CPU-AD` allows Case Management Record Review.
   2. Note that the combined rate is calculated
   3. Change one of the individual measures to have numerator > denominator. You will see a warning on the page, but the data will still be saved when you click the Save button.
   4. Note that the combined rate now excludes that improper fraction.
4. Confirm that special measures are now allowed to be improper
   1. Fill out `EDV-AD`, for both Medicaid and CHIP.
   2. Note that the combined rate is calculated.
   3. Increase one of the numerators to be greater than the denominator.
   4. Note that the data is still included in the combined rate calculation.
5. (Testing the weighted calculation for special measures is not possible from the UI; neither EDV nor PQI allows hybrid data sources)

### Notes
n/a

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
