### PR TITLE
CMDCT-4825 - added html sanitizier to banner

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -17,6 +17,7 @@
     "base-64": "^1.0.0",
     "date-fns": "^2.30.0",
     "date-fns-tz": "^1.3.8",
+    "dompurify": "^3.2.6",
     "file-saver": "^2.0.5",
     "framer-motion": "^4",
     "jest-launchdarkly-mock": "^2.1.0",

--- a/services/ui-src/src/components/Banner/Banner.tsx
+++ b/services/ui-src/src/components/Banner/Banner.tsx
@@ -1,15 +1,27 @@
 import { Alert } from "@cmsgov/design-system";
 import { BannerData } from "types";
 import { parseLabelToHTML } from "utils";
+import DOMPurify from "dompurify";
+
+const domPurifyBannerConfig = {
+  // Only these tags will be allowed through
+  ALLOWED_TAGS: ["ul", "ol", "li", "a", "#text", "strong", "b", "em"],
+  // On those tags, only these attributes are allowed
+  ALLOWED_ATTR: ["href", "alt"],
+  // If a tag is removed, so will all its child elements & text
+  KEEP_CONTENT: false,
+};
 
 export const Banner = ({ bannerData, ...props }: Props) => {
   return (
     <>
       {bannerData && (
         <Alert heading={bannerData.title} {...props}>
-          <p className="ds-c-alert__text">
-            {parseLabelToHTML(bannerData.description)}
-          </p>
+          <span className="ds-c-alert__text">
+            {parseLabelToHTML(
+              DOMPurify.sanitize(bannerData.description, domPurifyBannerConfig)
+            )}
+          </span>
           {bannerData.link && (
             <p>
               <a href={encodeURI(bannerData.link)}>{bannerData.link}</a>

--- a/services/ui-src/src/components/Banner/Banner.tsx
+++ b/services/ui-src/src/components/Banner/Banner.tsx
@@ -17,11 +17,11 @@ export const Banner = ({ bannerData, ...props }: Props) => {
     <>
       {bannerData && (
         <Alert heading={bannerData.title} {...props}>
-          <span className="ds-c-alert__text">
+          <div className="ds-c-alert__text">
             {parseLabelToHTML(
               DOMPurify.sanitize(bannerData.description, domPurifyBannerConfig)
             )}
-          </span>
+          </div>
           {bannerData.link && (
             <p>
               <a href={encodeURI(bannerData.link)}>{bannerData.link}</a>

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -5989,6 +5989,11 @@
   dependencies:
     "@types/jest" "*"
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/uuid@^8.3.3":
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.3.tgz#c6a60686d953dbd1b1d45e66f4ecdbd5d471b4d0"
@@ -7197,6 +7202,13 @@ domexception@^2.0.1:
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+dompurify@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.6.tgz#ca040a6ad2b88e2a92dc45f38c79f84a714a1cad"
+  integrity sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dunder-proto@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description
- Banner descriptions are now being sanitized before being sent to the parser. The sanitization config is setup to match the one in the backend, so now the user will get a preview of exactly what is saved in the DB.
- Changed the `<p>` to a `<span>` so there would be no errors if a user provides a `<ul>` (as a `<ul>` should not be inside a `<p>`)

<!-- Detailed description of changes and related context -->

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-4825

---

### How to test
- Login as an admin: https://d1fv14y2db6spl.cloudfront.net/
- Modify the banner to something like:
```
<ul>
<li> list item </li>
</ul>
```
and verify there are no errors in the console

<!-- Step-by-step instructions on how to test, if necessary -->

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
