### PR TITLE
CMDCT-5061 - updates instructions with missing branch name dependency

### DIFF
--- a/deployment/PROD_TO_PRODUCTION_INSTRUCTIONS.md
+++ b/deployment/PROD_TO_PRODUCTION_INSTRUCTIONS.md
@@ -42,6 +42,8 @@ add new secret values inside `qmr-production`
 
 ### Fix `const vpnOnly = (isDev || stage === "prod")` to look to production
 
+### Fix `configToExport.BRANCH_NAME !== "prod"` to look to production
+
 ### Fix the names of this in the github secrets, use `qmr_secrets` in 1password for find value:
 
 - PROD_AWS_OIDC_ROLE_TO_ASSUME: PRODUCTION_AWS_OIDC_ROLE_TO_ASSUME


### PR DESCRIPTION
Tiny update to this PR:
https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2722