### PR TITLE
CMDCT-5254: move topics config into a separate file

### DIFF
--- a/services/topics/config.js
+++ b/services/topics/config.js
@@ -1,0 +1,9 @@
+module.exports = [
+  {
+    topicPrefix: "aws.mdct.qmr.cdc",
+    version: ".v0",
+    numPartitions: 1,
+    replicationFactor: 3,
+    topics: [".coreSet", ".measure", ".rate"],
+  },
+];

--- a/services/topics/handlers/createTopics.js
+++ b/services/topics/handlers/createTopics.js
@@ -1,4 +1,5 @@
 const topics = require("../libs/topics-lib.js");
+const condensedTopicList = require("../config.js");
 
 /**
  * String in the format of `--${event.project}--${event.stage}--`
@@ -6,17 +7,6 @@ const topics = require("../libs/topics-lib.js");
  * Only used for temp branches for easy identification and cleanup.
  */
 const namespace = process.env.topicNamespace;
-
-const condensedTopicList = [
-  {
-    // topics for the qmr service's connector
-    topicPrefix: "aws.mdct.qmr.cdc",
-    version: ".v0",
-    numPartitions: 1,
-    replicationFactor: 3,
-    topics: [".coreSet", ".measure", ".rate"],
-  },
-];
 
 /**
  * Handler triggered on deploy to create known topics in bigmac


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

CMDCT-5254: move topics config into a separate file

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5254

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
