### PR TITLE
[CMDCT-5043] Update stack name and output key in pr-notification.yml

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -34,13 +34,12 @@ jobs:
         id: getendpoint
         run: |
           set +e
-          application_endpoint_url=$(aws cloudformation describe-stacks --stack-name ui-${{ env.branch_name }} --output text --query "Stacks[0].Outputs[?OutputKey=='ApplicationEndpointUrl'].OutputValue")
+          application_endpoint_url=$(aws cloudformation describe-stacks --stack-name qmr-${{ env.branch_name }} --output text --query "Stacks[0].Outputs[?OutputKey=='CloudFrontUrl'].OutputValue")
           set -e
           if [[ -z $application_endpoint_url || ! $application_endpoint_url == http* ]]; then
               application_endpoint_url="endpoint not found"
           fi
           echo "application_endpoint_url=$application_endpoint_url" >> $GITHUB_OUTPUT
-
     outputs:
       application_endpoint_url: ${{ steps.getendpoint.outputs.application_endpoint_url }}
 
@@ -49,7 +48,11 @@ jobs:
     needs:
       - endpoint
     # avoiding notifications for automated Snyk Pull Requests and draft pull requests
-    if: github.actor != 'mdct-github-service-account' && !github.event.pull_request.draft
+    if: >
+      github.actor != 'mdct-github-service-account' &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'github-actions[bot]' &&
+      !github.event.pull_request.draft
     steps:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Update the stack name and output key so that Cloudfront URL populates in `#mdct-integrations-channel`.

Based on https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/1020

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5040

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. After this PR is opened, check the post in `#mdct-integrations-channel` for this PR
2. Confirm a Cloudfront URL is associated with this PR


<!-- ### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
