### PR TITLE
[QMR] Footer header should be h2

### DIFF
--- a/services/ui-src/src/components/Footer/index.tsx
+++ b/services/ui-src/src/components/Footer/index.tsx
@@ -113,7 +113,7 @@ export function Footer(): JSX.Element {
         >
           <CUI.Box maxW="4xl">
             <CUI.Heading
-              as="h3"
+              as="h2"
               fontSize="2xl"
               mb="3"
               className="prince-supp-text"


### PR DESCRIPTION
### Description
This PR covers a tiny change to update footer header to h2 instead of h3

### Related ticket(s)
CMDCT-4816

### How to test
**Deploy Link:** https://d1tjh4pzaqkn6i.cloudfront.net/

#### I use HeadingsMap extension and wow I just realized that checks Landmarks too! 🤭 
<img width="350" height="221" alt="headingsMap" src="https://github.com/user-attachments/assets/bdec9aa6-afb4-470d-8f86-e76025b1dc46" />

#### Alternatively, you can also check the element in the console:
<img width="739" height="53" alt="elements-in-console" src="https://github.com/user-attachments/assets/210d1253-e859-4a4c-9da4-ca1362535cbf" />

