### PR TITLE
CMDCT-5091 - ExportAll/util.tsx test coverage

### DIFF
--- a/services/ui-src/src/views/ExportAll/util.test.ts
+++ b/services/ui-src/src/views/ExportAll/util.test.ts
@@ -1,4 +1,9 @@
-import { applyPrinceSpecificCss, getSpaName, htmlStringCleanup } from "./util";
+import {
+  applyPrinceSpecificCss,
+  openPdf,
+  getSpaName,
+  htmlStringCleanup,
+} from "./util";
 
 describe("ExportAll utils", () => {
   describe("getSpaName", () => {
@@ -87,6 +92,18 @@ describe("ExportAll utils", () => {
       const countAfter = document.body.querySelectorAll("style").length;
 
       expect(countAfter).toBe(countBefore + 1);
+    });
+  });
+
+  describe("openPdf", () => {
+    beforeEach(() => {
+      global.open = jest.fn();
+      global.URL.createObjectURL = jest.fn();
+    });
+    it("should call window.open with proper url", () => {
+      openPdf("test");
+      expect(global.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+      expect(global.open).toHaveBeenCalled();
     });
   });
 });

--- a/services/ui-src/src/views/ExportAll/util.test.ts
+++ b/services/ui-src/src/views/ExportAll/util.test.ts
@@ -97,20 +97,15 @@ describe("ExportAll utils", () => {
 
   describe("cloneEmotionStyles", () => {
     let appendChildSpy: jest.SpyInstance;
-    let createElementSpy: jest.SpyInstance;
     let createTextNodeSpy: jest.SpyInstance;
 
     beforeEach(() => {
+      jest.clearAllMocks();
       appendChildSpy = jest.spyOn(document.body, "appendChild");
-      createElementSpy = jest.spyOn(document, "createElement");
       createTextNodeSpy = jest.spyOn(document, "createTextNode");
     });
 
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it.only("should clone style rules and create style tags", () => {
+    it("should clone style rules and create style tags", () => {
       const fakeCssText = ".foo { text-align: right; display: flex; }";
       const fakeStyleSheet = {
         href: null,
@@ -120,13 +115,12 @@ describe("ExportAll utils", () => {
         configurable: true,
         enumerable: true,
         writable: true,
-        value: [fakeStyleSheet],
+        value: [fakeStyleSheet, fakeStyleSheet],
       });
 
       const tags = cloneEmotionStyles();
       expect(tags.length).toBe(2);
       expect(appendChildSpy).toHaveBeenCalled();
-      expect(createElementSpy).toHaveBeenCalledWith("style");
       expect(createTextNodeSpy).toHaveBeenCalledWith(
         expect.stringContaining("text-align: center")
       );
@@ -150,6 +144,8 @@ describe("ExportAll utils", () => {
 
       const tags = cloneEmotionStyles();
       expect(tags.length).toBe(0);
+      expect(appendChildSpy).not.toHaveBeenCalled();
+      expect(createTextNodeSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -158,7 +154,7 @@ describe("ExportAll utils", () => {
       global.open = jest.fn();
       global.URL.createObjectURL = jest.fn();
     });
-    it("should call window.open with proper url", () => {
+    it("should call window.open", () => {
       openPdf("test");
       expect(global.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
       expect(global.open).toHaveBeenCalled();

--- a/services/ui-src/src/views/ExportAll/util.test.tsx
+++ b/services/ui-src/src/views/ExportAll/util.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import {
   applyPrinceSpecificCss,
   openPdf,
@@ -5,8 +6,14 @@ import {
   htmlStringCleanup,
   cloneChakraVariables,
   cloneEmotionStyles,
+  usePrinceRequest,
 } from "./util";
+import { render } from "@testing-library/react";
 
+const mockGetPDF = jest.fn().mockResolvedValue("PDFDATA");
+jest.mock("libs/api", () => ({
+  getPDF: () => mockGetPDF(),
+}));
 describe("ExportAll utils", () => {
   describe("getSpaName", () => {
     const props = {
@@ -203,6 +210,20 @@ describe("ExportAll utils", () => {
 
       cloneChakraVariables();
       expect(setAttributeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("usePrinceRequest", () => {
+    const TestComponent = (props: any) => {
+      const request = usePrinceRequest();
+      useEffect(() => {
+        request(props);
+      }, []);
+      return null;
+    };
+    it("should render and call the hook without error", async () => {
+      render(<TestComponent />);
+      expect(mockGetPDF).toHaveBeenCalled();
     });
   });
 });

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -12,7 +12,6 @@ interface HookProps {
 type PrinceHook = () => (props: HookProps) => Promise<void>;
 
 export const openPdf = (basePdf: string) => {
-  console.log("opening pdf", basePdf);
   let byteCharacters = atob(basePdf);
   let byteNumbers = new Array(byteCharacters.length);
   for (let i = 0; i < byteCharacters.length; i++) {

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -26,7 +26,7 @@ export const openPdf = (basePdf: string) => {
  * Gather chakra css variables and make available for the body (prince issue seeing applied normally)
  * */
 export const cloneChakraVariables = () => {
-  for (let i = 0; i < document.styleSheets.length - 1; i++) {
+  for (let i = 0; i < document.styleSheets.length; i++) {
     if (
       !document.styleSheets[i].href &&
       document.styleSheets[i]?.cssRules[0]?.cssText.includes("--chakra") &&
@@ -49,7 +49,7 @@ export const cloneEmotionStyles = (): HTMLStyleElement[] => {
 
   // gather all styles
   const cssRules = [];
-  for (let i = 0; i < document.styleSheets.length - 1; i++) {
+  for (let i = 0; i < document.styleSheets.length; i++) {
     if (!document.styleSheets[i].href) {
       let ruleString = "";
       const rules = document.styleSheets[i]?.cssRules ?? [];

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -12,6 +12,7 @@ interface HookProps {
 type PrinceHook = () => (props: HookProps) => Promise<void>;
 
 export const openPdf = (basePdf: string) => {
+  console.log("opening pdf", basePdf);
   let byteCharacters = atob(basePdf);
   let byteNumbers = new Array(byteCharacters.length);
   for (let i = 0; i < byteCharacters.length; i++) {

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState } from "react";
-
 import { SPA } from "libs/spaLib";
 import { getPDF } from "libs/api";
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

<!-- Detailed description of changes and related context -->
- Added tests for `ExportAll/util.tsx` to increase coverage to almost 100%
- Changed the test file to `.tsx` to be able to make a mock component to test `usePrinceRequest()`
- Removed `length-1` within `services/ui-src/src/views/ExportAll/util.tsx` because I realized it was skipping the very last element

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5091

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->
- Pull the branch locally and within `/services/ui-src` run the following command:
`yarn test util.test.ts --coverage --collectCoverageFrom=src/views/ExportAll/util.tsx`
and you will see the test coverage only for relevant file

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
