### PR TITLE
CMDCT-5147 removes need for PRODUCTION_SYNC_OIDC_ROLE

### DIFF
--- a/.github/workflows/scan_security-hub-jira-integration.yml
+++ b/.github/workflows/scan_security-hub-jira-integration.yml
@@ -7,19 +7,37 @@ on:
 
 permissions:
   id-token: write
+  actions: write
 
 jobs:
+  # Hack which is used just to redirect the "scheduled" triggers to deploy/production, since we can't just tell Github (for now) to do a scheduled action on a branch different from the default branch
+  trigger-action-on-deploy-production:
+    if: github.refs != 'refs/head/production'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Trigger production workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run .github/workflows/scan_security-hub-jira-integration.yml \
+            --ref production
+
   sync:
+    if: github.refs == 'refs/heads/production'
     name: Run sync
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+        with:
+          ref: production
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-          role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}
+          role-to-assume: ${{ secrets.PRODUCTION_AWS_OIDC_ROLE_TO_ASSUME }}
       - name: Sync Security Hub and Jira
         uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.0.9
         with:


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description
By consolidating use of github action role we can have our cake and eat it too and remove a stack called scheduled-github-action-oidc-role

### Related ticket(s)

CMDCT-5147

---

### How to test
Has already been tested in SEDs

### Notes

NA
---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
