### PR TITLE
Qualifier Validation Label Update

### DIFF
--- a/services/ui-src/src/shared/Qualifiers/validations/adult.ts
+++ b/services/ui-src/src/shared/Qualifiers/validations/adult.ts
@@ -31,9 +31,12 @@ const validate21To64EqualsToOneHundredPercent = (data: ACSQualifierForm) => {
     total65PlusPercent !== 0;
 
   if (total21To64Percent === 0) {
+    const label = featuresByYear.lessSpecificQualifierValidationLanguage
+      ? "Entries for Adults Under Age 65 column must have values"
+      : "Entries for Ages 21 to 64 column must have values";
     errorArray.push({
       errorLocation: "Delivery System",
-      errorMessage: "Entries for Ages 21 to 64 column must have values",
+      errorMessage: label,
     });
   }
 

--- a/services/ui-src/src/shared/Qualifiers/validations/adultChip.ts
+++ b/services/ui-src/src/shared/Qualifiers/validations/adultChip.ts
@@ -15,9 +15,12 @@ const validate21To64EqualsToOneHundredPercent = (data: ACSCQualifierForm) => {
   );
 
   if (total21To64Percent === 0) {
+    const label = featuresByYear.lessSpecificQualifierValidationLanguage
+      ? "Entries for column must have values"
+      : "Entries for Ages 21 to 64 column must have values";
     errorArray.push({
       errorLocation: "Delivery System",
-      errorMessage: "Entries for Ages 21 to 64 column must have values",
+      errorMessage: label,
     });
   }
   if (

--- a/services/ui-src/src/shared/Qualifiers/validations/adultMedicaid.ts
+++ b/services/ui-src/src/shared/Qualifiers/validations/adultMedicaid.ts
@@ -31,9 +31,12 @@ const validate21To64EqualsToOneHundredPercent = (data: ACSMQualifierForm) => {
     total65PlusPercent !== 0;
 
   if (has21To64ZeroError) {
+    const label = featuresByYear.lessSpecificQualifierValidationLanguage
+      ? "Entries for Adults Under Age 65 column must have values"
+      : "Entries for Ages 21 to 64 column must have values";
     errorArray.push({
       errorLocation: "Delivery System",
-      errorMessage: "Entries for Ages 21 to 64 column must have values",
+      errorMessage: label,
     });
   }
 

--- a/services/ui-src/src/shared/Qualifiers/validations/child.ts
+++ b/services/ui-src/src/shared/Qualifiers/validations/child.ts
@@ -32,12 +32,13 @@ const validate21To64EqualsToOneHundredPercent = (data: CCSQualifierForm) => {
     totalUnder21CHIPPercent > 0 &&
     (totalUnder21CHIPPercent < 99 || totalUnder21CHIPPercent > 101);
 
-  // TODO: Fix error message - There one column here
   if (totalUnder21EqualsZeroError) {
+    const label = featuresByYear.lessSpecificQualifierValidationLanguage
+      ? "Entries for column must have values"
+      : "Entries are required in at least one column.  Entries are permitted in the second column but are not required";
     errorArray.push({
       errorLocation: "Delivery System",
-      errorMessage:
-        "Entries are required in at least one column.  Entries are permitted in the second column but are not required",
+      errorMessage: label,
     });
   }
 

--- a/services/ui-src/src/shared/Qualifiers/validations/childCHIP.ts
+++ b/services/ui-src/src/shared/Qualifiers/validations/childCHIP.ts
@@ -22,9 +22,12 @@ const validate21To64EqualsToOneHundredPercent = (data: CCSCQualifierForm) => {
     (totalUnder21CHIPPercent < 99 || totalUnder21CHIPPercent > 101);
 
   if (isZeroError) {
+    const label = featuresByYear.lessSpecificQualifierValidationLanguage
+      ? "Entries for column must have values"
+      : "Entries for Under Age 21 CHIP are required.";
     errorArray.push({
       errorLocation: "Delivery System",
-      errorMessage: "Entries for Under Age 21 CHIP are required.",
+      errorMessage: label,
     });
   }
 

--- a/services/ui-src/src/shared/Qualifiers/validations/childMedicaid.ts
+++ b/services/ui-src/src/shared/Qualifiers/validations/childMedicaid.ts
@@ -16,9 +16,12 @@ const validate21To64EqualsToOneHundredPercent = (data: CCSMQualifierForm) => {
   );
 
   if (totalUnder21MedicaidPercent === 0) {
+    const label = featuresByYear.lessSpecificQualifierValidationLanguage
+      ? "Entries for column must have values"
+      : "Entries for Under Age 21 CHIP are required.";
     errorArray.push({
       errorLocation: "Delivery System",
-      errorMessage: "Entries for Under Age 21 Medicaid are required.",
+      errorMessage: label,
     });
   }
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
While reviewing @rocio-desantiago pr, I noticed that the error messages when you don't fill out the table still reference the column header even though there's no names for them anymore.

<img width="1041" height="702" alt="Screenshot 2025-08-26 at 11 48 52 AM" src="https://github.com/user-attachments/assets/adc4a3d6-798d-42e9-b83e-09e3c7aa3651" />

This PR will change it to a generic message:
<img width="1287" height="100" alt="Screenshot 2025-08-26 at 11 50 39 AM" src="https://github.com/user-attachments/assets/af4a51c0-3be3-4dbd-a8e7-0a03c097cf6e" />

The only two that has a column name is ACSM & ACS, so their warning looks like this:
<img width="1079" height="747" alt="Screenshot 2025-08-26 at 11 52 32 AM" src="https://github.com/user-attachments/assets/577f3f30-b814-41ca-83da-ae4ea108d9fd" />


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link:

1) Sign into QMR, any state user
2) 

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
